### PR TITLE
Fix basic rabbitmq GA

### DIFF
--- a/tests/receive.py
+++ b/tests/receive.py
@@ -3,8 +3,16 @@ import os
 import sys
 import pika
 
+host = os.getenv('RABBITMQ_HOST', 'localhost')
+port = os.getenv('RABBITMQ_PORT', 5672)
+
 def main():
-    connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(
+            host=host,
+            port=port
+        )
+    )
     channel = connection.channel()
 
     channel.queue_declare(queue='hello')

--- a/tests/send.py
+++ b/tests/send.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
+import os
 import pika
 
+host = os.getenv('RABBITMQ_HOST', 'localhost')
+port = os.getenv('RABBITMQ_PORT', 5672)
+
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(
+        host=host,
+        port=port
+    )
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='hello')


### PR DESCRIPTION
Read the host and port to use to open the rabbitmq connection from the env variables set by the GA. Especially import for the port that is dynamically set.