### PR TITLE
Redis connection: configurable

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -7,6 +7,9 @@ database:
   username: mongoadmin
   password: mongoadminsecret
   srv: false
+redis:
+  host: localhost
+  port: 6379
 workers:
   ZTF:
     command_interval: 500

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -11,6 +11,8 @@ struct Cli {
     survey: String,
     #[arg(help = "UTC date for which we want to consume alerts, with format YYYYMMDD")]
     date: Option<String>,
+    #[arg(long, value_name = "FILE", help = "Path to the configuration file")]
+    config: Option<String>,
     #[arg(help = "Number of processes to use to read the Kafka stream in parallel")]
     processes: Option<usize>,
     #[arg(help = "Clear the queue of alerts already consumed from Kafka and pushed to Redis")]
@@ -36,6 +38,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => chrono::Utc::now().date_naive().pred_opt().unwrap(),
     };
     let survey = args.survey;
+    let config_path = match args.config {
+        Some(path) => path,
+        None => "config.yaml".to_string(),
+    };
     let processes = args.processes.unwrap_or(1);
     let clear = args.clear.unwrap_or(false);
     let max_in_queue = args.max_in_queue.unwrap_or(15000);
@@ -45,16 +51,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match survey.as_str() {
         "ZTF" => {
-            let consumer =
-                ZtfAlertConsumer::new(processes, Some(max_in_queue), None, None, None, None);
+            let consumer = ZtfAlertConsumer::new(
+                processes,
+                Some(max_in_queue),
+                None,
+                None,
+                None,
+                None,
+                &config_path,
+            );
             if clear {
                 let _ = consumer.clear_output_queue();
             }
             consumer.consume(timestamp).await?;
         }
         "LSST" => {
-            let consumer =
-                LsstAlertConsumer::new(processes, Some(max_in_queue), None, None, None, None);
+            let consumer = LsstAlertConsumer::new(
+                processes,
+                Some(max_in_queue),
+                None,
+                None,
+                None,
+                None,
+                &config_path,
+            );
             if clear {
                 let _ = consumer.clear_output_queue();
             }

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -1,4 +1,7 @@
-use crate::kafka::base::{consume_partitions, AlertConsumer};
+use crate::{
+    conf,
+    kafka::base::{consume_partitions, AlertConsumer},
+};
 use rdkafka::config::ClientConfig;
 use redis::AsyncCommands;
 use tracing::{error, info};
@@ -13,6 +16,7 @@ pub struct ZtfAlertConsumer {
     max_in_queue: usize,
     group_id: String,
     server: String,
+    config_path: String,
 }
 
 #[async_trait::async_trait]
@@ -24,6 +28,7 @@ impl AlertConsumer for ZtfAlertConsumer {
         output_queue: Option<&str>,
         group_id: Option<&str>,
         server: Option<&str>,
+        config_path: &str,
     ) -> Self {
         if 15 % n_threads != 0 {
             panic!("Number of threads should be a factor of 15");
@@ -49,11 +54,12 @@ impl AlertConsumer for ZtfAlertConsumer {
             max_in_queue,
             group_id,
             server,
+            config_path: config_path.to_string(),
         }
     }
 
-    fn default() -> Self {
-        Self::new(1, None, None, None, None, None)
+    fn default(config_path: &str) -> Self {
+        Self::new(1, None, None, None, None, None, config_path)
     }
 
     async fn consume(&self, timestamp: i64) -> Result<(), Box<dyn std::error::Error>> {
@@ -75,6 +81,7 @@ impl AlertConsumer for ZtfAlertConsumer {
             let output_queue = self.output_queue.clone();
             let group_id = self.group_id.clone();
             let server = self.server.clone();
+            let config_path = self.config_path.clone();
             let handle = tokio::spawn(async move {
                 let result = consume_partitions(
                     &i.to_string(),
@@ -87,6 +94,7 @@ impl AlertConsumer for ZtfAlertConsumer {
                     &server,
                     None,
                     None,
+                    &config_path,
                 )
                 .await;
                 if let Err(e) = result {
@@ -104,8 +112,8 @@ impl AlertConsumer for ZtfAlertConsumer {
     }
 
     async fn clear_output_queue(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let client = redis::Client::open("redis://localhost:6379".to_string()).unwrap();
-        let mut con = client.get_multiplexed_async_connection().await.unwrap();
+        let config = conf::load_config(&self.config_path)?;
+        let mut con = conf::build_redis(&config).await?;
         let _: () = con.del(&self.output_queue).await.unwrap();
         info!("Cleared redis queued for ZTF Kafka consumer");
         Ok(())

--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -58,13 +58,8 @@ pub async fn run_ml_worker<T: MLWorker>(
 ) -> Result<(), MLWorkerError> {
     let ml_worker = T::new(config_path).await?;
 
-    // in a never ending loop, loop over the queues
-    let client_redis = redis::Client::open("redis://localhost:6379".to_string())
-        .map_err(MLWorkerError::ConnectRedisError)?;
-    let mut con = client_redis
-        .get_multiplexed_async_connection()
-        .await
-        .map_err(MLWorkerError::ConnectRedisError)?;
+    let config = conf::load_config(config_path)?;
+    let mut con = conf::build_redis(&config).await?;
 
     let input_queue = ml_worker.input_queue_name();
     let output_queue = ml_worker.output_queue_name();

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -205,11 +205,8 @@ pub async fn empty_processed_alerts_queue(
     input_queue_name: &str,
     output_queue_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client_redis = redis::Client::open("redis://localhost:6379".to_string()).unwrap();
-    let mut con = client_redis
-        .get_multiplexed_async_connection()
-        .await
-        .unwrap();
+    let config = conf::load_config("tests/config.test.yaml")?;
+    let mut con = conf::build_redis(&config).await?;
     con.del::<&str, usize>(input_queue_name).await.unwrap();
     con.del::<&str, usize>("{}_temp").await.unwrap();
     con.del::<&str, usize>(output_queue_name).await.unwrap();


### PR DESCRIPTION
In this PR, we make the redis connection configurable from the config file (defaulting to the usual localhost) just like the MongoDB connection already was, and replace all occurences of a hardcoded connection to redis with a call to that new function.

Addresses issue: https://github.com/boom-astro/boom/issues/121