### PR TITLE
Kafka "produce_from_archive": performance improvements

### DIFF
--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -189,6 +189,15 @@ pub async fn produce_from_archive(
     let producer: FutureProducer = ClientConfig::new()
         .set("bootstrap.servers", "localhost:9092")
         .set("message.timeout.ms", "5000")
+        // it's best to increase batch.size if the cluster
+        // is running on another machine. Locally, lower means less
+        // latency, since we are not limited by network speed anyways
+        .set("batch.size", "16384")
+        .set("linger.ms", "5")
+        .set("acks", "1")
+        .set("queue.buffering.max.kbytes", "67108864")
+        .set("max.in.flight.requests.per.connection", "5")
+        .set("retries", "3")
         .create()
         .expect("Producer creation error");
 

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -195,7 +195,6 @@ pub async fn produce_from_archive(
         .set("batch.size", "16384")
         .set("linger.ms", "5")
         .set("acks", "1")
-        .set("queue.buffering.max.kbytes", "67108864")
         .set("max.in.flight.requests.per.connection", "5")
         .set("retries", "3")
         .create()


### PR DESCRIPTION
In this PR, we tweak some of the parameters of the `librdkafka` producer to improve the performance when pushing messages to a topic. Before these changes producing speeds would be ~around 5.5s for 1000 messages, now we're around ~250ms for the same volume, which is ~20x faster. In another PR we should consider making similar config changes to the producer used to push alerts that pass filters to kafka (introduces in PR #97), but due to message size and volume it is only critical for the `produce_from_archive` method at the moment.

Solves part of issue #101 (persistence is missing still, should be added in another PR).

BTW kafka optimizing isn't an exact science, it requires one to do a number of trials to finetune numbers. I am sure that speed could be even better, but this is already so much faster than it used to be and more than enough for this purpose. I was inspired by a number of threads online (https://medium.com/@charchitpatidar/optimizing-kafka-producer-for-high-throughput-f8e808b06bcb, https://stackoverflow.com/questions/66045267/kafka-setting-high-linger-ms-and-batch-size-not-helping) and the official `librdkafka` documentation (https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md).