### PR TITLE
Scheduler Error Handling + dedicated module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,5 @@ pub mod conf;
 pub mod filter;
 pub mod kafka;
 pub mod ml;
-pub mod scheduling;
+pub mod scheduler;
 pub mod utils;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,0 +1,3 @@
+mod base;
+
+pub use base::{get_num_workers, SchedulerError, ThreadPool};


### PR DESCRIPTION
At the moment some methods to spawn a scheduler are found directly in the `bin/scheduler.rs`, and most of the scheduling code is located in `utils/scheduling.rs`. Also, we have a number of unwraps in there which isn't ideal.

In this PR we create a dedicated `scheduler` module, move all functions but main found in the binary to this new module, add better error handling and a dedicated scheduler error type.

PS: Will point to main once other PRs that this one depends on have been reviewed, right now I'm forced to point to another branch to not show changes that are irrelevant to this PR