### PR TITLE
handle index creation errors

### DIFF
--- a/src/alert_worker.rs
+++ b/src/alert_worker.rs
@@ -1,7 +1,7 @@
 pub use crate::conf;
 use crate::{
     alert,
-    db::create_index,
+    db::{create_index, CreateIndexError},
     types::ztf_alert_schema,
     worker_util::{self, WorkerCmd},
 };
@@ -14,7 +14,7 @@ pub enum AlertWorkerError {
     #[error("failed to load config")]
     LoadConfigError(#[from] conf::ConfigError),
     #[error("failed to create index")]
-    CreateIndexError(#[from] mongodb::error::Error),
+    CreateIndexError(#[from] CreateIndexError),
     #[error("failed to connect to redis")]
     ConnectRedisError(#[source] redis::RedisError),
     #[error("failed to get alert schema")]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
-use tracing::error;
+use tracing::instrument;
 
+#[instrument(skip(collection, index), err, fields(collection = collection.name()))]
 pub async fn create_index(
     collection: &mongodb::Collection<mongodb::bson::Document>,
     index: mongodb::bson::Document,
@@ -13,15 +14,6 @@ pub async fn create_index(
                 .build(),
         )
         .build();
-    match collection.create_index(index_model).await {
-        Err(e) => {
-            error!(
-                "Error when creating index for collection {}: {}",
-                collection.name(),
-                e
-            );
-        }
-        Ok(_x) => {}
-    }
+    collection.create_index(index_model).await?;
     Ok(())
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,11 +1,15 @@
 use tracing::instrument;
 
+#[derive(thiserror::Error, Debug)]
+#[error("failed to create index")]
+pub struct CreateIndexError(#[from] mongodb::error::Error);
+
 #[instrument(skip(collection, index), err, fields(collection = collection.name()))]
 pub async fn create_index(
     collection: &mongodb::Collection<mongodb::bson::Document>,
     index: mongodb::bson::Document,
     unique: bool,
-) -> mongodb::error::Result<()> {
+) -> Result<(), CreateIndexError> {
     let index_model = mongodb::IndexModel::builder()
         .keys(index)
         .options(


### PR DESCRIPTION
@Theodlz let me know whether this is helpful.

It looks like `db::create_index` might be a general-purpose thing, so this is the kind of function where it's good to wrap the 3rd party error (`mongodb::error::Error`) in our own type, so I made a simple tuple struct named `CreateIndexError`. In `alert_worker`, there are five different places where `create_index` is called, so I _could_ have added five new variants to the `AlertWorkerError` enum corresponding to those failure cases. However, I'm not sure we really care whether it's one index vs another that failed to be created, so I'm simply wrapping the `db::CreateIndexError` in `AlertWorkerError::CreateIndexError`. We can always change this in the future if we need more granularity.

You'll notice I got rid of the call to `error!` in `db.rs`. The error event is still logged, but it happens automatically via tracing's `instrument` proc macro. We don't have to do it this way, I'm fine logging events the way you had it, but the idea is that we just decorate functions and methods with `instrument` and that makes a lot of this logging stuff a little easier. It's also really useful for collecting context along the way, e.g., the collection name. This is what I had in mind for the rest of the codebase, so I thought I'd see what you think here.