### PR TITLE
34 ignore filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,23 @@ We welcome contributions! Please read the [CONTRIBUTING.md](CONTRIBUTING.md) (TB
 
 ### Dealing with Avro & Rust structs:
 
-It can get pretty painful in Rust to work with Avro schemas, and more specifically to have to write Rust structs that match them. To make this easier, we use the super useful `rsgen-avro` crate, which allows us to generate Rust structs from Avro schemas. First, install it as a binary with:
-```bash
-cargo install rsgen-avro --features="build-cli"
-```
-Then, you can generate the Rust structs from the Avro schema with:
-```bash
-rsgen-avro "schema/ztf/*.avsc" -
-```
-This will output the Rust structs to the standard output, which you can then copy-paste in a lib file in the `src` directory, so you can use them in your code.
-We already ran it for the ZTF Avro schema (so no need to do it again), and the corresponding Rust structs are in the `src/types.rs` file. We only slightly modified the `Alert` struct to add methods to create an alert from the bytes of an Avro record (`from_avro_bytes`).
+It can get pretty painful in Rust to work with Avro schemas, and more specifically to have to write Rust structs that match them. To make this easier, we can use the super useful `rsgen-avro` crate to generate Rust structs from the Avro schemas. Consider this a one-time process that provides a starting point for a given set of schemas. The generated structs can then be modified over time as needed:
+
+1. First, install `rsgen-avro` as a binary with:
+
+    ```bash
+    cargo install rsgen-avro --features="build-cli"
+    ```
+
+2. Then, generate the Rust structs from the Avro schema with:
+
+    ```bash
+    rsgen-avro "schema/ztf/*.avsc" -
+    ```
+
+    This will output the Rust structs to the standard output, which you can then copy-paste in a lib file in the `src` directory, so you can use them in your code.
+
+We already went through this process for the ZTF Avro schema (so no need to do it again), and the corresponding Rust structs are in the `src/types.rs` file. We only slightly modified the `Alert` struct to add methods to create an alert from the bytes of an Avro record (`from_avro_bytes`).
 
 ### Dealing with Rust structs and MongoDB BSON documents:
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ We are currently working on adding tests to the codebase. You can run the tests 
 cargo test
 ```
 
+Tests currently require the kafka, valkey, and mongo Docker containers to be running as described above.
+
 *When running the tests, the config file found in `tests/config.test.yaml` will be used.*
 
 The test suite also runs automagically on every push to the repository, and on every pull request. You can check the status of the tests in the "Actions" tab of the GitHub repository.

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@ use config::Value;
 use flare::spatial::{deg2dms, deg2hms, radec2lb};
 use mongodb::bson::doc;
 use mongodb::bson::to_document;
+use serde::{Deserialize, Deserializer};
 use tracing::error;
 
 pub fn ztf_alert_schema() -> Option<Schema> {
@@ -1129,15 +1130,32 @@ pub struct Alert {
     pub prv_candidates: Option<Vec<PrvCandidate>>,
     #[serde(default = "default_alert_fp_hists")]
     pub fp_hists: Option<Vec<FpHist>>,
-    #[serde(default = "default_alert_cutout_science", rename = "cutoutScience")]
-    pub cutout_science: Option<Cutout>,
-    #[serde(default = "default_alert_cutout_template", rename = "cutoutTemplate")]
-    pub cutout_template: Option<Cutout>,
+    #[serde(
+        default = "default_alert_cutout_science",
+        rename = "cutoutScience",
+        deserialize_with = "deserialize_cutout_as_bytes"
+    )]
+    pub cutout_science: Option<Vec<u8>>,
+    #[serde(
+        default = "default_alert_cutout_template",
+        rename = "cutoutTemplate",
+        deserialize_with = "deserialize_cutout_as_bytes"
+    )]
+    pub cutout_template: Option<Vec<u8>>,
     #[serde(
         default = "default_alert_cutout_difference",
-        rename = "cutoutDifference"
+        rename = "cutoutDifference",
+        deserialize_with = "deserialize_cutout_as_bytes"
     )]
-    pub cutout_difference: Option<Cutout>,
+    pub cutout_difference: Option<Vec<u8>>,
+}
+
+fn deserialize_cutout_as_bytes<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let cutout: Option<Cutout> = Option::deserialize(deserializer)?;
+    Ok(cutout.map(|cutout| cutout.stamp_data))
 }
 
 #[inline(always)]
@@ -1151,17 +1169,17 @@ fn default_alert_fp_hists() -> Option<Vec<FpHist>> {
 }
 
 #[inline(always)]
-fn default_alert_cutout_science() -> Option<Cutout> {
+fn default_alert_cutout_science() -> Option<Vec<u8>> {
     None
 }
 
 #[inline(always)]
-fn default_alert_cutout_template() -> Option<Cutout> {
+fn default_alert_cutout_template() -> Option<Vec<u8>> {
     None
 }
 
 #[inline(always)]
-fn default_alert_cutout_difference() -> Option<Cutout> {
+fn default_alert_cutout_difference() -> Option<Vec<u8>> {
     None
 }
 
@@ -1173,15 +1191,24 @@ pub struct AlertNoHistory {
     pub object_id: String,
     pub candid: i64,
     pub candidate: Candidate,
-    #[serde(default = "default_alert_cutout_science", rename = "cutoutScience")]
-    pub cutout_science: Option<Cutout>,
-    #[serde(default = "default_alert_cutout_template", rename = "cutoutTemplate")]
-    pub cutout_template: Option<Cutout>,
+    #[serde(
+        default = "default_alert_cutout_science",
+        rename = "cutoutScience",
+        deserialize_with = "deserialize_cutout_as_bytes"
+    )]
+    pub cutout_science: Option<Vec<u8>>,
+    #[serde(
+        default = "default_alert_cutout_template",
+        rename = "cutoutTemplate",
+        deserialize_with = "deserialize_cutout_as_bytes"
+    )]
+    pub cutout_template: Option<Vec<u8>>,
     #[serde(
         default = "default_alert_cutout_difference",
-        rename = "cutoutDifference"
+        rename = "cutoutDifference",
+        deserialize_with = "deserialize_cutout_as_bytes"
     )]
-    pub cutout_difference: Option<Cutout>,
+    pub cutout_difference: Option<Vec<u8>>,
 }
 
 // make a function for the Alert type, that creates a AlertNoHistory type

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -79,30 +79,9 @@ fn test_alert() {
     assert_eq!(fp_positive_flux.procstatus.as_ref().unwrap(), "0");
 
     // validate the cutouts
-    assert_eq!(
-        alert.cutout_science.clone().unwrap().file_name,
-        "candid2695378462115010012_pid2695378462115_targ_sci.fits.gz"
-    );
-    assert_eq!(
-        alert.cutout_template.clone().unwrap().file_name,
-        "candid2695378462115010012_ref.fits.gz"
-    );
-    assert_eq!(
-        alert.cutout_difference.clone().unwrap().file_name,
-        "candid2695378462115010012_pid2695378462115_targ_refmsci.fits.gz"
-    );
-    assert_eq!(
-        alert.cutout_science.clone().unwrap().stamp_data.len(),
-        13107
-    );
-    assert_eq!(
-        alert.cutout_template.clone().unwrap().stamp_data.len(),
-        12410
-    );
-    assert_eq!(
-        alert.cutout_difference.clone().unwrap().stamp_data.len(),
-        14878
-    );
+    assert_eq!(alert.cutout_science.clone().unwrap().len(), 13107);
+    assert_eq!(alert.cutout_template.clone().unwrap().len(), 12410);
+    assert_eq!(alert.cutout_difference.clone().unwrap().len(), 14878);
 
     // split alert from its history
     let (alert_no_history, prv_candidates, fp_hist) = alert.pop_history();


### PR DESCRIPTION
Closes #34 

I added a new `deserialize_with` function to the `serde` attributes of the different cutout fields in `types::Alert`. This new function, `deserialize_cutout_as_bytes`, extracts the image data from the inner cutout object and assigns it as the value of the deserialized field. No more inner type with a filename field.

I've also made some updates to the `README.md` file to clarify a couple points.