### PR TITLE
FITS utils - read img data from Alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "config",
  "criterion",
  "flare",
+ "flate2",
  "futures",
  "mongodb",
  "rdkafka",
@@ -810,6 +811,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7d8685978eda0b53b3fed876dc11f1f148c736d18d49447eb29a360624d0a3"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1561,9 +1572,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.43.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 uuid = { version = "1.12", features = ["v4"] }
+flate2 = "1.1.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/fake_ml_worker.rs
+++ b/src/fake_ml_worker.rs
@@ -165,8 +165,16 @@ pub async fn fake_ml_worker(
         // Ideally, we want to prepare the data for the whole batch of alerts at once, so we can
         // run the models on batches of alerts instead of one by one
         for alert in &alerts {
-            let (_cutout_science, _cutout_template, _cutout_difference) =
-                prepare_triplet(&alert).unwrap();
+            let obj_id = alert.get_str("objectId").unwrap();
+            let result = prepare_triplet(&alert);
+            if result.is_err() {
+                warn!(
+                    "ML WORKER {}: error preparing triplet for alert {}",
+                    id, obj_id
+                );
+                continue;
+            }
+            let (_cutout_science, _cutout_template, _cutout_difference) = result.unwrap();
         }
 
         let mut candids_grouped: HashMap<i32, Vec<i64>> = HashMap::new();

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -169,25 +169,19 @@ pub fn prepare_triplet(
     alert_doc: &mongodb::bson::Document,
 ) -> Result<(Vec<f32>, Vec<f32>, Vec<f32>), Box<dyn std::error::Error>> {
     let cutout_science = alert_doc
-        .get_document("cutoutScience")
-        .unwrap()
-        .get_binary_generic("stampData")
+        .get_binary_generic("cutoutScience")
         .unwrap()
         .to_vec();
     let cutout_science = prepare_cutout(cutout_science).unwrap();
 
     let cutout_template = alert_doc
-        .get_document("cutoutTemplate")
-        .unwrap()
-        .get_binary_generic("stampData")
+        .get_binary_generic("cutoutTemplate")
         .unwrap()
         .to_vec();
     let cutout_template = prepare_cutout(cutout_template).unwrap();
 
     let cutout_difference = alert_doc
-        .get_document("cutoutDifference")
-        .unwrap()
-        .get_binary_generic("stampData")
+        .get_binary_generic("cutoutDifference")
         .unwrap()
         .to_vec();
     let cutout_difference = prepare_cutout(cutout_difference).unwrap();

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -78,8 +78,9 @@ pub fn buffer_to_image(buffer: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::
         .parse::<usize>()
         .unwrap();
 
-    let mut image_data =
-        u8_to_f32_vec(&decompressed_data[FITS_HEADER_LEN..(FITS_HEADER_LEN + (naxis1 * naxis2 * 4) as usize)]); // 32 BITPIX / 8 bits per byte = 4
+    let mut image_data = u8_to_f32_vec(
+        &decompressed_data[FITS_HEADER_LEN..(FITS_HEADER_LEN + (naxis1 * naxis2 * 4) as usize)],
+    ); // 32 BITPIX / 8 bits per byte = 4
 
     // if NAXIS1 and NAXIS2 are not NAXIS_STANDARD, we need to pad the image with zeros
     // we can't just add zeros to the end of the image_data vector, because it's a 2D array we flattened into a 1D vector
@@ -107,15 +108,15 @@ pub fn buffer_to_image(buffer: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::
 pub fn normalize_image(image: Vec<f32>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
     // replace all NaNs with 0s and clamp all values to the range [f32::MIN, f32::MAX]
     let mut normalized: Vec<f32> = image
-    .into_iter()
-    .map(|pixel| {
-        if pixel.is_nan() {
-            0.0
-        } else {
-            pixel.clamp(f32::MIN, f32::MAX)
-        }
-    })
-    .collect();
+        .into_iter()
+        .map(|pixel| {
+            if pixel.is_nan() {
+                0.0
+            } else {
+                pixel.clamp(f32::MIN, f32::MAX)
+            }
+        })
+        .collect();
 
     // then, compute the norm of the vector, which is the Frobenius norm of this array
     // so a 2-norm of a vector is the square root of the sum of the squares of the elements (in absolute value)

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -5,6 +5,9 @@ const NAXIS1_BYTES: &[u8] = "NAXIS1  =".as_bytes();
 const NAXIS2_BYTES: &[u8] = "NAXIS2  =".as_bytes();
 const NAXIS1_BYTES_LEN: usize = NAXIS1_BYTES.len();
 const NAXIS2_BYTES_LEN: usize = NAXIS2_BYTES.len();
+const FITS_HEADER_LEN: usize = 2880; // FITS headers are in blocks of 2880 bytes
+const NAXIS_STANDARD: usize = 63;
+const NB_PIXELS: usize = NAXIS_STANDARD * NAXIS_STANDARD;
 
 fn u8_to_f32_vec(v: &[u8]) -> Vec<f32> {
     v.chunks_exact(4)
@@ -14,16 +17,7 @@ fn u8_to_f32_vec(v: &[u8]) -> Vec<f32> {
         .collect()
 }
 
-/// Converts a buffer of bytes to an image
-///
-/// The buffer is expected to be a gzipped FITS file served as a binary
-/// The function decompresses the buffer and extracts the image data
-/// The image is expected to be a 2D array of floats
-/// We assume that the FITS image has headers that indicate the dimensions of the image
-/// Looking for the NAXIS1 and NAXIS2 keywords as bytes is much faster than
-/// converting the whole buffer to a string and searching with a regex
-/// The function returns a vector of f32
-/// The image is expected to be a 2D array of floats
+/// Converts a buffer of bytes from a gzipped FITS file to a vector of flattened 2D image data
 pub fn buffer_to_image(buffer: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
     let cursor = Cursor::new(buffer);
 
@@ -32,86 +26,75 @@ pub fn buffer_to_image(buffer: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::
     let mut decompressed_data = Vec::new();
     let _ = decoder.read_to_end(&mut decompressed_data);
 
-    let subset = &decompressed_data[0..2880];
+    let subset = &decompressed_data[0..FITS_HEADER_LEN];
 
-    let mut naxis1_start = 0;
-    let mut naxis1_end = 0;
-    let mut digits_end = 0;
+    let mut naxis1_key_start = 0;
+    let mut naxis1_val_start = 0;
+    let mut naxis1_val_end = 0;
     for i in 0..subset.len() - NAXIS1_BYTES_LEN {
         if &subset[i..(i + NAXIS1_BYTES_LEN)] == NAXIS1_BYTES {
-            naxis1_start = i + NAXIS1_BYTES_LEN;
+            naxis1_key_start = i;
             break;
         }
     }
-    for i in naxis1_start..subset.len() {
+    for i in (naxis1_key_start + NAXIS1_BYTES_LEN)..subset.len() {
         if subset[i] != b' ' {
-            naxis1_end = i;
+            naxis1_val_start = i;
             break;
         }
     }
-    for i in naxis1_end..subset.len() {
+    for i in naxis1_val_start..subset.len() {
         if subset[i] == b' ' {
-            digits_end = i;
+            naxis1_val_end = i;
             break;
         }
     }
-    let naxis1 = String::from_utf8_lossy(&subset[naxis1_end..digits_end])
-        .parse::<i32>()
+    let naxis1 = String::from_utf8_lossy(&subset[naxis1_val_start..naxis1_val_end])
+        .parse::<usize>()
         .unwrap();
 
-    let mut naxis2_start = digits_end;
-    let mut naxis2_end = 0;
-    let mut digits2_end = 0;
-    for i in naxis2_start..subset.len() - NAXIS2_BYTES_LEN {
+    let mut naxis2_key_start = naxis1_val_end;
+    let mut naxis2_val_start = 0;
+    let mut naxis2_val_end = 0;
+    for i in naxis2_key_start..subset.len() - NAXIS2_BYTES_LEN {
         if &subset[i..(i + NAXIS2_BYTES_LEN)] == NAXIS2_BYTES {
-            naxis2_start = i + NAXIS2_BYTES_LEN;
+            naxis2_key_start = i + NAXIS2_BYTES_LEN;
             break;
         }
     }
-    for i in naxis2_start..subset.len() {
+    for i in naxis2_key_start..subset.len() {
         if subset[i] != b' ' {
-            naxis2_end = i;
+            naxis2_val_start = i;
             break;
         }
     }
-    for i in naxis2_end..subset.len() {
+    for i in naxis2_val_start..subset.len() {
         if subset[i] == b' ' {
-            digits2_end = i;
+            naxis2_val_end = i;
             break;
         }
     }
-    let naxis2 = String::from_utf8_lossy(&subset[naxis2_end..digits2_end])
-        .parse::<i32>()
+    let naxis2 = String::from_utf8_lossy(&subset[naxis2_val_start..naxis2_val_end])
+        .parse::<usize>()
         .unwrap();
 
     let mut image_data =
-        u8_to_f32_vec(&decompressed_data[2880..(2880 + (naxis1 * naxis2 * 4) as usize)]); // 32 BITPIX / 8 bits per byte = 4
+        u8_to_f32_vec(&decompressed_data[FITS_HEADER_LEN..(FITS_HEADER_LEN + (naxis1 * naxis2 * 4) as usize)]); // 32 BITPIX / 8 bits per byte = 4
 
-    // if NAXIS1 and NAXIS2 are not 63, we need to pad the image with zeros
+    // if NAXIS1 and NAXIS2 are not NAXIS_STANDARD, we need to pad the image with zeros
     // we can't just add zeros to the end of the image_data vector, because it's a 2D array we flattened into a 1D vector
-    // so if NAXIS1 is not 63, we need to add 63 - NAXIS1 zeros to the start and end of each row
-    // and if NAXIS2 is not 63, we need to add 63 - NAXIS2 zeros to the start and end of the vector
+    // so if NAXIS1 is not NAXIS_STANDARD, we need to add NAXIS_STANDARD - NAXIS1 zeros to the start and end of each row
+    // and if NAXIS2 is not NAXIS_STANDARD, we need to add NAXIS_STANDARD - NAXIS2 zeros to the start and end of the vector
 
-    if naxis1 != 63 {
-        let mut new_image_data = vec![];
-        for row in image_data.chunks_exact(naxis1 as usize) {
-            let mut new_row = vec![0.0; 63];
-            let start = (63 - naxis1) / 2;
-            for i in 0..naxis1 as i32 {
-                new_row[(start + i) as usize] = row[i as usize];
-            }
-            new_image_data.extend(new_row);
-        }
-        image_data = new_image_data;
-    }
-
-    if naxis2 != 63 {
-        let mut new_image_data = vec![0.0; 63 * 63];
-        let start = (63 - naxis2) / 2;
-        for i in 0..naxis2 as i32 {
-            for j in 0..63 {
-                new_image_data[((start + i) * 63 + j) as usize] =
-                    image_data[(i * naxis1 + j) as usize];
+    let offset1 = (NAXIS_STANDARD - naxis1) / 2; // Assuming naxis1 and naxis2 are both usize
+    let offset2 = (NAXIS_STANDARD - naxis2) / 2;
+    if (offset1, offset2) != (0, 0) {
+        let mut new_image_data = vec![0.0; NB_PIXELS];
+        for i in 0..naxis2 {
+            for j in 0..naxis1 {
+                let k = i * naxis1 + j;
+                let k_new = (i + offset2) * NAXIS_STANDARD + (j + offset1);
+                new_image_data[k_new] = image_data[k];
             }
         }
         image_data = new_image_data;
@@ -120,29 +103,20 @@ pub fn buffer_to_image(buffer: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::
     Ok(image_data)
 }
 
-/// Normalizes an image by replacing NaNs with 0s and infinities with the maximum finite value
-/// Then, it computes the Frobenius norm of the image
-/// and normalizes the image by dividing each pixel by the norm
+/// Normalizes a flattened 2D image
 pub fn normalize_image(image: Vec<f32>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
-    // first, replace all NaNs with 0s
-    // and infinities with the maximum finite value
-    let mut normalized = vec![];
-    for pixel in image {
+    // replace all NaNs with 0s and clamp all values to the range [f32::MIN, f32::MAX]
+    let mut normalized: Vec<f32> = image
+    .into_iter()
+    .map(|pixel| {
         if pixel.is_nan() {
-            //println!("Found a NaN");
-            normalized.push(0.0);
-        } else if pixel.is_infinite() {
-            println!("Found an infinity");
-            // f32MIN if the number is negative, f32MAX if the number is positive
-            normalized.push(if pixel.is_sign_negative() {
-                f32::MIN
-            } else {
-                f32::MAX
-            });
+            0.0
         } else {
-            normalized.push(pixel);
+            pixel.clamp(f32::MIN, f32::MAX)
         }
-    }
+    })
+    .collect();
+
     // then, compute the norm of the vector, which is the Frobenius norm of this array
     // so a 2-norm of a vector is the square root of the sum of the squares of the elements (in absolute value)
     let norm: f32 = normalized.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
@@ -153,8 +127,7 @@ pub fn normalize_image(image: Vec<f32>) -> Result<Vec<f32>, Box<dyn std::error::
 
 /// Prepares a cutout image for ML models
 /// It reads the image from the alert document
-/// decompresses it, normalizes it and returns it as a vector of f32
-/// The image is expected to be a 2D array of floats
+/// decompresses it, normalizes it and returns it as a flattened 2D array of floats
 fn prepare_cutout(cutout: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
     let cutout = buffer_to_image(cutout).unwrap();
     let cutout = normalize_image(cutout).unwrap();
@@ -162,9 +135,6 @@ fn prepare_cutout(cutout: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::Error
 }
 
 /// Prepares a triplet of cutouts for ML models
-/// It reads the images from the alert document
-/// decompresses them, normalizes them and returns them as a tuple of vectors of f32
-/// The images are expected to be 2D arrays of floats
 pub fn prepare_triplet(
     alert_doc: &mongodb::bson::Document,
 ) -> Result<(Vec<f32>, Vec<f32>, Vec<f32>), Box<dyn std::error::Error>> {

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -1,0 +1,196 @@
+use flate2::read::GzDecoder;
+use std::io::{Cursor, Read};
+
+const NAXIS1_BYTES: &[u8] = "NAXIS1  =".as_bytes();
+const NAXIS2_BYTES: &[u8] = "NAXIS2  =".as_bytes();
+const NAXIS1_BYTES_LEN: usize = NAXIS1_BYTES.len();
+const NAXIS2_BYTES_LEN: usize = NAXIS2_BYTES.len();
+
+fn u8_to_f32_vec(v: &[u8]) -> Vec<f32> {
+    v.chunks_exact(4)
+        .map(TryInto::try_into)
+        .map(Result::unwrap)
+        .map(f32::from_be_bytes)
+        .collect()
+}
+
+/// Converts a buffer of bytes to an image
+///
+/// The buffer is expected to be a gzipped FITS file served as a binary
+/// The function decompresses the buffer and extracts the image data
+/// The image is expected to be a 2D array of floats
+/// We assume that the FITS image has headers that indicate the dimensions of the image
+/// Looking for the NAXIS1 and NAXIS2 keywords as bytes is much faster than
+/// converting the whole buffer to a string and searching with a regex
+/// The function returns a vector of f32
+/// The image is expected to be a 2D array of floats
+pub fn buffer_to_image(buffer: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+    let cursor = Cursor::new(buffer);
+
+    let mut decoder = GzDecoder::new(cursor);
+
+    let mut decompressed_data = Vec::new();
+    let _ = decoder.read_to_end(&mut decompressed_data);
+
+    let subset = &decompressed_data[0..2880];
+
+    let mut naxis1_start = 0;
+    let mut naxis1_end = 0;
+    let mut digits_end = 0;
+    for i in 0..subset.len() - NAXIS1_BYTES_LEN {
+        if &subset[i..(i + NAXIS1_BYTES_LEN)] == NAXIS1_BYTES {
+            naxis1_start = i + NAXIS1_BYTES_LEN;
+            break;
+        }
+    }
+    for i in naxis1_start..subset.len() {
+        if subset[i] != b' ' {
+            naxis1_end = i;
+            break;
+        }
+    }
+    for i in naxis1_end..subset.len() {
+        if subset[i] == b' ' {
+            digits_end = i;
+            break;
+        }
+    }
+    let naxis1 = String::from_utf8_lossy(&subset[naxis1_end..digits_end])
+        .parse::<i32>()
+        .unwrap();
+
+    let mut naxis2_start = digits_end;
+    let mut naxis2_end = 0;
+    let mut digits2_end = 0;
+    for i in naxis2_start..subset.len() - NAXIS2_BYTES_LEN {
+        if &subset[i..(i + NAXIS2_BYTES_LEN)] == NAXIS2_BYTES {
+            naxis2_start = i + NAXIS2_BYTES_LEN;
+            break;
+        }
+    }
+    for i in naxis2_start..subset.len() {
+        if subset[i] != b' ' {
+            naxis2_end = i;
+            break;
+        }
+    }
+    for i in naxis2_end..subset.len() {
+        if subset[i] == b' ' {
+            digits2_end = i;
+            break;
+        }
+    }
+    let naxis2 = String::from_utf8_lossy(&subset[naxis2_end..digits2_end])
+        .parse::<i32>()
+        .unwrap();
+
+    let mut image_data =
+        u8_to_f32_vec(&decompressed_data[2880..(2880 + (naxis1 * naxis2 * 4) as usize)]); // 32 BITPIX / 8 bits per byte = 4
+
+    // if NAXIS1 and NAXIS2 are not 63, we need to pad the image with zeros
+    // we can't just add zeros to the end of the image_data vector, because it's a 2D array we flattened into a 1D vector
+    // so if NAXIS1 is not 63, we need to add 63 - NAXIS1 zeros to the start and end of each row
+    // and if NAXIS2 is not 63, we need to add 63 - NAXIS2 zeros to the start and end of the vector
+
+    if naxis1 != 63 {
+        let mut new_image_data = vec![];
+        for row in image_data.chunks_exact(naxis1 as usize) {
+            let mut new_row = vec![0.0; 63];
+            let start = (63 - naxis1) / 2;
+            for i in 0..naxis1 as i32 {
+                new_row[(start + i) as usize] = row[i as usize];
+            }
+            new_image_data.extend(new_row);
+        }
+        image_data = new_image_data;
+    }
+
+    if naxis2 != 63 {
+        let mut new_image_data = vec![0.0; 63 * 63];
+        let start = (63 - naxis2) / 2;
+        for i in 0..naxis2 as i32 {
+            for j in 0..63 {
+                new_image_data[((start + i) * 63 + j) as usize] =
+                    image_data[(i * naxis1 + j) as usize];
+            }
+        }
+        image_data = new_image_data;
+    }
+
+    Ok(image_data)
+}
+
+/// Normalizes an image by replacing NaNs with 0s and infinities with the maximum finite value
+/// Then, it computes the Frobenius norm of the image
+/// and normalizes the image by dividing each pixel by the norm
+pub fn normalize_image(image: Vec<f32>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+    // first, replace all NaNs with 0s
+    // and infinities with the maximum finite value
+    let mut normalized = vec![];
+    for pixel in image {
+        if pixel.is_nan() {
+            //println!("Found a NaN");
+            normalized.push(0.0);
+        } else if pixel.is_infinite() {
+            println!("Found an infinity");
+            // f32MIN if the number is negative, f32MAX if the number is positive
+            normalized.push(if pixel.is_sign_negative() {
+                f32::MIN
+            } else {
+                f32::MAX
+            });
+        } else {
+            normalized.push(pixel);
+        }
+    }
+    // then, compute the norm of the vector, which is the Frobenius norm of this array
+    // so a 2-norm of a vector is the square root of the sum of the squares of the elements (in absolute value)
+    let norm: f32 = normalized.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+
+    normalized = normalized.iter().map(|x| x / norm).collect();
+    Ok(normalized)
+}
+
+/// Prepares a cutout image for ML models
+/// It reads the image from the alert document
+/// decompresses it, normalizes it and returns it as a vector of f32
+/// The image is expected to be a 2D array of floats
+fn prepare_cutout(cutout: Vec<u8>) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+    let cutout = buffer_to_image(cutout).unwrap();
+    let cutout = normalize_image(cutout).unwrap();
+    Ok(cutout)
+}
+
+/// Prepares a triplet of cutouts for ML models
+/// It reads the images from the alert document
+/// decompresses them, normalizes them and returns them as a tuple of vectors of f32
+/// The images are expected to be 2D arrays of floats
+pub fn prepare_triplet(
+    alert_doc: &mongodb::bson::Document,
+) -> Result<(Vec<f32>, Vec<f32>, Vec<f32>), Box<dyn std::error::Error>> {
+    let cutout_science = alert_doc
+        .get_document("cutoutScience")
+        .unwrap()
+        .get_binary_generic("stampData")
+        .unwrap()
+        .to_vec();
+    let cutout_science = prepare_cutout(cutout_science).unwrap();
+
+    let cutout_template = alert_doc
+        .get_document("cutoutTemplate")
+        .unwrap()
+        .get_binary_generic("stampData")
+        .unwrap()
+        .to_vec();
+    let cutout_template = prepare_cutout(cutout_template).unwrap();
+
+    let cutout_difference = alert_doc
+        .get_document("cutoutDifference")
+        .unwrap()
+        .get_binary_generic("stampData")
+        .unwrap()
+        .to_vec();
+    let cutout_difference = prepare_cutout(cutout_difference).unwrap();
+
+    Ok((cutout_science, cutout_template, cutout_difference))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod conf;
 pub mod fake_ml_worker;
 pub mod filter;
 pub mod filter_worker;
+pub mod fits;
 pub mod kafka;
 pub mod scheduling;
 pub mod spatial;


### PR DESCRIPTION
This PR adds the code we need to:
- read the image data from the gzipped cutouts we get in the alert packets
- normalize the image data using the [Frobenius norm](https://www.wikiwand.com/en/articles/Matrix_norm#Frobenius_norm)
- a method that takes an alert bson document and returns the image data for all 3 cutouts as a triplet of images
- calls said method in the ML worker.

TODOs:
- [ ] unit tests (reviewer should be able to look at the code without those, but I'll ask for another review once these are added)

Future PRs will keep improving the ML worker until we can do actual ML with it, calling models. We'll start with BTSbot, which is the model we already make the most use of in production w/ Kowalski and a great way to show BOOM's capabilities.

*PS: here we take a lot of shortcuts when reading the FITS data. Instead of having a generic fits file handling, since we know what the actual data looks like ahead of time we can optimize it and focus on the bare minimum needed to read img data from the alert packets. I should mention that this is significantly quicker than the fits file handling alternatives I could find on crates.io, and that way we keep things lightweight too.*