### PR TITLE
Additional conversions (magap, jd, ...) to LSST schema

### DIFF
--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -54,10 +54,14 @@ pub enum AlertError {
     EmptyAlertError,
     #[error("failed to read avro")]
     AvroReadError(#[source] apache_avro::Error),
-    #[error("missing flux psf")]
+    #[error("missing psf flux")]
     MissingFluxPSF,
-    #[error("missing flux psf error")]
+    #[error("missing psf flux error")]
     MissingFluxPSFError,
+    #[error("missing ap flux")]
+    MissingFluxAperture,
+    #[error("missing ap flux error")]
+    MissingFluxApertureError,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -143,12 +143,6 @@ pub struct DiaSource {
     /// Forced PSF flux not enough non-rejected pixels in data to attempt the fit.
     #[serde(rename = "forced_PsfFlux_flag_noGoodPixels")]
     pub forced_psf_flux_flag_no_good_pixels: Option<bool>,
-    /// Calibrated flux for Point Source model centered on radec but measured on the difference of snaps comprising this visit.
-    #[serde(rename = "snapDiffFlux")]
-    pub snap_diff_flux: Option<f32>,
-    /// Estimated uncertainty of snapDiffFlux.
-    #[serde(rename = "snapDiffFluxErr")]
-    pub snap_diff_flux_err: Option<f32>,
     /// Estimated sky background at the position (centroid) of the object.
     #[serde(rename = "fpBkgd")]
     pub fp_bkgd: Option<f32>,
@@ -172,57 +166,6 @@ pub struct DiaSource {
     /// General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.
     #[serde(rename = "pixelFlags")]
     pub pixel_flags: Option<bool>,
-    /// Bad pixel in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_bad")]
-    pub pixel_flags_bad: Option<bool>,
-    /// Cosmic ray in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_cr")]
-    pub pixel_flags_cr: Option<bool>,
-    /// Cosmic ray in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_crCenter")]
-    pub pixel_flags_cr_center: Option<bool>,
-    /// Some of the source footprint is outside usable exposure region (masked EDGE or NO_DATA, or centroid off image).
-    #[serde(rename = "pixelFlags_edge")]
-    pub pixel_flags_edge: Option<bool>,
-    /// Interpolated pixel in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_interpolated")]
-    pub pixel_flags_interpolated: Option<bool>,
-    /// Interpolated pixel in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_interpolatedCenter")]
-    pub pixel_flags_interpolated_center: Option<bool>,
-    /// DiaSource center is off image.
-    #[serde(rename = "pixelFlags_offimage")]
-    pub pixel_flags_offimage: Option<bool>,
-    /// Saturated pixel in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_saturated")]
-    pub pixel_flags_saturated: Option<bool>,
-    /// Saturated pixel in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_saturatedCenter")]
-    pub pixel_flags_saturated_center: Option<bool>,
-    /// DiaSource's footprint includes suspect pixels.
-    #[serde(rename = "pixelFlags_suspect")]
-    pub pixel_flags_suspect: Option<bool>,
-    /// Suspect pixel in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_suspectCenter")]
-    pub pixel_flags_suspect_center: Option<bool>,
-    /// Streak in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_streak")]
-    pub pixel_flags_streak: Option<bool>,
-    /// Streak in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_streakCenter")]
-    pub pixel_flags_streak_center: Option<bool>,
-    /// Injection in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_injected")]
-    pub pixel_flags_injected: Option<bool>,
-    /// Injection in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_injectedCenter")]
-    pub pixel_flags_injected_center: Option<bool>,
-    /// Template injection in the DiaSource footprint.
-    #[serde(rename = "pixelFlags_injected_template")]
-    pub pixel_flags_injected_template: Option<bool>,
-    /// Template injection in the 3x3 region around the centroid.
-    #[serde(rename = "pixelFlags_injected_templateCenter")]
-    pub pixel_flags_injected_template_center: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
@@ -284,9 +227,9 @@ pub struct DiaObject {
     #[serde(rename = "decErr")]
     pub dec_err: Option<f32>,
     /// Time at which the object was at a position ra/dec, expressed as Modified Julian Date, International Atomic Time.
-    #[serde(rename = "radecMjdTai")]
+    #[serde(rename(deserialize = "radecMjdTai", serialize = "jd"))]
     #[serde(deserialize_with = "deserialize_mjd_option")]
-    pub radec_mjd_tai: Option<f64>,
+    pub jd: Option<f64>,
     /// Proper motion in right ascension.
     #[serde(rename = "pmRa")]
     pub pm_ra: Option<f32>,
@@ -436,6 +379,27 @@ pub struct DiaObject {
     /// Mean of the y band flux errors.
     #[serde(rename = "y_psfFluxErrMean")]
     pub y_psf_flux_err_mean: Option<f32>,
+
+    #[serde(rename = "nearbyObj1")]
+    pub nearby_obj1: Option<i64>,
+    #[serde(rename = "nearbyObj1Dist")]
+    pub nearby_obj1_dist: Option<f32>,
+    #[serde(rename = "nearbyObj1LnP")]
+    pub nearby_obj1_lnp: Option<f32>,
+
+    #[serde(rename = "nearbyObj2")]
+    pub nearby_obj2: Option<i64>,
+    #[serde(rename = "nearbyObj2Dist")]
+    pub nearby_obj2_dist: Option<f32>,
+    #[serde(rename = "nearbyObj2LnP")]
+    pub nearby_obj2_lnp: Option<f32>,
+
+    #[serde(rename = "nearbyObj3")]
+    pub nearby_obj3: Option<i64>,
+    #[serde(rename = "nearbyObj3Dist")]
+    pub nearby_obj3_dist: Option<f32>,
+    #[serde(rename = "nearbyObj3LnP")]
+    pub nearby_obj3_lnp: Option<f32>,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -38,8 +38,6 @@ pub struct PrvCandidate {
     pub nid: Option<i32>,
     pub rcid: Option<i32>,
     pub field: Option<i32>,
-    pub xpos: Option<f32>,
-    pub ypos: Option<f32>,
     pub ra: Option<f64>,
     pub dec: Option<f64>,
     pub magpsf: Option<f32>,

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -233,18 +233,8 @@ where
     D: Deserializer<'de>,
 {
     // if the value is null, "null", "", return None
-    let value: serde_json::Value = serde::Deserialize::deserialize(deserializer)?;
-    match value {
-        serde_json::Value::Null => Ok(None),
-        serde_json::Value::String(s) => {
-            if s.is_empty() || s.eq_ignore_ascii_case("null") {
-                Ok(None)
-            } else {
-                Ok(Some(s))
-            }
-        }
-        _ => Ok(None),
-    }
+    let value: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+    Ok(value.filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("null")))
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -25,16 +25,16 @@ pub struct Cutout {
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct PrvCandidate {
     pub jd: f64,
-    pub fid: i32,
+    #[serde(rename(deserialize = "fid", serialize = "band"))]
+    #[serde(deserialize_with = "deserialize_fid")]
+    pub band: String,
     pub pid: i64,
     pub diffmaglim: Option<f32>,
-    pub pdiffimfilename: Option<String>,
     pub programpi: Option<String>,
     pub programid: i32,
     pub candid: Option<i64>,
     #[serde(deserialize_with = "deserialize_isdiffpos_option")]
     pub isdiffpos: Option<bool>,
-    pub tblid: Option<i64>,
     pub nid: Option<i32>,
     pub rcid: Option<i32>,
     pub field: Option<i32>,
@@ -51,35 +51,25 @@ pub struct PrvCandidate {
     pub chinr: Option<f32>,
     pub sharpnr: Option<f32>,
     pub sky: Option<f32>,
-    pub magdiff: Option<f32>,
     pub fwhm: Option<f32>,
-    pub classtar: Option<f32>,
     pub mindtoedge: Option<f32>,
-    pub magfromlim: Option<f32>,
     pub seeratio: Option<f32>,
     pub aimage: Option<f32>,
     pub bimage: Option<f32>,
-    pub aimagerat: Option<f32>,
-    pub bimagerat: Option<f32>,
     pub elong: Option<f32>,
     pub nneg: Option<i32>,
     pub nbad: Option<i32>,
     pub rb: Option<f32>,
     pub ssdistnr: Option<f32>,
     pub ssmagnr: Option<f32>,
+    #[serde(deserialize_with = "deserialize_ssnamenr")]
     pub ssnamenr: Option<String>,
-    pub sumrat: Option<f32>,
-    pub magapbig: Option<f32>,
-    pub sigmagapbig: Option<f32>,
     pub ranr: Option<f64>,
     pub decnr: Option<f64>,
     pub scorr: Option<f64>,
     pub magzpsci: Option<f32>,
     pub magzpsciunc: Option<f32>,
     pub magzpscirms: Option<f32>,
-    pub clrcoeff: Option<f32>,
-    pub clrcounc: Option<f32>,
-    pub rbversion: String,
 }
 
 /// avro alert schema
@@ -120,21 +110,19 @@ pub struct FpHist {
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Candidate {
     pub jd: f64,
-    pub fid: i32,
+    #[serde(rename(deserialize = "fid", serialize = "band"))]
+    #[serde(deserialize_with = "deserialize_fid")]
+    pub band: String,
     pub pid: i64,
     pub diffmaglim: Option<f32>,
-    pub pdiffimfilename: Option<String>,
     pub programpi: Option<String>,
     pub programid: i32,
     pub candid: i64,
     #[serde(deserialize_with = "deserialize_isdiffpos")]
     pub isdiffpos: bool,
-    pub tblid: Option<i64>,
     pub nid: Option<i32>,
     pub rcid: Option<i32>,
     pub field: Option<i32>,
-    pub xpos: Option<f32>,
-    pub ypos: Option<f32>,
     pub ra: f64,
     pub dec: f64,
     pub magpsf: f32,
@@ -148,26 +136,19 @@ pub struct Candidate {
     pub chinr: Option<f32>,
     pub sharpnr: Option<f32>,
     pub sky: Option<f32>,
-    pub magdiff: Option<f32>,
     pub fwhm: Option<f32>,
-    pub classtar: Option<f32>,
     pub mindtoedge: Option<f32>,
-    pub magfromlim: Option<f32>,
     pub seeratio: Option<f32>,
     pub aimage: Option<f32>,
     pub bimage: Option<f32>,
-    pub aimagerat: Option<f32>,
-    pub bimagerat: Option<f32>,
     pub elong: Option<f32>,
     pub nneg: Option<i32>,
     pub nbad: Option<i32>,
     pub rb: Option<f32>,
     pub ssdistnr: Option<f32>,
     pub ssmagnr: Option<f32>,
+    #[serde(deserialize_with = "deserialize_ssnamenr")]
     pub ssnamenr: Option<String>,
-    pub sumrat: Option<f32>,
-    pub magapbig: Option<f32>,
-    pub sigmagapbig: Option<f32>,
     pub ranr: f64,
     pub decnr: f64,
     pub sgmag1: Option<f32>,
@@ -179,50 +160,28 @@ pub struct Candidate {
     pub ndethist: i32,
     pub ncovhist: i32,
     pub jdstarthist: Option<f64>,
-    pub jdendhist: Option<f64>,
     pub scorr: Option<f64>,
-    pub tooflag: Option<i32>,
-    pub objectidps1: Option<i64>,
-    pub objectidps2: Option<i64>,
     pub sgmag2: Option<f32>,
     pub srmag2: Option<f32>,
     pub simag2: Option<f32>,
     pub szmag2: Option<f32>,
     pub sgscore2: Option<f32>,
     pub distpsnr2: Option<f32>,
-    pub objectidps3: Option<i64>,
     pub sgmag3: Option<f32>,
     pub srmag3: Option<f32>,
     pub simag3: Option<f32>,
     pub szmag3: Option<f32>,
     pub sgscore3: Option<f32>,
     pub distpsnr3: Option<f32>,
-    pub nmtchps: i32,
-    pub rfid: i64,
-    pub jdstartref: f64,
-    pub jdendref: f64,
-    pub nframesref: i32,
-    pub rbversion: String,
     pub dsnrms: Option<f32>,
     pub ssnrms: Option<f32>,
     pub dsdiff: Option<f32>,
     pub magzpsci: Option<f32>,
     pub magzpsciunc: Option<f32>,
     pub magzpscirms: Option<f32>,
-    pub nmatches: i32,
-    pub clrcoeff: Option<f32>,
-    pub clrcounc: Option<f32>,
-    pub zpclrcov: Option<f32>,
     pub zpmed: Option<f32>,
-    pub clrmed: Option<f32>,
-    pub clrrms: Option<f32>,
-    pub neargaia: Option<f32>,
-    pub neargaiabright: Option<f32>,
-    pub maggaia: Option<f32>,
-    pub maggaiabright: Option<f32>,
     pub exptime: Option<f32>,
     pub drb: Option<f32>,
-    pub drbversion: String,
 }
 
 fn deserialize_isdiffpos_option<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
@@ -232,8 +191,11 @@ where
     let value: serde_json::Value = serde::Deserialize::deserialize(deserializer)?;
     match value {
         serde_json::Value::String(s) => {
-            // if s is in t, T, true, True
-            if s.eq_ignore_ascii_case("t") || s.eq_ignore_ascii_case("true") {
+            // if s is in t, T, true, True, "1"
+            if s.eq_ignore_ascii_case("t")
+                || s.eq_ignore_ascii_case("true")
+                || s.eq_ignore_ascii_case("1")
+            {
                 Ok(Some(true))
             } else {
                 Ok(Some(false))
@@ -250,6 +212,39 @@ where
     D: Deserializer<'de>,
 {
     deserialize_isdiffpos_option(deserializer).map(|x| x.unwrap())
+}
+
+fn deserialize_fid<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // the fid is a mapper: 1 = g, 2 = r, 3 = i
+    let fid: i32 = serde::Deserialize::deserialize(deserializer)?;
+    match fid {
+        1 => Ok("g".to_string()),
+        2 => Ok("r".to_string()),
+        3 => Ok("i".to_string()),
+        _ => Err(serde::de::Error::custom(format!("Unknown fid: {}", fid))),
+    }
+}
+
+fn deserialize_ssnamenr<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // if the value is null, "null", "", return None
+    let value: serde_json::Value = serde::Deserialize::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(s) => {
+            if s.is_empty() || s.eq_ignore_ascii_case("null") {
+                Ok(None)
+            } else {
+                Ok(Some(s))
+            }
+        }
+        _ => Ok(None),
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]

--- a/tests/test_lsst.rs
+++ b/tests/test_lsst.rs
@@ -24,7 +24,7 @@ async fn test_lsst_alert_from_avro_bytes() {
 
     // add mag data to the candidate
 
-    assert!((alert.candidate.dia_source.mjd - 57454.329282).abs() < 1e-6);
+    assert!((alert.candidate.dia_source.jd - 2457454.829282).abs() < 1e-6);
     assert!((alert.candidate.magpsf - 23.146893).abs() < 1e-6);
     assert!((alert.candidate.sigmapsf - 0.039097).abs() < 1e-6);
     assert!((alert.candidate.diffmaglim - 25.00841).abs() < 1e-5);
@@ -40,7 +40,7 @@ async fn test_lsst_alert_from_avro_bytes() {
     // validate the first prv_candidate
     let prv_candidate = prv_candidates.get(0).unwrap();
 
-    assert!((prv_candidate.dia_source.mjd - 57454.299200).abs() < 1e-6);
+    assert!((prv_candidate.dia_source.jd - 2457454.7992).abs() < 1e-6);
     assert!((prv_candidate.magpsf - 24.763279).abs() < 1e-6);
     assert!((prv_candidate.sigmapsf - 0.329765).abs() < 1e-6);
     assert!((prv_candidate.diffmaglim - 24.309652).abs() < 1e-6);
@@ -56,7 +56,7 @@ async fn test_lsst_alert_from_avro_bytes() {
     // validate the first fp_hist
     let fp_hist = fp_hists.get(0).unwrap();
 
-    assert!((fp_hist.dia_forced_source.mjd - 57454.299200).abs() < 1e-6);
+    assert!((fp_hist.dia_forced_source.jd - 2457454.7992).abs() < 1e-6);
     assert!((fp_hist.magpsf.unwrap() - 24.735056).abs() < 1e-6);
     assert!((fp_hist.sigmapsf.unwrap() - 0.329754).abs() < 1e-6);
     assert!((fp_hist.diffmaglim.unwrap() - 24.281467).abs() < 1e-6);


### PR DESCRIPTION
Here we:
- add the magnitude data for the aperture photometry
- convert all MJD fields from LSST to JD
- remove the provided SNR, replace it with the one we calculate from the reported flux and fluxerr (psf)
- remove some bad pixel flags that are redundant
- remove the "snaps" based photometry (whatever it might be lol)
- add the "3 closest objects" data to the `DiaObject` (will use it in the future).
- convert the ZTF `fid` (filter/band id) field to `band` as a string, similar to LSST
- ZTF's `ssnamenr`, avoid values such as "null" (as a str), making sure it is None/null when it should be.
- removed a number of ZTF alert fields (magdiff, classtar, magfromlim, aimagerat, bimagerat, sumrat, magapbig, sigmagapbig, jdendhist, tooflag, objectidps1, objectidps2, objectidps3, nmtchps, rfid, jdstartref, jdendref, nframesref, rbversion, nmatches, clrcoeff, clrcount, zpclrcount, clrmed, clrrms, neargaia, neargaiabright, maggaia, maggaiabright, drbversion) that are redundant, unused, or computed by us elsewhere.