### PR TITLE
Alert stream crossmatching: bugfixes, cleanup, and unit test improvement

### DIFF
--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -75,6 +75,7 @@ pub enum AlertError {
     BsonValueAccess(#[from] mongodb::bson::document::ValueAccessError),
 }
 
+#[derive(Clone, Debug)]
 pub struct SchemaRegistry {
     client: reqwest::Client,
     cache: HashMap<String, Schema>,

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -10,9 +10,8 @@ use crate::{
     alert::base::{AlertError, AlertWorker, AlertWorkerError, SchemaRegistry},
     conf,
     utils::{
-        self,
         conversions::{flux2mag, fluxerr2diffmaglim, SNT, ZP_AB},
-        db::{cutout2bsonbinary, get_coordinates, mongify},
+        db::{create_index, cutout2bsonbinary, get_coordinates, mongify},
         spatial::xmatch,
     },
 };
@@ -684,10 +683,10 @@ impl AlertWorker for LsstAlertWorker {
         let alert_aux_collection = db.collection(&ALERT_AUX_COLLECTION);
         let alert_cutout_collection = db.collection(&ALERT_CUTOUT_COLLECTION);
 
-        utils::db::create_index(
+        create_index(
             &alert_aux_collection,
             doc! {"coordinates.radec_geojson": "2dsphere"},
-            true,
+            false,
         )
         .await?;
 

--- a/src/alert/mod.rs
+++ b/src/alert/mod.rs
@@ -8,4 +8,4 @@ pub use base::AlertWorkerError;
 pub use base::SchemaRegistry;
 pub use base::SchemaRegistryError;
 pub use lsst::{LsstAlertWorker, LSST_SCHEMA_REGISTRY_URL};
-pub use ztf::ZtfAlertWorker;
+pub use ztf::{ZtfAlertWorker, LSST_XMATCH_RADIUS};

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -477,7 +477,7 @@ impl ZtfAlertWorker {
             return Ok(vec![]);
         }
 
-        let lsst_matches: Vec<i64> = if dec <= LSST_DEC_LIMIT as f64 {
+        let lsst_matches = if dec <= LSST_DEC_LIMIT as f64 {
             let result = self
                 .lsst_alert_aux_collection
                 .find_one(doc! {

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -6,7 +6,7 @@ use crate::{
     conf,
     utils::{
         conversions::{flux2mag, fluxerr2diffmaglim, SNT},
-        db::{cutout2bsonbinary, get_coordinates, mongify},
+        db::{create_index, cutout2bsonbinary, get_coordinates, mongify},
         spatial::xmatch,
     },
 };
@@ -14,7 +14,7 @@ use apache_avro::from_value;
 use apache_avro::{from_avro_datum, Reader, Schema};
 use constcat::concat;
 use flare::Time;
-use mongodb::bson::doc;
+use mongodb::bson::{doc, Document};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 use std::io::Read;
@@ -24,7 +24,9 @@ pub const STREAM_NAME: &str = "ZTF";
 pub const ALERT_COLLECTION: &str = concat!(STREAM_NAME, "_alerts");
 pub const ALERT_AUX_COLLECTION: &str = concat!(STREAM_NAME, "_alerts_aux");
 pub const ALERT_CUTOUT_COLLECTION: &str = concat!(STREAM_NAME, "_alerts_cutouts");
-const LSST_DEC_LIMIT: f32 = 33.5;
+
+const LSST_DEC_LIMIT: f64 = 33.5;
+pub const LSST_XMATCH_RADIUS: f64 = (2.0_f64 / 3600.0_f64).to_radians(); // 2 arcseconds in radians
 
 pub fn get_schema_and_startidx(avro_bytes: &[u8]) -> Result<(Schema, usize), SchemaRegistryError> {
     // First, we extract the schema from the avro bytes
@@ -420,6 +422,7 @@ pub struct ZtfAlertWorker {
     alert_cutout_collection: mongodb::Collection<mongodb::bson::Document>,
     cached_schema: Option<Schema>,
     cached_start_idx: Option<usize>,
+    lsst_alert_aux_collection: mongodb::Collection<mongodb::bson::Document>,
 }
 
 impl ZtfAlertWorker {
@@ -468,6 +471,50 @@ impl ZtfAlertWorker {
 
         Ok(alert)
     }
+
+    async fn get_lsst_matches(&self, ra: f64, dec: f64) -> Result<Vec<i64>, AlertError> {
+        if dec > LSST_DEC_LIMIT {
+            return Ok(vec![]);
+        }
+
+        let lsst_matches: Vec<i64> = if dec <= LSST_DEC_LIMIT as f64 {
+            let result = self
+                .lsst_alert_aux_collection
+                .find_one(doc! {
+                    "coordinates.radec_geojson": {
+                        "$nearSphere": [ra - 180.0, dec],
+                        "$maxDistance": LSST_XMATCH_RADIUS,
+                    },
+                })
+                .projection(doc! {
+                    "_id": 1
+                })
+                .await;
+            match result {
+                Ok(Some(doc)) => {
+                    let object_id = doc.get_i64("_id")?;
+                    vec![object_id]
+                }
+                Ok(None) => vec![],
+                Err(e) => {
+                    error!("Error cross-matching with LSST: {}", e);
+                    vec![]
+                }
+            }
+        } else {
+            vec![]
+        };
+
+        Ok(lsst_matches)
+    }
+
+    async fn get_survey_matches(&self, ra: f64, dec: f64) -> Result<Document, AlertError> {
+        let lsst_matches = self.get_lsst_matches(ra, dec).await?;
+
+        Ok(doc! {
+            "LSST": lsst_matches,
+        })
+    }
 }
 
 #[async_trait::async_trait]
@@ -483,6 +530,16 @@ impl AlertWorker for ZtfAlertWorker {
         let alert_aux_collection = db.collection(&ALERT_AUX_COLLECTION);
         let alert_cutout_collection = db.collection(&ALERT_CUTOUT_COLLECTION);
 
+        create_index(
+            &alert_aux_collection,
+            doc! {"coordinates.radec_geojson": "2dsphere"},
+            false,
+        )
+        .await?;
+
+        let lsst_alert_aux_collection: mongodb::Collection<mongodb::bson::Document> =
+            db.collection(&lsst::ALERT_AUX_COLLECTION);
+
         let worker = ZtfAlertWorker {
             stream_name: STREAM_NAME.to_string(),
             xmatch_configs,
@@ -492,6 +549,7 @@ impl AlertWorker for ZtfAlertWorker {
             alert_cutout_collection,
             cached_schema: None,
             cached_start_idx: None,
+            lsst_alert_aux_collection,
         };
         Ok(worker)
     }
@@ -600,25 +658,14 @@ impl AlertWorker for ZtfAlertWorker {
 
         trace!("Formatting prv_candidates & fp_hist: {:?}", start.elapsed());
 
-        let lsst_alert_aux_collection: mongodb::Collection<mongodb::bson::Document> =
-            self.db.collection(&lsst::ALERT_AUX_COLLECTION);
-        let closest_match: Option<String> = if dec <= LSST_DEC_LIMIT as f64 {
-            lsst_alert_aux_collection
-                .find_one(doc! {
-                    "coordinates.radec_geojson": {
-                        "$nearSphere": [ra - 180.0, dec],
-                        "$maxDistance": self.xmatch_configs[0].radius,
-                    },
-                })
-                .projection(doc! {
-                    "_id": 1
-                })
-                .await?
-                .map(|doc| doc.get_i64("_id").map(|id| id.to_string()))
-                .transpose()?
-        } else {
-            None
-        };
+        let start = std::time::Instant::now();
+
+        let survey_matches = self.get_survey_matches(ra, dec).await?;
+
+        trace!(
+            "Xmatching ZTF alert with other surveys: {:?}",
+            start.elapsed()
+        );
 
         if !alert_aux_exists {
             let start = std::time::Instant::now();
@@ -632,7 +679,7 @@ impl AlertWorker for ZtfAlertWorker {
                 "prv_nondetections": prv_nondetections_doc,
                 "fp_hists": fp_hist_doc,
                 "cross_matches": xmatches,
-                "aliases": { "LSST": closest_match.into_iter().collect::<Vec<_>>() },
+                "aliases": survey_matches,
                 "created_at": now,
                 "updated_at": now,
                 "coordinates": {
@@ -658,7 +705,7 @@ impl AlertWorker for ZtfAlertWorker {
                 },
                 "$set": {
                     "updated_at": now,
-                    "aliases.LSST": closest_match.into_iter().collect::<Vec<_>>(),
+                    "aliases": survey_matches,
                 }
             };
 

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -295,8 +295,8 @@ impl AlertRandomizerTrait for ZtfAlertRandomizer {
             schema: Some(schema),
             candid: Some(Self::randomize_i64()),
             object_id: Some(Self::randomize_object_id()),
-            ra: None,
-            dec: None,
+            ra: Some(Self::randomize_ra()),
+            dec: Some(Self::randomize_dec()),
         }
     }
 
@@ -481,8 +481,8 @@ impl AlertRandomizerTrait for LsstAlertRandomizer {
             schema_registry: SchemaRegistry::new(LSST_SCHEMA_REGISTRY_URL),
             candid: Some(Self::randomize_i64()),
             object_id: Some(Self::randomize_i64()),
-            ra: None,
-            dec: None,
+            ra: Some(Self::randomize_ra()),
+            dec: Some(Self::randomize_dec()),
         }
     }
 

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -273,6 +273,7 @@ pub trait AlertRandomizerTrait {
     type ObjectId;
 }
 
+#[derive(Clone, Debug)]
 pub struct ZtfAlertRandomizer {
     payload: Option<Vec<u8>>,
     schema: Option<Schema>,
@@ -461,6 +462,7 @@ impl ZtfAlertRandomizer {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct LsstAlertRandomizer {
     payload: Option<Vec<u8>>,
     schema_registry: SchemaRegistry,

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -1,5 +1,5 @@
 use boom::{
-    alert::{AlertWorker, LsstAlertWorker, ZtfAlertWorker},
+    alert::{AlertWorker, LsstAlertWorker, ZtfAlertWorker, LSST_XMATCH_RADIUS},
     conf,
     filter::{FilterWorker, ZtfFilterWorker},
     ml::{MLWorker, ZtfMLWorker},
@@ -233,15 +233,25 @@ async fn test_process_ztf_lsst_xmatch() {
 
     // ZTF setup
     let mut alert_worker = ZtfAlertWorker::new(CONFIG_FILE).await.unwrap();
-    let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get().await;
+    let (_, object_id, ra, dec, bytes_content) =
+        ZtfAlertRandomizer::default().dec(10.0).get().await;
     let aux_collection_name = "ZTF_alerts_aux";
     let filter_aux = doc! {"_id": &object_id};
-    let r = conf::build_xmatch_configs(&config_file, "ZTF").unwrap()[0].radius;
 
     // LSST setup
     let mut lsst_alert_worker = LsstAlertWorker::new(CONFIG_FILE).await.unwrap();
 
-    // If no LSST alerts have been processed, then no match should be found:
+    // 1. LSST alert further than max radius, ZTF alert should not have an LSST alias
+    let (_, _, _, _, lsst_bytes_content) = LsstAlertRandomizer::default()
+        .ra(ra)
+        .dec(dec + 1.1 * LSST_XMATCH_RADIUS.to_degrees())
+        .get()
+        .await;
+    lsst_alert_worker
+        .process_alert(&lsst_bytes_content)
+        .await
+        .unwrap();
+
     alert_worker.process_alert(&bytes_content).await.unwrap();
     let aux = db
         .collection::<mongodb::bson::Document>(aux_collection_name)
@@ -255,12 +265,11 @@ async fn test_process_ztf_lsst_xmatch() {
         .get_array("LSST")
         .unwrap();
     assert_eq!(matches.len(), 0);
-    drop_alert_from_collections(candid, "ZTF").await.unwrap();
 
-    // // Generate an LSST alert with the same ra and dec, but shifted north a bit within the search radius:
-    let (lsst_candid, _, _, _, lsst_bytes_content) = LsstAlertRandomizer::default()
+    // 2. nearby LSST alert, ZTF alert should have an LSST alias
+    let (_, lsst_object_id, _, _, lsst_bytes_content) = LsstAlertRandomizer::default()
         .ra(ra)
-        .dec(dec + 0.9 * r * 180.0 / std::f64::consts::PI)
+        .dec(dec + 0.9 * LSST_XMATCH_RADIUS.to_degrees())
         .get()
         .await;
     lsst_alert_worker
@@ -268,7 +277,12 @@ async fn test_process_ztf_lsst_xmatch() {
         .await
         .unwrap();
 
-    // Now check again, the lsst_object_id should be present:
+    let (_, _, _, _, bytes_content) = ZtfAlertRandomizer::default()
+        .objectid(&object_id)
+        .ra(ra)
+        .dec(dec)
+        .get()
+        .await;
     alert_worker.process_alert(&bytes_content).await.unwrap();
     let aux = db
         .collection::<mongodb::bson::Document>(aux_collection_name)
@@ -276,26 +290,87 @@ async fn test_process_ztf_lsst_xmatch() {
         .await
         .unwrap()
         .unwrap();
-    let matches = aux
+    let lsst_matches = aux
         .get_document("aliases")
         .unwrap()
         .get_array("LSST")
         .unwrap()
         .iter()
-        .map(|x| x.as_str().unwrap())
+        .map(|x| x.as_i64().unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(
-        matches,
-        vec![lsst_candid.to_string()],
-        "matches: {:?}",
-        matches
-    );
-    drop_alert_from_collections(candid, "ZTF").await.unwrap();
-    drop_alert_from_collections(lsst_candid, "LSST")
+
+    assert_eq!(lsst_matches.len(), 1);
+    assert_eq!(lsst_matches[0], lsst_object_id);
+
+    // 3. Closer LSST alert, ZTF alert should have a new LSST alias
+    let (_, lsst_object_id, _, _, lsst_bytes_content) = LsstAlertRandomizer::default()
+        .ra(ra)
+        .dec(dec + 0.1 * LSST_XMATCH_RADIUS.to_degrees())
+        .get()
+        .await;
+    lsst_alert_worker
+        .process_alert(&lsst_bytes_content)
         .await
         .unwrap();
 
-    // And do it again for a negative result.
+    let (_, _, _, _, bytes_content) = ZtfAlertRandomizer::default()
+        .objectid(&object_id)
+        .ra(ra)
+        .dec(dec)
+        .get()
+        .await;
+    alert_worker.process_alert(&bytes_content).await.unwrap();
+    let aux = db
+        .collection::<mongodb::bson::Document>(aux_collection_name)
+        .find_one(filter_aux.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    let lsst_matches = aux
+        .get_document("aliases")
+        .unwrap()
+        .get_array("LSST")
+        .unwrap()
+        .iter()
+        .map(|x| x.as_i64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(lsst_matches.len(), 1);
+    assert_eq!(lsst_matches[0], lsst_object_id);
+
+    // 4. Further LSST alert, ZTF alert should have a new LSST alias
+    let (_, bad_lsst_object_id, _, _, lsst_bytes_content) = LsstAlertRandomizer::default()
+        .ra(ra)
+        .dec(dec + 0.5 * LSST_XMATCH_RADIUS.to_degrees())
+        .get()
+        .await;
+    lsst_alert_worker
+        .process_alert(&lsst_bytes_content)
+        .await
+        .unwrap();
+    let (_, _, _, _, bytes_content) = ZtfAlertRandomizer::default()
+        .objectid(&object_id)
+        .ra(ra)
+        .dec(dec)
+        .get()
+        .await;
+    alert_worker.process_alert(&bytes_content).await.unwrap();
+    let aux = db
+        .collection::<mongodb::bson::Document>(aux_collection_name)
+        .find_one(filter_aux.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    let lsst_matches = aux
+        .get_document("aliases")
+        .unwrap()
+        .get_array("LSST")
+        .unwrap()
+        .iter()
+        .map(|x| x.as_i64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(lsst_matches.len(), 1);
+    assert_eq!(lsst_matches[0], lsst_object_id);
+    assert_ne!(lsst_matches[0], bad_lsst_object_id);
 }
 
 #[tokio::test]


### PR DESCRIPTION
@jesaerys please take a look, in this PR I:
- moved the lsst crossmatching code to its own function
- added a const for the radius, right now it looked like you were grabbing a somewhat random number from the crossmatch config that could have been anything and likely unrelated to LSST
- changed the alert randomizers to randomize the ra/dec by default otherwise tests generate stuff at the same positions so that messes things up. Here I randomize everything and then set the dec to a fixed value because otherwise it could be randomized above 33.5 dec while would always result in no matches. A unit test for the > dec case would be a nice addition actually
- fixed the index that was set to unique which is not necessary and actually incorrect (seems due to astrometry, pipelines and such you could in theory have 2 objects at the same position).
- fixed the unit tests and tested more scenarios (updated when new closer match, not updated when new further match, no match if too far, ...)