### PR TITLE
GeoJSON index on aux table + db utils

### DIFF
--- a/src/alert.rs
+++ b/src/alert.rs
@@ -75,6 +75,12 @@ pub async fn process_alert(
             "fp_hists": fp_hist_doc,
             "created_at": jd_timestamp,
             "updated_at": jd_timestamp,
+            "coordinates": {
+                "radec_geojson": {
+                    "type": "Point",
+                    "coordinates": [ra - 180.0, dec],
+                },
+            },
         };
         doc.insert(
             "cross_matches",

--- a/src/alert_worker.rs
+++ b/src/alert_worker.rs
@@ -1,18 +1,20 @@
 pub use crate::conf;
 use crate::{
     alert,
-    db::create_index,
+    db::{create_index, CreateIndexError},
     types::ztf_alert_schema,
     worker_util::{self, WorkerCmd},
 };
 use redis::AsyncCommands;
 use std::sync::mpsc::{self, TryRecvError};
-use tracing::{error, info, warn};
+use tracing::{error, info, instrument, warn};
 
 #[derive(thiserror::Error, Debug)]
 pub enum AlertWorkerError {
     #[error("failed to load config")]
     LoadConfigError(#[from] conf::ConfigError),
+    #[error("failed to create index")]
+    CreateIndexError(#[from] CreateIndexError),
     #[error("failed to connect to redis")]
     ConnectRedisError(#[source] redis::RedisError),
     #[error("failed to get alert schema")]
@@ -30,6 +32,7 @@ pub enum AlertWorkerError {
 }
 
 // alert worker as a standalone function which is run by the scheduler
+#[instrument(skip(receiver), err)]
 #[tokio::main]
 pub async fn alert_worker(
     id: &str,
@@ -54,25 +57,15 @@ pub async fn alert_worker(
     let alert_candid_index = mongodb::bson::doc! { "candid": -1 };
     let alert_object_id_index = mongodb::bson::doc! { "objectId": -1 };
     let alert_radec_geojson_index = mongodb::bson::doc! { "coordinates.radec_geojson": "2dsphere" };
-    create_index(&alert_collection, alert_candid_index, true)
-        .await
-        .unwrap();
-    create_index(&alert_collection, alert_object_id_index, false)
-        .await
-        .unwrap();
-    create_index(&alert_collection, alert_radec_geojson_index, false)
-        .await
-        .unwrap();
+    create_index(&alert_collection, alert_candid_index, true).await?;
+    create_index(&alert_collection, alert_object_id_index, false).await?;
+    create_index(&alert_collection, alert_radec_geojson_index, false).await?;
 
     let alert_aux_id_index = mongodb::bson::doc! { "_id": -1 };
     let alert_aux_radec_geojson_index =
         mongodb::bson::doc! { "coordinates.radec_geojson": "2dsphere" };
-    create_index(&alert_aux_collection, alert_aux_id_index, true)
-        .await
-        .unwrap();
-    create_index(&alert_aux_collection, alert_aux_radec_geojson_index, false)
-        .await
-        .unwrap();
+    create_index(&alert_aux_collection, alert_aux_id_index, true).await?;
+    create_index(&alert_aux_collection, alert_aux_radec_geojson_index, false).await?;
 
     // REDIS
     let client_redis = redis::Client::open("redis://localhost:6379".to_string())

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,27 @@
+use tracing::error;
+
+pub async fn create_index(
+    collection: &mongodb::Collection<mongodb::bson::Document>,
+    index: mongodb::bson::Document,
+    unique: bool,
+) -> mongodb::error::Result<()> {
+    let index_model = mongodb::IndexModel::builder()
+        .keys(index)
+        .options(
+            mongodb::options::IndexOptions::builder()
+                .unique(unique)
+                .build(),
+        )
+        .build();
+    match collection.create_index(index_model).await {
+        Err(e) => {
+            error!(
+                "Error when creating index for collection {}: {}",
+                collection.name(),
+                e
+            );
+        }
+        Ok(_x) => {}
+    }
+    Ok(())
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,15 @@
-use tracing::error;
+use tracing::instrument;
 
+#[derive(thiserror::Error, Debug)]
+#[error("failed to create index")]
+pub struct CreateIndexError(#[from] mongodb::error::Error);
+
+#[instrument(skip(collection, index), err, fields(collection = collection.name()))]
 pub async fn create_index(
     collection: &mongodb::Collection<mongodb::bson::Document>,
     index: mongodb::bson::Document,
     unique: bool,
-) -> mongodb::error::Result<()> {
+) -> Result<(), CreateIndexError> {
     let index_model = mongodb::IndexModel::builder()
         .keys(index)
         .options(
@@ -13,15 +18,6 @@ pub async fn create_index(
                 .build(),
         )
         .build();
-    match collection.create_index(index_model).await {
-        Err(e) => {
-            error!(
-                "Error when creating index for collection {}: {}",
-                collection.name(),
-                e
-            );
-        }
-        Ok(_x) => {}
-    }
+    collection.create_index(index_model).await?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod alert;
 pub mod alert_worker;
 pub mod conf;
+pub mod db;
 pub mod fake_ml_worker;
 pub mod filter;
 pub mod filter_worker;


### PR DESCRIPTION
This PR adds:
- a `coordinates.radec_geojson` field on the alert_aux entries to allow direct object-level queries. One issue we noticed in Kowalski is that folks might want to simply query for objects (often even just their names) without having to query for alerts (where you have multiple entries for the same object). This will also speed up the survey <-> survey cone searches we'll have to do for ZTF + Rubin operations, so we can query a table of N objects rather than a table of N * M alerts.
- We take advantage of this PR to properly add code to create the 2dsphere indexes we need to query the tables with cone searches, which was missing so far. For that we add a new `db.rs` file with a method to create indexes given a collection, and an index details' as a bson document

TODO: think about the error handling :) Here we do not care if creating an index fails, so the current error handling which simply logs errors should be fine already.