### PR TITLE
Clean up outdated Python setup and clarify Kafka usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,21 @@ BOOM runs on macOS and Linux. You'll need:
 
 ## Setup
 
-1. We'll start by creating a python virtual environment to manage our python install and dependencies. Here's how you can do that with `uv`:
-    ```bash
-    uv venv --python 3.10
-    source .venv/bin/activate
-    uv pip install -r requirements.txt
-    ```
-    Note: If requirements.txt is missing, it can be skipped. It's only required for the ML pipeline.
-   
-3. Next, copy the default config file, `config.default.yaml`, to `config.yaml`:
+1. Copy the default config file, `config.default.yaml`, to `config.yaml`:
     ```bash
     cp config.default.yaml config.yaml
     ```
-4. Same for the `docker-compose.yaml` file:
+2. Same for the `docker-compose.yaml` file:
     ```bash
     cp docker-compose.default.yaml docker-compose.yaml
     ```
-5. Launch `Valkey`, `MongoDB`, and `Kafka` using docker, using the provided `docker compose.yaml` file:
+3. Launch `Valkey`, `MongoDB`, and `Kafka` using docker, using the provided `docker compose.yaml` file:
     ```bash
     docker compose up -d
     ```
     This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
     *To check if the containers are running and healthy, run `docker ps`.*
-6. Last but not least, build the Rust binaries. You can do this with or without the `--release` flag, but we recommend using it for better performance:
+4. Last but not least, build the Rust binaries. You can do this with or without the `--release` flag, but we recommend using it for better performance:
     ```bash
     cargo build --release
     ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ BOOM runs on macOS and Linux. You'll need:
 - `Rust` (a systems programming language) `>= 1.55.0`;
 - `Python` (a high-level programming language) `>= 3.10`: we recommend using `uv` to create a virtual environment with the required Python dependencies.
 - `wget` and `tar`: used to download and extract the ZTF alerts for testing purposes.
+- If you're on Windows, you must use WSL2 (Windows Subsystem for Linux) and install a Linux distribution like Ubuntu 24.04.
 
 ### Installation steps:
 
@@ -36,6 +37,11 @@ BOOM runs on macOS and Linux. You'll need:
 - Rust: You can use [rustup](https://www.rust-lang.org/tools/install) to install Rust. Once installed, you can verify the installation by running `rustc --version` in your terminal. You also want to make sure that cargo is installed, which is the Rust package manager. You can verify this by running `cargo --version` in your terminal.
 - Python: We strongly recommend using [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage your python installation and virtual environments. You can install it with `pip`, or using the [install script](https://docs.astral.sh/uv/getting-started/installation/#install-script). We recommend the later. Once installed, you can verify the installation by running `uv --version` in your terminal.
 - `wget` and `tar`: Most Linux distributions come with `wget` and `tar` pre-installed. If not, you can install them with your package manager.
+- System packages are essential for compiling and linking some Rust crates that require native libraries like OpenSSL and SASL. Run the following to install necessary system packages:
+  ```bash
+  sudo apt update
+  sudo apt install build-essential pkg-config libssl-dev libsasl2-dev -y
+  ```
 
 ## Setup
 
@@ -45,6 +51,7 @@ BOOM runs on macOS and Linux. You'll need:
     source .venv/bin/activate
     uv pip install -r requirements.txt
     ```
+    Note: If requirements.txt is missing, it can be skipped. It's only required for the ML pipeline.
 2. Next, copy the default config file, `config.default.yaml`, to `config.yaml`:
     ```bash
     cp config.default.yaml config.yaml
@@ -68,9 +75,9 @@ BOOM runs on macOS and Linux. You'll need:
 
 BOOM is meant to be run in production, reading from a real-time stream of astronomical alerts. **That said, we can create our own Kafka stream using the[ZTF alerts public archive](https://ztf.uw.edu/alerts/public/) to test BOOM.** To do so, you can start the `Kafka` producer with:
 ```bash
-cargo run --release --bin kafka_producer <date_in_YYYMMDD_format> <limit>
+cargo run --release --bin kafka_producer <date_in_YYYMMDD_format>
 ```
-Where `<date_in_YYYMMDD_format>` is the date of the alerts you want to read. We suggest using a night with a very small number of alerts to just get the code running, like `20240617` for example. The script will take care of downloading the alerts from the ZTF IPAC server, writing them on disk for the `Kafka` producer to read, and then will start producing them to the associated `Kafka` topic, `ztf_YYYYMMDD_programid1`. You can leave that running in the background, and start the rest of the pipeline in another terminal. The <limit> argument is optional, and will limit the number of alerts pushed to the `Kafka` topic.
+Where `<date_in_YYYMMDD_format>` is the date of the alerts you want to read. We suggest using a night with a very small number of alerts to just get the code running, like `20240617` for example. The script will take care of downloading the alerts from the ZTF IPAC server, writing them on disk for the `Kafka` producer to read, and then will start producing them to the associated `Kafka` topic, `ztf_YYYYMMDD_programid1`. You can leave that running in the background, and start the rest of the pipeline in another terminal.
 
 *If you'd like to clear the `Kafka` topic before starting the producer, you can run the following command:*
 ```bash
