### PR TITLE
ZTF processing: various bugfixes.

### DIFF
--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -25,6 +25,10 @@ pub enum SchemaRegistryError {
     CursorError(#[source] std::io::Error),
     #[error("could not find avro magic bytes")]
     MagicBytesError,
+    #[error("incorrect number of records in the avro file")]
+    InvalidRecordCount(usize),
+    #[error("integer overflow")]
+    IntegerOverflow,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -38,7 +42,7 @@ pub enum AlertError {
     #[error("failed to find objectid in the aux alert collection")]
     FindObjectIdError(#[source] mongodb::error::Error),
     #[error("failed to insert into the alert aux collection")]
-    InsertAuxAlertError(#[source] mongodb::error::Error),
+    InsertAlertAuxError(#[source] mongodb::error::Error),
     #[error("failed to update the alert aux collection")]
     UpdateAuxAlertError(#[source] mongodb::error::Error),
     #[error("failed to insert into the alert cutout collection")]
@@ -51,6 +55,8 @@ pub enum AlertError {
     SchemaRegistryError(#[from] SchemaRegistryError),
     #[error("alert already exists")]
     AlertExists,
+    #[error("alert aux already exists")]
+    AlertAuxExists,
     #[error("missing object_id")]
     MissingObjectId,
     #[error("missing cutout")]

--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -205,12 +205,31 @@ pub enum AlertWorkerError {
 
 #[async_trait::async_trait]
 pub trait AlertWorker {
+    type ObjectId;
     async fn new(config_path: &str) -> Result<Self, AlertWorkerError>
     where
         Self: Sized;
     fn stream_name(&self) -> String;
     fn input_queue_name(&self) -> String;
     fn output_queue_name(&self) -> String;
+    async fn insert_aux(
+        self: &mut Self,
+        object_id: impl Into<Self::ObjectId> + Send,
+        ra: f64,
+        dec: f64,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError>;
+    async fn update_aux(
+        self: &mut Self,
+        object_id: impl Into<Self::ObjectId> + Send,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError>;
     async fn process_alert(self: &mut Self, avro_bytes: &[u8]) -> Result<i64, AlertError>;
 }
 

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -817,7 +817,7 @@ impl AlertWorker for LsstAlertWorker {
             self.alert_aux_collection
                 .insert_one(alert_aux_doc)
                 .await
-                .map_err(AlertError::InsertAuxAlertError)?;
+                .map_err(AlertError::InsertAlertAuxError)?;
 
             trace!("Inserting alert_aux: {:?}", start.elapsed());
         } else {

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -877,7 +877,7 @@ impl AlertWorker for LsstAlertWorker {
         trace!("Formatting prv_candidates & fp_hist: {:?}", start.elapsed());
 
         if !alert_aux_exists {
-            match self
+            let result = self
                 .insert_aux(
                     object_id,
                     ra,
@@ -887,22 +887,18 @@ impl AlertWorker for LsstAlertWorker {
                     &fp_hist_doc,
                     now,
                 )
-                .await
-            {
-                Ok(_) => {}
-                Err(AlertError::AlertAuxExists) => {
-                    self.update_aux(
-                        object_id,
-                        &prv_candidates_doc,
-                        &prv_nondetections_doc,
-                        &fp_hist_doc,
-                        now,
-                    )
-                    .await?;
-                }
-                Err(e) => {
-                    return Err(e);
-                }
+                .await;
+            if let Err(AlertError::AlertAuxExists) = result {
+                self.update_aux(
+                    object_id,
+                    &prv_candidates_doc,
+                    &prv_nondetections_doc,
+                    &fp_hist_doc,
+                    now,
+                )
+                .await?;
+            } else {
+                result?;
             }
         } else {
             self.update_aux(

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -667,6 +667,8 @@ impl LsstAlertWorker {
 
 #[async_trait::async_trait]
 impl AlertWorker for LsstAlertWorker {
+    type ObjectId = i64;
+
     async fn new(config_path: &str) -> Result<LsstAlertWorker, AlertWorkerError> {
         let stream_name = "LSST".to_string();
 
@@ -702,6 +704,83 @@ impl AlertWorker for LsstAlertWorker {
 
     fn output_queue_name(&self) -> String {
         format!("{}_alerts_filter_queue", self.stream_name)
+    }
+
+    async fn insert_aux(
+        self: &mut Self,
+        object_id: impl Into<Self::ObjectId> + Send,
+        ra: f64,
+        dec: f64,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let start = std::time::Instant::now();
+        let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await;
+        trace!("Xmatch took: {:?}", start.elapsed());
+
+        let start = std::time::Instant::now();
+        let alert_aux_doc = doc! {
+            "_id": object_id.into(),
+            "prv_candidates": prv_candidates_doc,
+            "prv_nondetections": prv_nondetections_doc,
+            "fp_hists": fp_hist_doc,
+            "cross_matches": xmatches,
+            "created_at": now,
+            "updated_at": now,
+            "coordinates": {
+                "radec_geojson": {
+                    "type": "Point",
+                    "coordinates": [ra - 180.0, dec],
+                },
+            },
+        };
+
+        self.alert_aux_collection
+            .insert_one(alert_aux_doc)
+            .await
+            .map_err(|e| match *e.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
+                _ => AlertError::InsertAlertAuxError(e),
+            })?;
+
+        trace!("Inserting alert_aux: {:?}", start.elapsed());
+
+        Ok(())
+    }
+
+    async fn update_aux(
+        self: &mut Self,
+        object_id: impl Into<Self::ObjectId> + Send,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let start = std::time::Instant::now();
+
+        let update_doc = doc! {
+            "$addToSet": {
+                "prv_candidates": { "$each": prv_candidates_doc },
+                "prv_nondetections": { "$each": prv_nondetections_doc },
+                "fp_hists": { "$each": fp_hist_doc }
+            },
+            "$set": {
+                "updated_at": now,
+            }
+        };
+
+        self.alert_aux_collection
+            .update_one(doc! { "_id": object_id.into() }, update_doc)
+            .await
+            .map_err(AlertError::UpdateAuxAlertError)?;
+
+        trace!("Updating alert_aux: {:?}", start.elapsed());
+
+        Ok(())
     }
 
     async fn process_alert(self: &mut Self, avro_bytes: &[u8]) -> Result<i64, AlertError> {
@@ -798,47 +877,42 @@ impl AlertWorker for LsstAlertWorker {
         trace!("Formatting prv_candidates & fp_hist: {:?}", start.elapsed());
 
         if !alert_aux_exists {
-            let start = std::time::Instant::now();
-            let alert_aux_doc = doc! {
-                "_id": &object_id,
-                "prv_candidates": prv_candidates_doc,
-                "prv_nondetections": prv_nondetections_doc,
-                "fp_hists": fp_hist_doc,
-                "cross_matches": xmatch(ra, dec, &self.xmatch_configs, &self.db).await,
-                "created_at": now,
-                "updated_at": now,
-                "coordinates": {
-                    "radec_geojson": {
-                        "type": "Point",
-                        "coordinates": [ra - 180.0, dec],
-                    },
-                },
-            };
-            self.alert_aux_collection
-                .insert_one(alert_aux_doc)
+            match self
+                .insert_aux(
+                    object_id,
+                    ra,
+                    dec,
+                    &prv_candidates_doc,
+                    &prv_nondetections_doc,
+                    &fp_hist_doc,
+                    now,
+                )
                 .await
-                .map_err(AlertError::InsertAlertAuxError)?;
-
-            trace!("Inserting alert_aux: {:?}", start.elapsed());
-        } else {
-            let start = std::time::Instant::now();
-            let update_doc = doc! {
-                "$addToSet": {
-                    "prv_candidates": { "$each": prv_candidates_doc },
-                    "prv_nondetections": { "$each": prv_nondetections_doc },
-                    "fp_hists": { "$each": fp_hist_doc }
-                },
-                "$set": {
-                    "updated_at": now,
+            {
+                Ok(_) => {}
+                Err(AlertError::AlertAuxExists) => {
+                    self.update_aux(
+                        object_id,
+                        &prv_candidates_doc,
+                        &prv_nondetections_doc,
+                        &fp_hist_doc,
+                        now,
+                    )
+                    .await?;
                 }
-            };
-
-            self.alert_aux_collection
-                .update_one(doc! { "_id": &object_id }, update_doc)
-                .await
-                .map_err(AlertError::UpdateAuxAlertError)?;
-
-            trace!("Updating alert_aux: {:?}", start.elapsed());
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        } else {
+            self.update_aux(
+                object_id,
+                &prv_candidates_doc,
+                &prv_nondetections_doc,
+                &fp_hist_doc,
+                now,
+            )
+            .await?;
         }
 
         Ok(candid)

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -16,6 +16,43 @@ use serde_with::{serde_as, skip_serializing_none};
 use std::io::Read;
 use tracing::{error, trace};
 
+fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, SchemaRegistryError> {
+    let mut i = 0u64;
+    let mut buf = [0u8; 1];
+
+    let mut j = 0;
+    loop {
+        if j > 9 {
+            return Err(SchemaRegistryError::IntegerOverflow);
+        }
+        reader
+            .read_exact(&mut buf[..])
+            .map_err(SchemaRegistryError::CursorError)?;
+
+        i |= (u64::from(buf[0] & 0x7F)) << (j * 7);
+        if (buf[0] >> 7) == 0 {
+            break;
+        } else {
+            j += 1;
+        }
+    }
+
+    Ok(i)
+}
+
+pub fn zag_i64<R: Read>(reader: &mut R) -> Result<i64, SchemaRegistryError> {
+    let z = decode_variable(reader)?;
+    if z & 0x1 == 0 {
+        Ok((z >> 1) as i64)
+    } else {
+        Ok(!(z >> 1) as i64)
+    }
+}
+
+fn decode_long<R: Read>(reader: &mut R) -> Result<i64, SchemaRegistryError> {
+    Ok(zag_i64(reader)?)
+}
+
 pub fn get_schema_and_startidx(avro_bytes: &[u8]) -> Result<(Schema, usize), SchemaRegistryError> {
     // First, we extract the schema from the avro bytes
     let cursor = std::io::Cursor::new(avro_bytes);
@@ -46,12 +83,14 @@ pub fn get_schema_and_startidx(avro_bytes: &[u8]) -> Result<(Schema, usize), Sch
         .read_exact(&mut buf)
         .map_err(SchemaRegistryError::CursorError)?;
 
-    // each avro record is preceded by a 4-byte length field. We know alert packets
-    // contain only one record so we can read the first 4 bytes, and consider
-    // everything else after that as the data
-    cursor
-        .read_exact(&mut [0u8; 4])
-        .map_err(SchemaRegistryError::CursorError)?;
+    // each avro record is preceded by:
+    // 1. a variable-length integer, the number of records in the block
+    // 2. a variable-length integer, the number of bytes in the block
+    let nb_records = decode_long(&mut cursor)?;
+    if nb_records != 1 {
+        return Err(SchemaRegistryError::InvalidRecordCount(nb_records as usize));
+    }
+    let _ = decode_long(&mut cursor)?;
 
     // we now have the start index of the data
     let start_idx = cursor.position();
@@ -458,6 +497,83 @@ impl ZtfAlertWorker {
 
         Ok(alert)
     }
+
+    async fn insert_aux(
+        self: &mut Self,
+        object_id: &str,
+        ra: f64,
+        dec: f64,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let start = std::time::Instant::now();
+        let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await;
+        trace!("Xmatch took: {:?}", start.elapsed());
+
+        let start = std::time::Instant::now();
+        let alert_aux_doc = doc! {
+            "_id": &object_id,
+            "prv_candidates": prv_candidates_doc,
+            "prv_nondetections": prv_nondetections_doc,
+            "fp_hists": fp_hist_doc,
+            "cross_matches": xmatches,
+            "created_at": now,
+            "updated_at": now,
+            "coordinates": {
+                "radec_geojson": {
+                    "type": "Point",
+                    "coordinates": [ra - 180.0, dec],
+                },
+            },
+        };
+
+        self.alert_aux_collection
+            .insert_one(alert_aux_doc)
+            .await
+            .map_err(|e| match *e.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
+                _ => AlertError::InsertAlertAuxError(e),
+            })?;
+
+        trace!("Inserting alert_aux: {:?}", start.elapsed());
+
+        Ok(())
+    }
+
+    async fn update_aux(
+        self: &mut Self,
+        object_id: &str,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let start = std::time::Instant::now();
+
+        let update_doc = doc! {
+            "$addToSet": {
+                "prv_candidates": { "$each": prv_candidates_doc },
+                "prv_nondetections": { "$each": prv_nondetections_doc },
+                "fp_hists": { "$each": fp_hist_doc }
+            },
+            "$set": {
+                "updated_at": now,
+            }
+        };
+
+        self.alert_aux_collection
+            .update_one(doc! { "_id": object_id }, update_doc)
+            .await
+            .map_err(AlertError::UpdateAuxAlertError)?;
+
+        trace!("Updating alert_aux: {:?}", start.elapsed());
+
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -593,51 +709,42 @@ impl AlertWorker for ZtfAlertWorker {
         trace!("Formatting prv_candidates & fp_hist: {:?}", start.elapsed());
 
         if !alert_aux_exists {
-            let start = std::time::Instant::now();
-            let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await;
-            trace!("Xmatch took: {:?}", start.elapsed());
-
-            let start = std::time::Instant::now();
-            let alert_aux_doc = doc! {
-                "_id": &object_id,
-                "prv_candidates": prv_candidates_doc,
-                "prv_nondetections": prv_nondetections_doc,
-                "fp_hists": fp_hist_doc,
-                "cross_matches": xmatches,
-                "created_at": now,
-                "updated_at": now,
-                "coordinates": {
-                    "radec_geojson": {
-                        "type": "Point",
-                        "coordinates": [ra - 180.0, dec],
-                    },
-                },
-            };
-            self.alert_aux_collection
-                .insert_one(alert_aux_doc)
+            match self
+                .insert_aux(
+                    &object_id,
+                    ra,
+                    dec,
+                    &prv_candidates_doc,
+                    &prv_nondetections_doc,
+                    &fp_hist_doc,
+                    now,
+                )
                 .await
-                .map_err(AlertError::InsertAuxAlertError)?;
-
-            trace!("Inserting alert_aux: {:?}", start.elapsed());
-        } else {
-            let start = std::time::Instant::now();
-            let update_doc = doc! {
-                "$addToSet": {
-                    "prv_candidates": { "$each": prv_candidates_doc },
-                    "prv_nondetections": { "$each": prv_nondetections_doc },
-                    "fp_hists": { "$each": fp_hist_doc }
-                },
-                "$set": {
-                    "updated_at": now,
+            {
+                Ok(_) => {}
+                Err(AlertError::AlertAuxExists) => {
+                    self.update_aux(
+                        &object_id,
+                        &prv_candidates_doc,
+                        &prv_nondetections_doc,
+                        &fp_hist_doc,
+                        now,
+                    )
+                    .await?;
                 }
-            };
-
-            self.alert_aux_collection
-                .update_one(doc! { "_id": &object_id }, update_doc)
-                .await
-                .map_err(AlertError::UpdateAuxAlertError)?;
-
-            trace!("Updating alert_aux: {:?}", start.elapsed());
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        } else {
+            self.update_aux(
+                &object_id,
+                &prv_candidates_doc,
+                &prv_nondetections_doc,
+                &fp_hist_doc,
+                now,
+            )
+            .await?;
         }
 
         Ok(candid)

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -497,87 +497,12 @@ impl ZtfAlertWorker {
 
         Ok(alert)
     }
-
-    async fn insert_aux(
-        self: &mut Self,
-        object_id: &str,
-        ra: f64,
-        dec: f64,
-        prv_candidates_doc: &Vec<mongodb::bson::Document>,
-        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
-        fp_hist_doc: &Vec<mongodb::bson::Document>,
-        now: f64,
-    ) -> Result<(), AlertError> {
-        let start = std::time::Instant::now();
-        let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await;
-        trace!("Xmatch took: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-        let alert_aux_doc = doc! {
-            "_id": &object_id,
-            "prv_candidates": prv_candidates_doc,
-            "prv_nondetections": prv_nondetections_doc,
-            "fp_hists": fp_hist_doc,
-            "cross_matches": xmatches,
-            "created_at": now,
-            "updated_at": now,
-            "coordinates": {
-                "radec_geojson": {
-                    "type": "Point",
-                    "coordinates": [ra - 180.0, dec],
-                },
-            },
-        };
-
-        self.alert_aux_collection
-            .insert_one(alert_aux_doc)
-            .await
-            .map_err(|e| match *e.kind {
-                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
-                    write_error,
-                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
-                _ => AlertError::InsertAlertAuxError(e),
-            })?;
-
-        trace!("Inserting alert_aux: {:?}", start.elapsed());
-
-        Ok(())
-    }
-
-    async fn update_aux(
-        self: &mut Self,
-        object_id: &str,
-        prv_candidates_doc: &Vec<mongodb::bson::Document>,
-        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
-        fp_hist_doc: &Vec<mongodb::bson::Document>,
-        now: f64,
-    ) -> Result<(), AlertError> {
-        let start = std::time::Instant::now();
-
-        let update_doc = doc! {
-            "$addToSet": {
-                "prv_candidates": { "$each": prv_candidates_doc },
-                "prv_nondetections": { "$each": prv_nondetections_doc },
-                "fp_hists": { "$each": fp_hist_doc }
-            },
-            "$set": {
-                "updated_at": now,
-            }
-        };
-
-        self.alert_aux_collection
-            .update_one(doc! { "_id": object_id }, update_doc)
-            .await
-            .map_err(AlertError::UpdateAuxAlertError)?;
-
-        trace!("Updating alert_aux: {:?}", start.elapsed());
-
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]
 impl AlertWorker for ZtfAlertWorker {
+    type ObjectId = String;
+
     async fn new(config_path: &str) -> Result<ZtfAlertWorker, AlertWorkerError> {
         let stream_name = "ZTF".to_string();
 
@@ -614,6 +539,83 @@ impl AlertWorker for ZtfAlertWorker {
 
     fn output_queue_name(&self) -> String {
         format!("{}_alerts_classifier_queue", self.stream_name)
+    }
+
+    async fn insert_aux(
+        self: &mut Self,
+        object_id: impl Into<Self::ObjectId> + Send,
+        ra: f64,
+        dec: f64,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let start = std::time::Instant::now();
+        let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await;
+        trace!("Xmatch took: {:?}", start.elapsed());
+
+        let start = std::time::Instant::now();
+        let alert_aux_doc = doc! {
+            "_id": object_id.into(),
+            "prv_candidates": prv_candidates_doc,
+            "prv_nondetections": prv_nondetections_doc,
+            "fp_hists": fp_hist_doc,
+            "cross_matches": xmatches,
+            "created_at": now,
+            "updated_at": now,
+            "coordinates": {
+                "radec_geojson": {
+                    "type": "Point",
+                    "coordinates": [ra - 180.0, dec],
+                },
+            },
+        };
+
+        self.alert_aux_collection
+            .insert_one(alert_aux_doc)
+            .await
+            .map_err(|e| match *e.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
+                _ => AlertError::InsertAlertAuxError(e),
+            })?;
+
+        trace!("Inserting alert_aux: {:?}", start.elapsed());
+
+        Ok(())
+    }
+
+    async fn update_aux(
+        self: &mut Self,
+        object_id: impl Into<Self::ObjectId> + Send,
+        prv_candidates_doc: &Vec<mongodb::bson::Document>,
+        prv_nondetections_doc: &Vec<mongodb::bson::Document>,
+        fp_hist_doc: &Vec<mongodb::bson::Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let start = std::time::Instant::now();
+
+        let update_doc = doc! {
+            "$addToSet": {
+                "prv_candidates": { "$each": prv_candidates_doc },
+                "prv_nondetections": { "$each": prv_nondetections_doc },
+                "fp_hists": { "$each": fp_hist_doc }
+            },
+            "$set": {
+                "updated_at": now,
+            }
+        };
+
+        self.alert_aux_collection
+            .update_one(doc! { "_id": object_id.into() }, update_doc)
+            .await
+            .map_err(AlertError::UpdateAuxAlertError)?;
+
+        trace!("Updating alert_aux: {:?}", start.elapsed());
+
+        Ok(())
     }
 
     async fn process_alert(self: &mut Self, avro_bytes: &[u8]) -> Result<i64, AlertError> {


### PR DESCRIPTION
This PR addresses issues #112  and #114.

For #112, the solution was that while some old avro spec stack overflow I read claimed that the block size detail was contained in a fixed 4 bytes, it was actually made of 2 variable length zigzag encoded long values (so avro's way of storing a simple i64 value, where it only uses the number of bytes required to encode the value => small value = less bytes):
- the first tells us how many records are in the next data block, which we can also double check is equal to 1 for our purpose.
- the second tells us the total length in bytes of the records in that block, useless for us.
So to fix that issue we replace the 4 bytes read by a proper decoding of these variable length values. We could quite frankly just read the 1 byte for the number of records but the performance impact is so minimal that I'd rather play it safe and read that data properly and not take shortcuts. Might revisit that bit later.

For #114 it is well described in the issue, but we can run in concurrency issues if 2 workers try to insert an entry in the aux table for the same object id. In which case we just need to handle mongo's duplication error and defer to an update. In that one I refactored the insert/update of the aux table into their own methods. That's just to keep the main logic clean, and when I add the same insert => update failsafe for LSST (in a future PR) I'll do the same and turn that into methods required by the AlertWorker trait.

PS: One alert that failed parsing was just genuinely problematic (as in the avro isn't quite correct). I tried to open it with an online avro reader (the excellent https://konbert.com/viewer/avro for those who want to check, it's a great website to check tabular data without writing any code) and it failed as well. At a later date I'll give a go at reading it with `fastavro` in Python, to see if somehow that library is able to read it.