### PR TITLE
rabbitmq mod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tokio = "1.38.0"
 tokio-executor-trait = "2.1.1"
 tokio-reactor-trait = "1.1.0"
 tokio-stream = "0.1.15"
+uuid = "1.8.0"
 
 [dependencies.mongodb]
 version = "2.8.2"

--- a/src/bin/consumer.rs
+++ b/src/bin/consumer.rs
@@ -1,14 +1,8 @@
-use lapin::{
-    // message::DeliveryResult,
-    options::{BasicAckOptions, BasicConsumeOptions, QueueDeclareOptions},
-    types::FieldTable,
-    Connection, ConnectionProperties,
-};
 use apache_avro::from_value;
 use apache_avro::Reader;
 use std::io::BufReader;
-use tokio_stream::StreamExt;
 
+mod rabbitmq;
 mod structs;
 mod database;
 mod utils;
@@ -58,88 +52,24 @@ async fn process_record(record: apache_avro::types::Value) {
     // println!("Processed alert: {}", alert_packet.candid);
 }
 
+// callback returns an async future with a Result type
+async fn callback(content: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
+    let reader = Reader::new(BufReader::new(&content[..])).unwrap();
+    for record in reader {
+        let record = record.unwrap();
+        // we can now process the alert
+        process_record(record).await;
+    }
+    Ok(())
+}
 #[tokio::main(flavor = "multi_thread", worker_threads = 1)]
 async fn main() {
     let uri = "amqp://localhost:5672";
-    let options = ConnectionProperties::default()
-        // Use tokio executor and reactor.
-        // At the moment the reactor is only available for unix.
-        .with_executor(tokio_executor_trait::Tokio::current())
-        .with_reactor(tokio_reactor_trait::Tokio);
+    let connection = rabbitmq::connect(uri).await;
+    let channel = rabbitmq::create_channel(&connection).await;
+    rabbitmq::declare_queue(&channel, "queue_test").await;
 
-    let connection = Connection::connect(uri, options).await.unwrap();
-    let channel = connection.create_channel().await.unwrap();
+    let mut consumer = rabbitmq::create_consumer(&channel, "queue_test").await;
 
-    let _queue = channel
-        .queue_declare(
-            "queue_test",
-            QueueDeclareOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .unwrap();
-
-    channel.basic_qos(1, Default::default()).await.unwrap();
-
-    let mut consumer = channel
-        .basic_consume(
-            "queue_test",
-            "tag_foo",
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .unwrap();
-
-    while let Some(delivery) = consumer.next().await {
-        if let Ok(delivery) = delivery {
-            let content = delivery.data.clone();
-            let reader = Reader::new(BufReader::new(&content[..])).unwrap();
-            for record in reader {
-                let record = record.unwrap();
-                // we can now process the alert
-                process_record(record).await;
-            }
-            delivery
-                .ack(BasicAckOptions::default())
-                .await
-                .expect("basic_ack");
-        }
-    }
-
-    // THE CODE UNDERNEATH LETS TOKIO SPAWN A NEW THREAD FOR EACH MESSAGE RECEIVED
-    // UNTIL WE CAN SET A MAX NB OF THREADS, WE WILL USE THE ABOVE CODE
-    // THAT IS SINGLE THREADED, SO WE CAN JUST START MULTIPLE INSTANCES OF THE CONSUMER
-    // TO SCALE UP
-    // consumer.set_delegate(move |delivery: DeliveryResult| async move {
-    //     let delivery = match delivery {
-    //         // Carries the delivery alongside its channel
-    //         Ok(Some(delivery)) => {
-    //             // add a 2 seconds sleep to simulate processing time
-    //             tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-    //             let content = delivery.data.clone();
-    //             let reader = Reader::new(BufReader::new(&content[..])).unwrap();
-    //             for record in reader {
-    //                 let record = record.unwrap();
-    //                 // we can now process the alert
-    //                 process_record(record).await;
-    //             }
-    //             delivery
-    //         }
-    //         // The consumer got canceled
-    //         Ok(None) => return,
-    //         // Carries the error and is always followed by Ok(None)
-    //         Err(error) => {
-    //             dbg!("Failed to consume queue message {}", error);
-    //             return;
-    //         }
-    //     };
-
-    //     // Do something with the delivery data (The message payload)
-
-    //     delivery
-    //         .ack(BasicAckOptions::default())
-    //         .await
-    //         .expect("Failed to ack send_webhook_event message");
-    // });
+    rabbitmq::consume(&mut consumer, callback).await;
 }

--- a/src/bin/producer.rs
+++ b/src/bin/producer.rs
@@ -1,54 +1,21 @@
-use lapin::{
-    options::{BasicPublishOptions, QueueDeclareOptions},
-    types::FieldTable,
-    BasicProperties, Connection, ConnectionProperties,
-};
+mod rabbitmq;
 
 #[tokio::main]
 async fn main() {
     let uri = "amqp://localhost:5672";
-    let options = ConnectionProperties::default()
-        // Use tokio executor and reactor.
-        // At the moment the reactor is only available for unix.
-        .with_executor(tokio_executor_trait::Tokio::current())
-        .with_reactor(tokio_reactor_trait::Tokio);
+    let connection = rabbitmq::connect(uri).await;
+    let channel = rabbitmq::create_channel(&connection).await;
+    rabbitmq::declare_queue(&channel, "queue_test").await;
 
-    let connection = Connection::connect(uri, options).await.unwrap();
-    let channel = connection.create_channel().await.unwrap();
-
-    let _queue = channel
-        .queue_declare(
-            "queue_test",
-            QueueDeclareOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .unwrap();
-
-    // find the list of files in the data directory
-    // let files = std::fs::read_dir("data/ztf_public_20240611").unwrap();
-    let mut files = std::fs::read_dir("data/ztf_alerts").unwrap();
+    let files = std::fs::read_dir("data/ztf_alerts").unwrap();
     let mut i = 0;
     for f in files {
         let f = f.unwrap();
         let msg = std::fs::read(f.path()).unwrap();
-        channel
-            .basic_publish(
-                "",
-                "queue_test",
-                BasicPublishOptions::default(),
-                &msg,
-                BasicProperties::default(),
-            )
-            .await
-            .unwrap()
-            .await
-            .unwrap();
-
+        rabbitmq::publish_message(&channel, "", "queue_test", &msg).await;
         println!("Sent message: {}", i);
         i += 1;
-        // tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-        }
+    }
 
         
 }

--- a/src/bin/rabbitmq/mod.rs
+++ b/src/bin/rabbitmq/mod.rs
@@ -1,0 +1,88 @@
+use std::future::Future;
+
+use lapin::{
+    options::{BasicPublishOptions, QueueDeclareOptions},
+    types::FieldTable,
+    BasicProperties, Connection, ConnectionProperties,
+};
+use tokio_stream::StreamExt;
+
+pub async fn connect(uri: &str) -> Connection {
+    let options = ConnectionProperties::default()
+        // Use tokio executor and reactor.
+        // At the moment the reactor is only available for unix.
+        .with_executor(tokio_executor_trait::Tokio::current())
+        .with_reactor(tokio_reactor_trait::Tokio);
+
+    Connection::connect(uri, options).await.unwrap()
+}
+
+pub async fn create_channel(connection: &Connection) -> lapin::Channel {
+    connection.create_channel().await.unwrap()
+}
+
+pub async fn declare_queue(channel: &lapin::Channel, queue_name: &str) {
+    channel
+        .queue_declare(
+            queue_name,
+            QueueDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+}
+
+pub async fn publish_message(
+    channel: &lapin::Channel,
+    exchange: &str,
+    queue_name: &str,
+    message: &[u8],
+) {
+    channel
+        .basic_publish(
+            exchange,
+            queue_name,
+            BasicPublishOptions::default(),
+            message,
+            BasicProperties::default(),
+        )
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+}
+
+pub async fn create_consumer(channel: &lapin::Channel, queue_name: &str) -> lapin::Consumer {
+    // randomly generate a tag for the consumer
+    let tag = format!("tag_{}", uuid::Uuid::new_v4());
+
+    channel.basic_qos(1, Default::default()).await.unwrap();
+    channel
+        .basic_consume(
+            queue_name,
+            &tag,
+            lapin::options::BasicConsumeOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap()
+}
+
+// next is a function that takes a consumer + a callback function to run on each message
+// the callback is an async function that returns a Result type
+pub async fn consume<F, Fut>(consumer: &mut lapin::Consumer, callback: F)
+where
+    F: Fn(Vec<u8>) -> Fut,
+    Fut: Future<Output = Result<(), Box<dyn std::error::Error>>> + 'static,
+{
+    while let Some(delivery) = consumer.next().await {
+        if let Ok(delivery) = delivery {
+            let content = delivery.data.clone();
+            callback(content).await.unwrap();
+            delivery
+                .ack(lapin::options::BasicAckOptions::default())
+                .await
+                .expect("basic_ack");
+        }
+    }
+}


### PR DESCRIPTION
Move rabbitmq-specific methods to a reusable library, this greatly shortens and simplified the code found in both producer and consumer.