@@ -82,7 +89,13 @@ Next, you can start the `Kafka` consumer with:
 ```bash
 cargo run --release --bin kafka_consumer <SURVEY> [DATE] [PROCESSES] [CLEAR] [max_in_queue]
 ```
-Where `<SURVEY>` and `[DATE]` determine which topic to read from. In our case, `<SURVEY>` should be `ZTF` and `[DATE]` is the date in YYYMMDD format that was given to `kafka_producer` earlier, telling the consumer to read from the topic named `ztf_YYYYMMDD_programid1`. This naming scheme follows the actual naming scheme used by the real ZTF alert streams.  `<group_id>` is the name of the `Kafka` consumer group (optional), and `<exit_on_eof>` is a boolean that tells the consumer to exit when it reaches the end of the topic. You can set it to `true` for testing purposes, and `false` for production, as you would want the consumer to keep running and reading new alerts as they come in. Last but not least `<max_in_queue>` allows you to set a limit on how many alert packets can be in the redis queue at once. By default, this is set to 1000, and can be set to 0 to be ignored. The script will read the alerts from the `Kafka` topic, and write them to the `Redis`/`Valkey` queue. You can leave that running in the background, and start the rest of the pipeline in another terminal.
+Where `<SURVEY>` and `[DATE]` determine which topic to read from. In our case, `<SURVEY>` should be `ZTF` and `[DATE]` is the date in YYYMMDD format that was given to `kafka_producer` earlier, telling the consumer to read from the topic named `ztf_YYYYMMDD_programid1`. 
+
+Note: This version of the code requires the correct order of arguments. Run the following for help:
+```bash
+cargo run --release --bin kafka_consumer -- --help
+```
+This naming scheme follows the actual naming scheme used by the real ZTF alert streams.  `<group_id>` is the name of the `Kafka` consumer group (optional), and `<exit_on_eof>` is a boolean that tells the consumer to exit when it reaches the end of the topic. You can set it to `true` for testing purposes, and `false` for production, as you would want the consumer to keep running and reading new alerts as they come in. Last but not least `<max_in_queue>` allows you to set a limit on how many alert packets can be in the redis queue at once. By default, this is set to 1000, and can be set to 0 to be ignored. The script will read the alerts from the `Kafka` topic, and write them to the `Redis`/`Valkey` queue. You can leave that running in the background, and start the rest of the pipeline in another terminal.
 
 Instead of starting each worker manually, we provide the `scheduler`. It reads the number of workers for each type from `config.yaml`. Run the scheduler with:
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ BOOM runs on macOS and Linux. You'll need:
 - Rust: You can either use [rustup](https://www.rust-lang.org/tools/install) to install Rust, or you can use [Homebrew](https://brew.sh/) to install it. If you choose the latter, you can run `brew install rust` in your terminal. We recommend using rustup, as it allows you to easily switch between different versions of Rust, and to keep your Rust installation up to date. Once installed, you can verify the installation by running `rustc --version` in your terminal. You also want to make sure that cargo is installed, which is the Rust package manager. You can verify this by running `cargo --version` in your terminal.
 - Python: We strongly recommend using [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage your python installation and virtual environments. You can install it with `brew`, `pip`, or using the [install script](https://docs.astral.sh/uv/getting-started/installation/#install-script). We recommend the later. Once installed, you can verify the installation by running `uv --version` in your terminal.
 - `wget` and `tar`: `tar` is already installed on macOS, but you can install `wget` with `brew install wget` or any other package manager you prefer.
+- System packages are essential for compiling and linking some Rust crates that require native libraries like OpenSSL and SASL. Run the following to install necessary system packages:
+  ```bash
+  sudo apt update
+  sudo apt install build-essential pkg-config libssl-dev libsasl2-dev -y
+  ```
 
 #### Linux
 
@@ -52,21 +57,22 @@ BOOM runs on macOS and Linux. You'll need:
     uv pip install -r requirements.txt
     ```
     Note: If requirements.txt is missing, it can be skipped. It's only required for the ML pipeline.
-2. Next, copy the default config file, `config.default.yaml`, to `config.yaml`:
+   
+3. Next, copy the default config file, `config.default.yaml`, to `config.yaml`:
     ```bash
     cp config.default.yaml config.yaml
     ```
-3. Same for the `docker-compose.yaml` file:
+4. Same for the `docker-compose.yaml` file:
     ```bash
     cp docker-compose.default.yaml docker-compose.yaml
     ```
-4. Launch `Valkey`, `MongoDB`, and `Kafka` using docker, using the provided `docker compose.yaml` file:
+5. Launch `Valkey`, `MongoDB`, and `Kafka` using docker, using the provided `docker compose.yaml` file:
     ```bash
     docker compose up -d
     ```
     This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
     *To check if the containers are running and healthy, run `docker ps`.*
-5. Last but not least, build the Rust binaries. You can do this with or without the `--release` flag, but we recommend using it for better performance:
+6. Last but not least, build the Rust binaries. You can do this with or without the `--release` flag, but we recommend using it for better performance:
     ```bash
     cargo build --release
     ```


### PR DESCRIPTION
This PR removes the outdated Python virtual environment setup instructions from the README, following recent changes and discussion in PR #128 and #133.