### PR TITLE
Add error types to the alert worker system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+
+[[package]]
 name = "apache-avro"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +282,7 @@ dependencies = [
 name = "boom"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "apache-avro",
  "chrono",
  "clap",
@@ -289,6 +296,7 @@ dependencies = [
  "rsgen-avro",
  "serde",
  "serde_json",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ rdkafka = "0.37.0"
 redis = { version = "0.28.2", features = ["tokio-comp"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.138"
+thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 uuid = { version = "1.12", features = ["v4"] }
+anyhow = "1.0.96"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -32,7 +32,7 @@ pub async fn process_alert(
     let alert = types::Alert::from_avro_bytes_unsafe(avro_bytes, schema)?;
 
     // check if the alert already exists in the alerts collection
-    if let None = alert_collection
+    if let Some(_) = alert_collection
         .find_one(doc! { "candid": &alert.candid })
         .await
         .map_err(AlertError::FindCandIdError)?

--- a/src/alert_worker.rs
+++ b/src/alert_worker.rs
@@ -1,34 +1,52 @@
+pub use crate::conf;
 use crate::{
-    alert, conf,
+    alert,
     types::ztf_alert_schema,
     worker_util::{self, WorkerCmd},
 };
 use redis::AsyncCommands;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::mpsc::{self, TryRecvError};
 use tracing::{error, info, warn};
+
+#[derive(thiserror::Error, Debug)]
+pub enum AlertWorkerError {
+    #[error("failed to load config")]
+    LoadConfigError(#[from] conf::ConfigError),
+    #[error("failed to connect to redis")]
+    ConnectRedisError(#[source] redis::RedisError),
+    #[error("failed to get alert schema")]
+    GetAlertSchemaError,
+    #[error("failed to pop from the alert queue")]
+    PopAlertError(#[source] redis::RedisError),
+    #[error("failed to get avro bytes from the alert queue")]
+    GetAvroBytesError,
+    #[error("failed to push candid onto the candid queue")]
+    PushCandidError(#[source] redis::RedisError),
+    #[error("failed to remove alert from the alert queue")]
+    RemoveAlertError(#[source] redis::RedisError),
+    #[error("failed to push alert onto the alert queue")]
+    PushAlertError(#[source] redis::RedisError),
+}
 
 // alert worker as a standalone function which is run by the scheduler
 #[tokio::main]
 pub async fn alert_worker(
-    id: String,
-    receiver: Arc<Mutex<mpsc::Receiver<WorkerCmd>>>,
+    id: &str,
     stream_name: String,
-    config_path: String,
-) {
-    let config_file = conf::load_config(&config_path).unwrap();
+    config_path: &str,
+    receiver: mpsc::Receiver<WorkerCmd>,
+) -> Result<(), AlertWorkerError> {
+    let config_file = conf::load_config(config_path)?;
 
     // XMATCH CONFIGS
     let xmatch_configs = conf::build_xmatch_configs(&config_file, &stream_name);
 
     // DATABASE
     let db: mongodb::Database = conf::build_db(&config_file).await;
-    if let Err(e) = db.list_collection_names().await {
-        error!("Error connecting to the database: {}", e);
-        return;
-    }
 
     // create alert and alert-auxillary collections
-    let alert_collection = db.collection(&format!("{}_alerts", stream_name));
+    let alert_collection_name = format!("{}_alerts", stream_name);
+    let alert_collection = db.collection(&alert_collection_name);
     let alert_aux_collection = db.collection(&format!("{}_alerts_aux", stream_name));
 
     // create index for alert collection
@@ -40,119 +58,128 @@ pub async fn alert_worker(
                 .build(),
         )
         .build();
-    match alert_collection.create_index(alert_candid_index).await {
-        Err(e) => {
-            error!(
-                "Error when creating index for candidate.candid in collection {}: {}",
-                format!("{}_alerts", stream_name),
-                e
-            );
-        }
-        Ok(_x) => {}
-    }
+
+    // TODO: Is it OK to proceed if this fails?
+    if let Err(error) = alert_collection.create_index(alert_candid_index).await {
+        warn!(
+            error = %error,
+            "Error when creating index for candidate.candid in collection {}",
+            alert_collection_name,
+        );
+    };
 
     // REDIS
-    let client_redis = redis::Client::open("redis://localhost:6379".to_string()).unwrap();
+    let client_redis = redis::Client::open("redis://localhost:6379".to_string())
+        .map_err(AlertWorkerError::ConnectRedisError)?;
     let mut con = client_redis
         .get_multiplexed_async_connection()
         .await
-        .unwrap();
+        .map_err(AlertWorkerError::ConnectRedisError)?;
     let queue_name = format!("{}_alerts_packets_queue", stream_name);
     let queue_temp_name = format!("{}_alerts_packets_queuetemp", stream_name);
     let classifer_queue_name = format!("{}_alerts_classifier_queue", stream_name);
 
-    let mut alert_counter = 0;
     let command_interval = worker_util::get_check_command_interval(config_file, &stream_name);
+    let mut command_check_countdown = command_interval;
     // ALERT SCHEMA (for fast avro decoding)
-    let schema = ztf_alert_schema().unwrap();
+    let schema = ztf_alert_schema().ok_or(AlertWorkerError::GetAlertSchemaError)?;
     let mut count = 0;
     let start = std::time::Instant::now();
     loop {
         // check for command from threadpool
-        if alert_counter - command_interval > 0 {
-            alert_counter = 0;
-            if let Ok(command) = receiver.lock().unwrap().try_recv() {
-                match command {
-                    WorkerCmd::TERM => {
-                        warn!("alert worker {} received termination command", id);
-                        return;
-                    }
+        if command_check_countdown == 0 {
+            match receiver.try_recv() {
+                Ok(WorkerCmd::TERM) => {
+                    info!("alert worker {} received termination command", id);
+                    break;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    warn!("alert worker {} receiver disconnected, terminating", id);
+                    break;
+                }
+                Err(TryRecvError::Empty) => {
+                    command_check_countdown = command_interval;
                 }
             }
         }
         // retrieve candids from redis
-        let result: Option<Vec<Vec<u8>>> =
-            con.rpoplpush(&queue_name, &queue_temp_name).await.unwrap();
+        let Some(mut value): Option<Vec<Vec<u8>>> = con
+            // TODO: If the intention is to have a reliable queue, then there
+            // needs to be a separate thread that continuously monitors the temp
+            // queue and adds any items it finds back to the main queue.
+            // However, we're already pushing the value back onto the when we
+            // handle a processing error, so do we need the temp queue?
+            .rpoplpush(&queue_name, &queue_temp_name)
+            .await
+            .map_err(AlertWorkerError::PopAlertError)?
+        else {
+            info!("ALERT WORKER {}: Queue is empty", id);
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            command_check_countdown = 0;
+            continue;
+        };
+        // TODO: Where does the nested vector structure come from, and are there
+        // any guarantees about whether the outer vector always has exactly one
+        // inner vector? There may be a way to simplify this.
+        let avro_bytes = (!value.is_empty())
+            .then_some(value.remove(0))
+            .ok_or(AlertWorkerError::GetAvroBytesError)?;
+        let result = alert::process_alert(
+            &avro_bytes,
+            &xmatch_configs,
+            &db,
+            &alert_collection,
+            &alert_aux_collection,
+            &schema,
+        )
+        .await;
         match result {
-            Some(value) => {
-                let candid = alert::process_alert(
-                    value[0].clone(),
-                    &xmatch_configs,
-                    &db,
-                    &alert_collection,
-                    &alert_aux_collection,
-                    &schema,
-                )
-                .await;
-                alert_counter += 1;
-                match candid {
-                    Ok(Some(candid)) => {
-                        info!(
-                            "Processed alert with candid: {}, queueing for classification",
-                            candid
-                        );
-                        // queue the candid for processing by the classifier
-                        con.lpush::<&str, i64, isize>(&classifer_queue_name, candid)
-                            .await
-                            .unwrap();
-                        con.lrem::<&str, Vec<u8>, isize>(&queue_temp_name, 1, value[0].clone())
-                            .await
-                            .unwrap();
-                    }
-                    Ok(None) => {
-                        info!("Alert already exists");
-                        // remove the alert from the queue
-                        con.lrem::<&str, Vec<u8>, isize>(&queue_temp_name, 1, value[0].clone())
-                            .await
-                            .unwrap();
-                    }
-                    Err(e) => {
-                        error!("Error processing alert: {}, requeueing", e);
-                        // put it back in the ZTF_alerts_packets_queue, to the left (pop from the right, push to the left)
-                        con.lrem::<&str, Vec<u8>, isize>(&queue_temp_name, 1, value[0].clone())
-                            .await
-                            .unwrap();
-                        con.lpush::<&str, Vec<u8>, isize>(&queue_name, value[0].clone())
-                            .await
-                            .unwrap();
-                    }
-                }
-                if count > 1 && count % 100 == 0 {
-                    let elapsed = start.elapsed().as_secs();
-                    info!(
-                        "\nProcessed {} {} alerts in {} seconds, avg: {:.4} alerts/s\n",
-                        count,
-                        stream_name,
-                        elapsed,
-                        count as f64 / elapsed as f64
-                    );
-                }
-                count += 1;
+            Ok(Some(candid)) => {
+                info!(
+                    "Processed alert with candid: {}, queueing for classification",
+                    candid
+                );
+                // queue the candid for processing by the classifier
+                con.lpush::<&str, i64, isize>(&classifer_queue_name, candid)
+                    .await
+                    .map_err(AlertWorkerError::PushCandidError)?;
+                // TODO: Is this correct? The value in the main queue was a nested vector.
+                con.lrem::<&str, Vec<u8>, isize>(&queue_temp_name, 1, avro_bytes)
+                    .await
+                    .map_err(AlertWorkerError::RemoveAlertError)?;
             }
-            None => {
-                info!("ALERT WORKER {}: Queue is empty", id);
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                alert_counter = 0;
-                // check for command from threadpool
-                if let Ok(command) = receiver.lock().unwrap().try_recv() {
-                    match command {
-                        WorkerCmd::TERM => {
-                            warn!("alert worker {} received termination command", id);
-                            return;
-                        }
-                    }
-                }
+            Ok(None) => {
+                info!("Alert already exists");
+                // TODO: Is this correct? The value in the main queue was a nested vector.
+                con.lrem::<&str, Vec<u8>, isize>(&queue_temp_name, 1, avro_bytes)
+                    .await
+                    .map_err(AlertWorkerError::RemoveAlertError)?;
+            }
+            Err(error) => {
+                warn!(error = %error, "Error processing alert, requeueing");
+                // put it back in the ZTF_alerts_packets_queue, to the left (pop from the right, push to the left)
+                // TODO: Is this correct? The original value was a nested vector.
+                con.lpush::<&str, Vec<u8>, isize>(&queue_name, avro_bytes.clone())
+                    .await
+                    .map_err(AlertWorkerError::PushAlertError)?;
+                // TODO: Is this correct? The value in the main queue was a nested vector.
+                con.lrem::<&str, Vec<u8>, isize>(&queue_temp_name, 1, avro_bytes)
+                    .await
+                    .map_err(AlertWorkerError::RemoveAlertError)?;
             }
         }
+        if count > 1 && count % 100 == 0 {
+            let elapsed = start.elapsed().as_secs();
+            info!(
+                "\nProcessed {} {} alerts in {} seconds, avg: {:.4} alerts/s\n",
+                count,
+                stream_name,
+                elapsed,
+                count as f64 / elapsed as f64
+            );
+        }
+        count += 1;
+        command_check_countdown -= 1;
     }
+    Ok(())
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,5 +1,7 @@
 use config::Config;
-use config::ConfigError;
+// TODO: we do not want to get in the habit of making 3rd party types part of
+// our public API. It's almost always asking for trouble.
+pub use config::ConfigError;
 use config::File;
 use std::path::Path;
 use tracing::error;
@@ -15,8 +17,7 @@ pub fn load_config(filepath: &str) -> Result<Config, ConfigError> {
 
     let conf = Config::builder()
         .add_source(File::with_name(filepath))
-        .build()
-        .unwrap();
+        .build()?;
     Ok(conf)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod alert;
-pub mod alert_worker;
+mod alert_worker;
 pub mod conf;
-pub mod fake_ml_worker;
+mod fake_ml_worker;
 pub mod filter;
-pub mod filter_worker;
+mod filter_worker;
 pub mod kafka;
 pub mod scheduling;
 pub mod spatial;

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -3,7 +3,7 @@ use crate::{
     worker_util::{WorkerCmd, WorkerType},
 };
 use std::{sync::mpsc, thread};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 // Thread pool
 // allows spawning, killing, and managing of various worker threads through
@@ -48,7 +48,7 @@ impl ThreadPool {
         for worker in &self.workers {
             info!("sending termination signal to worker {}", &worker.id);
             if let Err(error) = worker.terminate() {
-                error!(
+                warn!(
                     error = %error,
                     "failed to send termination signal to worker {}",
                     &worker.id

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -2,22 +2,17 @@ use crate::{
     alert_worker, fake_ml_worker, filter_worker,
     worker_util::{WorkerCmd, WorkerType},
 };
-use std::{
-    collections::HashMap,
-    sync::{mpsc, Arc, Mutex},
-    thread,
-};
-use tracing::{info, warn};
+use std::{sync::mpsc, thread};
+use tracing::{error, info};
 
 // Thread pool
 // allows spawning, killing, and managing of various worker threads through
 // the use of a messages
 pub struct ThreadPool {
-    pub worker_type: WorkerType,
-    pub stream_name: String,
-    pub config_path: String,
-    pub workers: HashMap<String, Worker>,
-    pub senders: HashMap<String, Option<mpsc::Sender<WorkerCmd>>>,
+    worker_type: WorkerType,
+    stream_name: String,
+    config_path: String,
+    workers: Vec<Worker>,
 }
 
 /// Threadpool
@@ -35,99 +30,65 @@ impl ThreadPool {
         size: usize,
         stream_name: String,
         config_path: String,
-    ) -> ThreadPool {
-        let mut workers = HashMap::new();
-        let mut senders = HashMap::new();
-
-        for _ in 0..size {
-            let id = uuid::Uuid::new_v4().to_string();
-            let (sender, receiver) = mpsc::channel();
-            let receiver = Arc::new(Mutex::new(receiver));
-            workers.insert(
-                id.clone(),
-                Worker::new(
-                    worker_type,
-                    id.clone(),
-                    Arc::clone(&receiver),
-                    stream_name.clone(),
-                    config_path.clone(),
-                ),
-            );
-            senders.insert(id.clone(), Some(sender));
-        }
-
-        ThreadPool {
+    ) -> Self {
+        let mut thread_pool = ThreadPool {
             worker_type,
             stream_name,
             config_path,
-            workers,
-            senders,
+            workers: Vec::new(),
+        };
+        for _ in 0..size {
+            thread_pool.add_worker();
+        }
+        thread_pool
+    }
+
+    /// Send a termination signal to each worker thread.
+    fn terminate(&self) {
+        for worker in &self.workers {
+            info!("sending termination signal to worker {}", &worker.id);
+            if let Err(error) = worker.terminate() {
+                error!(
+                    error = %error,
+                    "failed to send termination signal to worker {}",
+                    &worker.id
+                );
+            }
         }
     }
 
-    /// remove a worker from the thread pool by id
-    ///
-    /// id: string identifier for the worker to be removed
-    pub fn remove_worker(&mut self, id: String) {
-        if let Some(sender) = &self.senders[&id] {
-            match sender.send(WorkerCmd::TERM) {
-                Ok(_) => {
-                    warn!("Sent terminate message to worker {}", &id);
-                }
-                Err(e) => {
-                    warn!("Failed to send terminate message to worker {}: {}", &id, e);
+    /// Join all worker threads in the pool.
+    fn join(&mut self) {
+        for worker in &mut self.workers {
+            if let Some(thread) = worker.thread.take() {
+                match thread.join() {
+                    Ok(_) => info!("successfully shut down worker {}", &worker.id),
+                    Err(error) => {
+                        error!(error = ?error, "failed to shut down worker {}", &worker.id)
+                    }
                 }
             }
-            self.senders.remove(&id);
-
-            // if let Some(worker) = self.workers.get_mut(&id) {
-            //     if let Some(thread) = worker.thread.take() {
-            //     thread.join().unwrap();
-            // }
         }
     }
 
-    // add a new worker to the thread pool
-    pub fn add_worker(&mut self) {
+    /// Add a new worker to the thread pool
+    fn add_worker(&mut self) {
         let id = uuid::Uuid::new_v4().to_string();
-        let (sender, receiver) = mpsc::channel();
-        let receiver = Arc::new(Mutex::new(receiver));
-        self.workers.insert(
+        info!("adding worker with id {}", id);
+        self.workers.push(Worker::new(
+            self.worker_type,
             id.clone(),
-            Worker::new(
-                self.worker_type,
-                id.clone(),
-                Arc::clone(&receiver),
-                self.stream_name.clone(),
-                self.config_path.clone(),
-            ),
-        );
-        self.senders.insert(id.clone(), Some(sender));
-        info!("Added worker with id: {}", &id);
+            self.stream_name.clone(),
+            self.config_path.clone(),
+        ));
     }
 }
 
-// shut down all workers from the thread pool and drop the threadpool
+// Shut down all workers from the thread pool and drop the threadpool
 impl Drop for ThreadPool {
     fn drop(&mut self) {
-        warn!("Sending terminate message to all workers.");
-
-        // get the ids of all workers
-        let ids: Vec<String> = self.senders.keys().cloned().collect();
-
-        for id in ids {
-            self.remove_worker(id);
-        }
-
-        warn!("Shutting down all workers.");
-
-        for (id, worker) in &mut self.workers {
-            warn!("Shutting down worker {}", &id);
-
-            if let Some(thread) = worker.thread.take() {
-                thread.join().unwrap();
-            }
-        }
+        self.terminate();
+        self.join();
     }
 }
 
@@ -137,8 +98,9 @@ impl Drop for ThreadPool {
 /// controlled completely by a threadpool and has a listening channel through
 /// which it listens for commands from it.
 pub struct Worker {
-    pub id: String,
-    pub thread: Option<thread::JoinHandle<()>>,
+    id: String,
+    thread: Option<thread::JoinHandle<()>>,
+    sender: mpsc::Sender<WorkerCmd>,
 }
 
 impl Worker {
@@ -152,14 +114,19 @@ impl Worker {
     fn new(
         worker_type: WorkerType,
         id: String,
-        receiver: Arc<Mutex<mpsc::Receiver<WorkerCmd>>>,
         stream_name: String,
         config_path: String,
     ) -> Worker {
         let id_copy = id.clone();
+        let (sender, receiver) = mpsc::channel();
         let thread = match worker_type {
-            WorkerType::Alert => thread::spawn(|| {
-                alert_worker::alert_worker(id, receiver, stream_name, config_path);
+            // TODO: Spawn a new worker thread when one dies? (A supervisor or something like that?)
+            WorkerType::Alert => thread::spawn(move || {
+                if let Err(e) =
+                    alert_worker::alert_worker(&id, stream_name.clone(), &config_path, receiver)
+                {
+                    error!(id, stream_name, config_path, error = %e, "alert worker failed")
+                }
             }),
             WorkerType::Filter => thread::spawn(|| {
                 let _ = filter_worker::filter_worker(id, receiver, stream_name, config_path);
@@ -172,6 +139,12 @@ impl Worker {
         Worker {
             id: id_copy,
             thread: Some(thread),
+            sender,
         }
+    }
+
+    /// Send a termination signal to the worker's thread.
+    fn terminate(&self) -> Result<(), mpsc::SendError<WorkerCmd>> {
+        self.sender.send(WorkerCmd::TERM)
     }
 }

--- a/src/testing_util.rs
+++ b/src/testing_util.rs
@@ -58,7 +58,7 @@ pub async fn alert_worker(
         match result {
             Some(value) => {
                 let candid = alert::process_alert(
-                    value[0].clone(),
+                    &value[0],
                     &xmatch_configs,
                     &db,
                     &alert_collection,

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@ use mongodb::bson::doc;
 use mongodb::bson::to_document;
 use tracing::error;
 
+// TODO: This should return a Result.
 pub fn ztf_alert_schema() -> Option<Schema> {
     // infer the schema from an avro file directly,
     // easier than merging the 5 schemas in schema/ztf
@@ -1224,10 +1225,14 @@ impl Alert {
         Ok(alert)
     }
 
+    // TODO:
+    // * Why is this "unsafe"? We currently panic if the value can't be
+    //   deserialized into in Alert, but we could easily make that an error.
+    // * Why aren't we just using Reader::with_schema?
     pub fn from_avro_bytes_unsafe(
-        avro_bytes: Vec<u8>,
+        avro_bytes: &[u8],
         schema: &apache_avro::Schema,
-    ) -> Result<Alert, Box<dyn std::error::Error>> {
+    ) -> Result<Alert, Box<dyn std::error::Error>> { // TODO: need a concrete error type here
         let mut cursor = std::io::Cursor::new(avro_bytes);
 
         let mut buf = [0; 4];
@@ -1253,7 +1258,7 @@ impl Alert {
         let value = from_avro_datum(&schema, &mut cursor, None);
         match value {
             Ok(value) => {
-                let alert: Alert = from_value::<Alert>(&value).unwrap();
+                let alert: Alert = from_value::<Alert>(&value).unwrap(); // TODO: handle error
                 Ok(alert)
             }
             Err(e) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,6 @@ use mongodb::bson::doc;
 use mongodb::bson::to_document;
 use tracing::error;
 
-// TODO: This should return a Result.
 pub fn ztf_alert_schema() -> Option<Schema> {
     // infer the schema from an avro file directly,
     // easier than merging the 5 schemas in schema/ztf

--- a/src/types.rs
+++ b/src/types.rs
@@ -1232,7 +1232,8 @@ impl Alert {
     pub fn from_avro_bytes_unsafe(
         avro_bytes: &[u8],
         schema: &apache_avro::Schema,
-    ) -> Result<Alert, Box<dyn std::error::Error>> { // TODO: need a concrete error type here
+    ) -> Result<Alert, Box<dyn std::error::Error>> {
+        // TODO: need a concrete error type here
         let mut cursor = std::io::Cursor::new(avro_bytes);
 
         let mut buf = [0; 4];

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -14,7 +14,7 @@ fn test_avro_to_alert_unsafe() {
     let schema = types::ztf_alert_schema().unwrap();
     let file_name = "tests/data/alerts/ztf/2695378462115010012.avro";
     let bytes_content = std::fs::read(file_name).unwrap();
-    let alert = types::Alert::from_avro_bytes_unsafe(bytes_content, &schema);
+    let alert = types::Alert::from_avro_bytes_unsafe(&bytes_content, &schema);
     assert!(alert.is_ok());
 }
 


### PR DESCRIPTION
Closes #67

Normally I don't commit changes like I did here ("pile o changes"), I try to make the commit history a little more semantic for easier review. But in the interest of time, I'll try to summarize what was done here.

The main change was adding new `AlertError` and `AlertWorkerError` types. Errors encountered in both `alert_worker` and `process_alert` are converted into one of the variants of these types, either automatically via the `From` impl provided by `thiserror` or explicitly via `map_err`, and then we propagate the error back to the caller using the `?` syntax. This is all done instead of calling `unwrap`, which would cause the program to panic if there's an error.

There's some stuff I did in the scheduler, including taking out the mutex on the receiver which we didn't really need, and streamlining how we track and handle workers.