### PR TITLE
Testing utils - Alert Randomizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ data/alerts/ztf/20*.tar.gz
 __pycache__
 /env
 .DS_Store
+/experimental
 *~

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ dependencies = [
  "log",
  "num-bigint",
  "quad-rand",
- "rand",
+ "rand 0.8.5",
  "regex-lite",
  "serde",
  "serde_bytes",
@@ -299,6 +299,7 @@ dependencies = [
  "flate2",
  "futures",
  "mongodb",
+ "rand 0.9.0",
  "rdkafka",
  "redis",
  "reqwest",
@@ -326,7 +327,7 @@ dependencies = [
  "indexmap 2.7.1",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1150,7 +1151,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -1171,7 +1172,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -1808,7 +1809,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rustc_version_runtime",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -2163,7 +2164,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2218,8 +2219,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2229,7 +2241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2239,6 +2261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -3954,7 +3985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -3962,6 +4002,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.96"
 reqwest = { version = "0.12.12", features = ["json"] }
 async-trait = "0.1.87"
 serde_with = "3.12.0"
+rand = "0.9.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/alert/mod.rs
+++ b/src/alert/mod.rs
@@ -5,6 +5,7 @@ pub use base::run_alert_worker;
 pub use base::AlertError;
 pub use base::AlertWorker;
 pub use base::AlertWorkerError;
+pub use base::SchemaRegistry;
 pub use base::SchemaRegistryError;
-pub use lsst::LsstAlertWorker;
+pub use lsst::{LsstAlertWorker, LSST_SCHEMA_REGISTRY_URL};
 pub use ztf::ZtfAlertWorker;

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -156,6 +156,12 @@ pub trait AlertRandomizerTrait {
     fn candid(self, candid: i64) -> Self;
     fn ra(self, ra: f64) -> Self;
     fn dec(self, dec: f64) -> Self;
+    fn validate_ra(ra: f64) -> bool {
+        ra >= 0.0 && ra <= 360.0
+    }
+    fn validate_dec(dec: f64) -> bool {
+        dec >= -90.0 && dec <= 90.0
+    }
     fn get(self) -> (i64, Self::ObjectId, f64, f64, Vec<u8>);
     fn zigzag_encode_i64(n: i64) -> u64 {
         ((n << 1) ^ (n >> 63)) as u64
@@ -263,11 +269,17 @@ impl AlertRandomizerTrait for ZtfAlertRandomizer {
     }
 
     fn ra(mut self, ra: f64) -> Self {
-        self.ra = Some(ra);
+        match Self::validate_ra(ra) {
+            true => self.ra = Some(ra),
+            false => panic!("RA must be between 0 and 360"),
+        }
         self
     }
     fn dec(mut self, dec: f64) -> Self {
-        self.dec = Some(dec);
+        match Self::validate_dec(dec) {
+            true => self.dec = Some(dec),
+            false => panic!("Dec must be between -90 and 90"),
+        }
         self
     }
 
@@ -425,11 +437,17 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
     }
 
     fn ra(mut self, ra: f64) -> Self {
-        self.ra = Some(ra);
+        match Self::validate_ra(ra) {
+            true => self.ra = Some(ra),
+            false => panic!("RA must be between 0 and 360"),
+        }
         self
     }
     fn dec(mut self, dec: f64) -> Self {
-        self.dec = Some(dec);
+        match Self::validate_dec(dec) {
+            true => self.dec = Some(dec),
+            false => panic!("Dec must be between -90 and 90"),
+        }
         self
     }
 

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -195,6 +195,9 @@ pub trait AlertRandomizerTrait {
             .windows(bytes.len())
             .position(|window| window == bytes)
     }
+    fn randomize_i64() -> i64 {
+        rand::rng().random_range(i64::MIN..i64::MAX)
+    }
     fn randomize_ra() -> f64 {
         rand::rng().random_range(0.0..360.0)
     }
@@ -227,7 +230,7 @@ impl AlertRandomizerTrait for ZtfAlertRandomizer {
             original_ra: 295.3031995,
             original_dec: -10.3958989,
             payload,
-            candid: Some(Self::randomize_candid()),
+            candid: Some(Self::randomize_i64()),
             object_id: Some(Self::randomize_object_id()),
             ra: None,
             dec: None,
@@ -275,7 +278,7 @@ impl AlertRandomizerTrait for ZtfAlertRandomizer {
         let original_dec_bytes = Self::encode_f64(self.original_dec);
         let mut payload = self.payload;
 
-        let candid = self.candid.unwrap_or_else(Self::randomize_candid);
+        let candid = self.candid.unwrap_or_else(Self::randomize_i64);
         let object_id = self.object_id.unwrap_or_else(Self::randomize_object_id);
         let ra = self.ra.unwrap_or_else(Self::randomize_ra);
         let dec = self.dec.unwrap_or_else(Self::randomize_dec);
@@ -364,13 +367,6 @@ impl ZtfAlertRandomizer {
         }
         object_id
     }
-
-    fn randomize_candid() -> i64 {
-        // variable length encoding means that small numbers result in less bytes
-        // so, we picked that range to make sure it creates a 9 byte number
-        // just like the original candid
-        rand::rng().random_range(2000000000000000000..3000000000000000000)
-    }
 }
 
 pub struct LsstAlertRandomizer {
@@ -396,8 +392,8 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
             original_ra: 149.8021056712687,
             original_dec: 2.2486503003111813,
             payload,
-            candid: Some(Self::randomize_candid()),
-            object_id: Some(Self::randomize_object_id()),
+            candid: Some(Self::randomize_i64()),
+            object_id: Some(Self::randomize_i64()),
             ra: None,
             dec: None,
         }
@@ -444,8 +440,8 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
         let original_dec_bytes = Self::encode_f64(self.original_dec);
         let mut payload = self.payload;
 
-        let candid = self.candid.unwrap_or_else(Self::randomize_candid);
-        let object_id = self.object_id.unwrap_or_else(Self::randomize_object_id);
+        let candid = self.candid.unwrap_or_else(Self::randomize_i64);
+        let object_id = self.object_id.unwrap_or_else(Self::randomize_i64);
         let ra = self.ra.unwrap_or_else(Self::randomize_ra);
         let dec = self.dec.unwrap_or_else(Self::randomize_dec);
 
@@ -518,17 +514,5 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
         }
 
         (candid, object_id, ra, dec, payload)
-    }
-}
-
-impl LsstAlertRandomizer {
-    fn randomize_object_id() -> i64 {
-        // 8 bytes long
-        rand::rng().random_range(20000000000000000..30000000000000000)
-    }
-
-    fn randomize_candid() -> i64 {
-        // 8 bytes long
-        rand::rng().random_range(20000000000000000..30000000000000000)
     }
 }

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -238,14 +238,7 @@ impl AlertRandomizerTrait for ZtfAlertRandomizer {
     }
 
     fn candid(mut self, candid: i64) -> Self {
-        match candid {
-            id if id < 2000000000000000000 || id > 3000000000000000000 => {
-                panic!("Candid must be between 2000000000000000000 and 3000000000000000000");
-            }
-            _ => {
-                self.candid = Some(candid);
-            }
-        }
+        self.candid = Some(candid);
         self
     }
 
@@ -264,8 +257,9 @@ impl AlertRandomizerTrait for ZtfAlertRandomizer {
         let mut found = false;
         loop {
             if let Some(candid_idx) = Self::find_bytes(&payload, &original_candid_bytes) {
-                payload[candid_idx..candid_idx + original_candid_bytes.len()]
-                    .copy_from_slice(&candid_bytes);
+                let left = &payload[..candid_idx];
+                let right = &payload[candid_idx + original_candid_bytes.len()..];
+                payload = [left, &candid_bytes, right].concat();
                 found = true;
             } else {
                 break;
@@ -356,27 +350,12 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
     }
 
     fn objectid(mut self, object_id: impl Into<Self::ObjectId>) -> Self {
-        let object_id = object_id.into();
-        match object_id {
-            id if id < 20000000000000000 || id > 30000000000000000 => {
-                panic!("Object ID must be between 20000000000000000 and 30000000000000000");
-            }
-            _ => {
-                self.object_id = Some(object_id);
-            }
-        }
+        self.object_id = Some(object_id.into());
         self
     }
 
     fn candid(mut self, candid: i64) -> Self {
-        match candid {
-            id if id < 20000000000000000 || id > 30000000000000000 => {
-                panic!("Candid must be between 20000000000000000 and 30000000000000000");
-            }
-            _ => {
-                self.candid = Some(candid);
-            }
-        }
+        self.candid = Some(candid);
         self
     }
 
@@ -395,8 +374,9 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
         let mut found = false;
         loop {
             if let Some(candid_idx) = Self::find_bytes(&payload, &original_candid_bytes) {
-                payload[candid_idx..candid_idx + original_candid_bytes.len()]
-                    .copy_from_slice(&candid_bytes);
+                let left = &payload[..candid_idx];
+                let right = &payload[candid_idx + original_candid_bytes.len()..];
+                payload = [left, &candid_bytes, right].concat();
                 found = true;
             } else {
                 break;
@@ -410,8 +390,9 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
         let mut found = false;
         loop {
             if let Some(object_idx) = Self::find_bytes(&payload, &original_object_id_bytes) {
-                payload[object_idx..object_idx + original_object_id_bytes.len()]
-                    .copy_from_slice(&object_id_bytes);
+                let left = &payload[..object_idx];
+                let right = &payload[object_idx + original_object_id_bytes.len()..];
+                payload = [left, &object_id_bytes, right].concat();
                 found = true;
             } else {
                 break;

--- a/tests/test_lsst.rs
+++ b/tests/test_lsst.rs
@@ -11,7 +11,7 @@ const CONFIG_FILE: &str = "tests/config.test.yaml";
 async fn test_lsst_alert_from_avro_bytes() {
     let mut alert_worker = LsstAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let (candid, object_id, ra, dec, bytes_content) = LsstAlertRandomizer::default().get();
+    let (candid, object_id, ra, dec, bytes_content) = LsstAlertRandomizer::default().get().await;
     let alert = alert_worker
         .alert_from_avro_bytes(&bytes_content)
         .await
@@ -77,7 +77,7 @@ async fn test_lsst_alert_from_avro_bytes() {
 async fn test_process_lsst_alert() {
     let mut alert_worker = LsstAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let (candid, object_id, ra, dec, bytes_content) = LsstAlertRandomizer::default().get();
+    let (candid, object_id, ra, dec, bytes_content) = LsstAlertRandomizer::default().get().await;
     let result = alert_worker.process_alert(&bytes_content).await.unwrap();
     assert_eq!(result, candid);
 

--- a/tests/test_lsst.rs
+++ b/tests/test_lsst.rs
@@ -1,7 +1,7 @@
 use boom::{
     alert::{AlertWorker, LsstAlertWorker},
     conf,
-    utils::testing::drop_alert_from_collections,
+    utils::testing::{drop_alert_from_collections, AlertRandomizerTrait, LsstAlertRandomizer},
 };
 use mongodb::bson::doc;
 
@@ -11,18 +11,14 @@ const CONFIG_FILE: &str = "tests/config.test.yaml";
 async fn test_lsst_alert_from_avro_bytes() {
     let mut alert_worker = LsstAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let file_name = "tests/data/alerts/lsst/0.avro";
-    let bytes_content = std::fs::read(file_name).unwrap();
+    let (candid, object_id, bytes_content) = LsstAlertRandomizer::default().get();
     let alert = alert_worker
         .alert_from_avro_bytes(&bytes_content)
         .await
         .unwrap();
 
-    assert_eq!(alert.candid, 25409136044802067);
-    assert_eq!(
-        alert.candidate.dia_source.object_id.unwrap(),
-        25401295582003262
-    );
+    assert_eq!(alert.candid, candid);
+    assert_eq!(alert.candidate.dia_source.object_id.unwrap(), object_id);
 
     assert!((alert.candidate.dia_source.ra - 149.802106).abs() < 1e-6);
     assert!((alert.candidate.dia_source.dec - 2.248650).abs() < 1e-6);
@@ -79,17 +75,11 @@ async fn test_lsst_alert_from_avro_bytes() {
 
 #[tokio::test]
 async fn test_process_lsst_alert() {
-    // first we need to drop the alert from the database
-    drop_alert_from_collections(25409136044802067, "LSST")
-        .await
-        .unwrap();
-
     let mut alert_worker = LsstAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let file_name = "tests/data/alerts/lsst/0.avro";
-    let bytes_content = std::fs::read(file_name).unwrap();
+    let (candid, object_id, bytes_content) = LsstAlertRandomizer::default().get();
     let result = alert_worker.process_alert(&bytes_content).await.unwrap();
-    assert_eq!(result, 25409136044802067);
+    assert_eq!(result, candid);
 
     // now that it has been inserted in the database, calling process alert should return an error
     let result = alert_worker.process_alert(&bytes_content).await;
@@ -100,7 +90,7 @@ async fn test_process_lsst_alert() {
     let config_file = conf::load_config(CONFIG_FILE).unwrap();
     let db = conf::build_db(&config_file).await.unwrap();
     let alert_collection_name = "LSST_alerts";
-    let filter = doc! {"_id": 25409136044802067_i64};
+    let filter = doc! {"_id": candid};
 
     let alert = db
         .collection::<mongodb::bson::Document>(alert_collection_name)
@@ -109,8 +99,8 @@ async fn test_process_lsst_alert() {
         .unwrap();
     assert!(alert.is_some());
     let alert = alert.unwrap();
-    assert_eq!(alert.get_i64("_id").unwrap(), 25409136044802067);
-    assert_eq!(alert.get_i64("objectId").unwrap(), 25401295582003262);
+    assert_eq!(alert.get_i64("_id").unwrap(), candid);
+    assert_eq!(alert.get_i64("objectId").unwrap(), object_id);
 
     // check that the cutouts were inserted
     let cutout_collection_name = "LSST_alerts_cutouts";
@@ -121,14 +111,14 @@ async fn test_process_lsst_alert() {
         .unwrap();
     assert!(cutouts.is_some());
     let cutouts = cutouts.unwrap();
-    assert_eq!(cutouts.get_i64("_id").unwrap(), 25409136044802067);
+    assert_eq!(cutouts.get_i64("_id").unwrap(), candid);
     assert!(cutouts.contains_key("cutoutScience"));
     assert!(cutouts.contains_key("cutoutTemplate"));
     assert!(cutouts.contains_key("cutoutDifference"));
 
     // check that the aux collection was inserted
     let aux_collection_name = "LSST_alerts_aux";
-    let filter_aux = doc! {"_id": 25401295582003262_i64};
+    let filter_aux = doc! {"_id": object_id};
     let aux = db
         .collection::<mongodb::bson::Document>(aux_collection_name)
         .find_one(filter_aux.clone())
@@ -137,7 +127,7 @@ async fn test_process_lsst_alert() {
 
     assert!(aux.is_some());
     let aux = aux.unwrap();
-    assert_eq!(aux.get_i64("_id").unwrap(), 25401295582003262);
+    assert_eq!(aux.get_i64("_id").unwrap(), object_id);
     // check that we have the arrays prv_candidates, prv_nondetections and fp_hists
     let prv_candidates = aux.get_array("prv_candidates").unwrap();
     assert_eq!(prv_candidates.len(), 3);
@@ -147,4 +137,6 @@ async fn test_process_lsst_alert() {
 
     let fp_hists = aux.get_array("fp_hists").unwrap();
     assert_eq!(fp_hists.len(), 3);
+
+    drop_alert_from_collections(candid, "LSST").await.unwrap();
 }

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -1,7 +1,10 @@
 use boom::{
     alert::{AlertWorker, ZtfAlertWorker},
     conf,
-    utils::{db::mongify, testing::drop_alert_from_collections},
+    utils::{
+        db::mongify,
+        testing::{drop_alert_from_collections, AlertRandomizerTrait, ZtfAlertRandomizer},
+    },
 };
 use mongodb::bson::doc;
 
@@ -11,8 +14,7 @@ const CONFIG_FILE: &str = "tests/config.test.yaml";
 async fn test_alert_from_avro_bytes() {
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let file_name = "tests/data/alerts/ztf/2695378462115010012.avro";
-    let bytes_content = std::fs::read(file_name).unwrap();
+    let (candid, object_id, bytes_content) = ZtfAlertRandomizer::default().get();
     let alert = alert_worker.alert_from_avro_bytes(&bytes_content).await;
     assert!(alert.is_ok());
 
@@ -20,8 +22,8 @@ async fn test_alert_from_avro_bytes() {
     let mut alert = alert.unwrap();
     assert_eq!(alert.schemavsn, "4.02");
     assert_eq!(alert.publisher, "ZTF (www.ztf.caltech.edu)");
-    assert_eq!(alert.object_id, "ZTF18abudxnw");
-    assert_eq!(alert.candid, 2695378462115010012);
+    assert_eq!(alert.object_id, object_id);
+    assert_eq!(alert.candid, candid);
 
     // validate the candidate
     let candidate = alert.clone().candidate;
@@ -93,8 +95,8 @@ async fn test_alert_from_avro_bytes() {
         alert_doc.get_str("publisher").unwrap(),
         "ZTF (www.ztf.caltech.edu)"
     );
-    assert_eq!(alert_doc.get_str("objectId").unwrap(), "ZTF18abudxnw");
-    assert_eq!(alert_doc.get_i64("candid").unwrap(), 2695378462115010012);
+    assert_eq!(alert_doc.get_str("objectId").unwrap(), object_id);
+    assert_eq!(alert_doc.get_i64("candid").unwrap(), candid);
     assert_eq!(
         alert_doc
             .get_document("candidate")
@@ -149,17 +151,12 @@ async fn test_alert_from_avro_bytes() {
 
 #[tokio::test]
 async fn test_process_ztf_alert() {
-    // drop the alert from the database
-    drop_alert_from_collections(2695378462115010012, "ZTF")
-        .await
-        .unwrap();
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let file_name = "tests/data/alerts/ztf/2695378462115010012.avro";
-    let bytes_content = std::fs::read(file_name).unwrap();
+    let (candid, object_id, bytes_content) = ZtfAlertRandomizer::default().get();
     let result = alert_worker.process_alert(&bytes_content).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), 2695378462115010012);
+    assert_eq!(result.unwrap(), candid);
 
     // now that it has been inserted in the database, calling process alert should return an error
     let result = alert_worker.process_alert(&bytes_content).await;
@@ -170,7 +167,7 @@ async fn test_process_ztf_alert() {
     let config_file = conf::load_config(CONFIG_FILE).unwrap();
     let db = conf::build_db(&config_file).await.unwrap();
     let alert_collection_name = "ZTF_alerts";
-    let filter = doc! {"_id": 2695378462115010012_i64};
+    let filter = doc! {"_id": candid};
 
     let alert = db
         .collection::<mongodb::bson::Document>(alert_collection_name)
@@ -179,8 +176,8 @@ async fn test_process_ztf_alert() {
         .unwrap();
     assert!(alert.is_some());
     let alert = alert.unwrap();
-    assert_eq!(alert.get_i64("_id").unwrap(), 2695378462115010012);
-    assert_eq!(alert.get_str("objectId").unwrap(), "ZTF18abudxnw");
+    assert_eq!(alert.get_i64("_id").unwrap(), candid);
+    assert_eq!(alert.get_str("objectId").unwrap(), object_id);
 
     // check that the cutouts were inserted
     let cutout_collection_name = "ZTF_alerts_cutouts";
@@ -191,14 +188,14 @@ async fn test_process_ztf_alert() {
         .unwrap();
     assert!(cutouts.is_some());
     let cutouts = cutouts.unwrap();
-    assert_eq!(cutouts.get_i64("_id").unwrap(), 2695378462115010012);
+    assert_eq!(cutouts.get_i64("_id").unwrap(), candid);
     assert!(cutouts.contains_key("cutoutScience"));
     assert!(cutouts.contains_key("cutoutTemplate"));
     assert!(cutouts.contains_key("cutoutDifference"));
 
     // check that the aux collection was inserted
     let aux_collection_name = "ZTF_alerts_aux";
-    let filter_aux = doc! {"_id": "ZTF18abudxnw"};
+    let filter_aux = doc! {"_id": &object_id};
     let aux = db
         .collection::<mongodb::bson::Document>(aux_collection_name)
         .find_one(filter_aux.clone())
@@ -207,7 +204,7 @@ async fn test_process_ztf_alert() {
 
     assert!(aux.is_some());
     let aux = aux.unwrap();
-    assert_eq!(aux.get_str("_id").unwrap(), "ZTF18abudxnw");
+    assert_eq!(aux.get_str("_id").unwrap(), &object_id);
     // check that we have the arrays prv_candidates, prv_nondetections and fp_hists
     let prv_candidates = aux.get_array("prv_candidates").unwrap();
     assert_eq!(prv_candidates.len(), 8);
@@ -217,4 +214,6 @@ async fn test_process_ztf_alert() {
 
     let fp_hists = aux.get_array("fp_hists").unwrap();
     assert_eq!(fp_hists.len(), 10);
+
+    drop_alert_from_collections(candid, "ZTF").await.unwrap();
 }

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -14,7 +14,7 @@ const CONFIG_FILE: &str = "tests/config.test.yaml";
 async fn test_alert_from_avro_bytes() {
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let (candid, object_id, bytes_content) = ZtfAlertRandomizer::default().get();
+    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get();
     let alert = alert_worker.alert_from_avro_bytes(&bytes_content).await;
     assert!(alert.is_ok());
 
@@ -27,8 +27,8 @@ async fn test_alert_from_avro_bytes() {
 
     // validate the candidate
     let candidate = alert.clone().candidate;
-    assert_eq!(candidate.ra, 295.3031995);
-    assert_eq!(candidate.dec, -10.3958989);
+    assert_eq!(candidate.ra, ra);
+    assert_eq!(candidate.dec, dec);
 
     // validate the prv_candidates
     let prv_candidates = alert.clone().prv_candidates;
@@ -153,7 +153,7 @@ async fn test_alert_from_avro_bytes() {
 async fn test_process_ztf_alert() {
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let (candid, object_id, bytes_content) = ZtfAlertRandomizer::default().get();
+    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get();
     let result = alert_worker.process_alert(&bytes_content).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), candid);
@@ -178,6 +178,9 @@ async fn test_process_ztf_alert() {
     let alert = alert.unwrap();
     assert_eq!(alert.get_i64("_id").unwrap(), candid);
     assert_eq!(alert.get_str("objectId").unwrap(), object_id);
+    let candidate = alert.get_document("candidate").unwrap();
+    assert_eq!(candidate.get_f64("ra").unwrap(), ra);
+    assert_eq!(candidate.get_f64("dec").unwrap(), dec);
 
     // check that the cutouts were inserted
     let cutout_collection_name = "ZTF_alerts_cutouts";

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -14,7 +14,7 @@ const CONFIG_FILE: &str = "tests/config.test.yaml";
 async fn test_alert_from_avro_bytes() {
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get();
+    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get().await;
     let alert = alert_worker.alert_from_avro_bytes(&bytes_content).await;
     assert!(alert.is_ok());
 
@@ -153,7 +153,7 @@ async fn test_alert_from_avro_bytes() {
 async fn test_process_ztf_alert() {
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get();
+    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get().await;
     let result = alert_worker.process_alert(&bytes_content).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), candid);

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -103,7 +103,7 @@ async fn test_alert_from_avro_bytes() {
             .unwrap()
             .get_f64("ra")
             .unwrap(),
-        295.3031995
+        ra
     );
     assert_eq!(
         alert_doc
@@ -111,7 +111,7 @@ async fn test_alert_from_avro_bytes() {
             .unwrap()
             .get_f64("dec")
             .unwrap(),
-        -10.3958989
+        dec
     );
 
     // validate the conversion to bson for prv_candidates


### PR DESCRIPTION
This PR is a quick attempt at addressing #102. Here are some notes;
- avro uses variable length + zigzag encoding for its long data type (equivalent of i64 in rust). So unlike String values we can't just convert to bytes and look for those in the bytes of an avro file, we need to encode it first.
- for the same reason, when randomizing new candid values (and object id for lsst) the new values need to be in a similar range as the original values, as they would otherwise result in a different number of bytes and that creates an error when we try to replace existing bytes with the new ones.
- this could easily be solved by changing how we replace the existing bytes. Instead of just replacing them we could split the bytes input in 2 around the existing value, and append/prepend around the new one. However since in most cases I can think about we just want to randomize these and not set our own values, I don't think that would be a huge blocker. That said the ability to replace values with new ones will be essential if we want to edit things such as ra, dec, ... and other fields where there are reasons for us to create alerts with specific positions to test spatial queries.