### PR TITLE
Kafka producer bugfix: avro files only

### DIFF
--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -205,8 +205,14 @@ pub async fn produce_from_archive(
     let mut total_pushed = 0;
     let start = std::time::Instant::now();
     for entry in std::fs::read_dir(format!("data/alerts/ztf/{}", date))? {
+        if entry.is_err() {
+            continue;
+        }
         let entry = entry.unwrap();
         let path = entry.path();
+        if !path.to_str().unwrap().ends_with(".avro") {
+            continue;
+        }
         let payload = std::fs::read(path).unwrap();
 
         let record = FutureRecord::to(&topic_name)


### PR DESCRIPTION
I noticed that if I had a non-avro file in the same dir as the alerts (say the original .tar.gz file from the ZTF archive), the producer tried to load it in memory which creates massive memory issues.

This PR simply makes sure that we skip non `.avro` files