### PR TITLE
Read database parameters from config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "boom",
  "futures",
  "mongodb",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
- "boom",
+ "config",
  "futures",
  "mongodb",
  "serde",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 actix-rt = "2.10.0"
 actix-web = "4.9.0"
-boom = { version = "0.1.0", path = ".." }
+config = "0.15.11"
 futures = "0.3.31"
 mongodb = "3.1.0"
 serde = "1.0.215"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 actix-rt = "2.10.0"
 actix-web = "4.9.0"
+boom = { version = "0.1.0", path = ".." }
 futures = "0.3.31"
 mongodb = "3.1.0"
 serde = "1.0.215"

--- a/api/src/api/alerts.rs
+++ b/api/src/api/alerts.rs
@@ -6,7 +6,7 @@ use mongodb::{
     bson::{Document, doc},
 };
 
-const DB_NAME: &str = "boom";
+use crate::DB_NAME;
 
 #[get("/alerts/{survey_name}/get_object/{object_id}")]
 pub async fn get_object(

--- a/api/src/api/alerts.rs
+++ b/api/src/api/alerts.rs
@@ -2,20 +2,17 @@ use crate::models::response;
 use actix_web::{HttpResponse, get, web};
 use futures::TryStreamExt;
 use mongodb::{
-    Client, Collection,
+    Collection, Database,
     bson::{Document, doc},
 };
 
-use crate::DB_NAME;
-
 #[get("/alerts/{survey_name}/get_object/{object_id}")]
 pub async fn get_object(
-    client: web::Data<Client>,
+    db: web::Data<Database>,
     path: web::Path<(String, String)>,
 ) -> HttpResponse {
     let (survey_name, object_id) = path.into_inner();
     let survey_name = survey_name.to_uppercase(); // (TEMP) to match with "ZTF"
-    let db = client.database(DB_NAME);
     let alerts_collection: Collection<Document> = db.collection(&format!("{}_alerts", survey_name));
     let aux_collection: Collection<Document> =
         db.collection(&format!("{}_alerts_aux", survey_name));

--- a/api/src/api/filters.rs
+++ b/api/src/api/filters.rs
@@ -7,7 +7,7 @@ use mongodb::{
 use std::vec;
 use uuid::Uuid;
 
-const DB_NAME: &str = "boom";
+use crate::DB_NAME;
 
 struct Filter {
     pub pipeline: Vec<mongodb::bson::Document>,

--- a/api/src/api/filters.rs
+++ b/api/src/api/filters.rs
@@ -1,13 +1,11 @@
 use crate::models::filter_models::*;
 use actix_web::{HttpResponse, patch, post, web};
 use mongodb::{
-    Client, Collection,
+    Collection, Database,
     bson::{Document, doc},
 };
 use std::vec;
 use uuid::Uuid;
-
-use crate::DB_NAME;
 
 struct Filter {
     pub pipeline: Vec<mongodb::bson::Document>,
@@ -95,14 +93,12 @@ fn build_test_pipeline(
 
 // tests the functionality of a filter by running it on alerts in database
 async fn run_test_pipeline(
-    client: web::Data<Client>,
+    db: web::Data<Database>,
     catalog: String,
     pipeline: Vec<mongodb::bson::Document>,
 ) -> Result<(), mongodb::error::Error> {
-    let collection: Collection<mongodb::bson::Document> = client
-        .database(DB_NAME)
-        .collection(format!("{}_alerts", catalog).as_str());
-
+    let collection: Collection<mongodb::bson::Document> =
+        db.collection(format!("{}_alerts", catalog).as_str());
     let result = collection.aggregate(pipeline).await;
     match result {
         Ok(_) => {
@@ -145,7 +141,7 @@ fn build_filter_bson(filter: Filter) -> Result<mongodb::bson::Document, mongodb:
 
 #[patch("/filters/{filter_id}")]
 pub async fn add_filter_version(
-    client: web::Data<Client>,
+    db: web::Data<Database>,
     filter_id: web::Path<i32>,
     body: web::Json<FilterSubmissionBody>,
 ) -> HttpResponse {
@@ -157,8 +153,7 @@ pub async fn add_filter_version(
                 .body("pipeline not provided. pipeline required for adding a filter version");
         }
     };
-
-    let collection: Collection<Document> = client.database(DB_NAME).collection("filters");
+    let collection: Collection<Document> = db.collection("filters");
     let owner_filter = match collection.find_one(doc! {"filter_id": filter_id}).await {
         Ok(Some(filter)) => filter,
         Ok(None) => {
@@ -181,7 +176,7 @@ pub async fn add_filter_version(
     // create test version of filter and test it
     let test_pipeline = build_test_pipeline(catalog.to_string(), permissions, pipeline.clone());
 
-    match run_test_pipeline(client.clone(), catalog.to_string(), test_pipeline).await {
+    match run_test_pipeline(db.clone(), catalog.to_string(), test_pipeline).await {
         Ok(()) => {}
         Err(e) => {
             return HttpResponse::BadRequest().body(format!(
@@ -226,7 +221,7 @@ pub async fn add_filter_version(
 
 #[post("/filters")]
 pub async fn post_filter(
-    client: web::Data<Client>,
+    db: web::Data<Database>,
     body: web::Json<FilterSubmissionBody>,
 ) -> HttpResponse {
     let body = body.clone();
@@ -261,7 +256,7 @@ pub async fn post_filter(
     let test_pipeline = build_test_pipeline(catalog.clone(), permissions.clone(), pipeline.clone());
 
     // perform test run to ensure no errors
-    match run_test_pipeline(client.clone(), catalog.clone(), test_pipeline).await {
+    match run_test_pipeline(db.clone(), catalog.clone(), test_pipeline).await {
         Ok(()) => {}
         Err(e) => {
             return HttpResponse::BadRequest().body(format!(
@@ -272,8 +267,7 @@ pub async fn post_filter(
     }
 
     // save original filter to database
-    let filter_collection: Collection<mongodb::bson::Document> =
-        client.database(DB_NAME).collection("filters");
+    let filter_collection: Collection<mongodb::bson::Document> = db.collection("filters");
     let database_filter = Filter {
         pipeline,
         permissions,

--- a/api/src/api/query.rs
+++ b/api/src/api/query.rs
@@ -1,3 +1,4 @@
+use crate::DB_NAME;
 use crate::models::{query_models::*, response};
 use actix_web::{HttpResponse, get, web};
 use futures::TryStreamExt;
@@ -6,8 +7,6 @@ use mongodb::{
     bson::{Document, doc},
 };
 use std::collections::HashMap;
-
-const DB_NAME: &str = "boom";
 
 // builds find options for mongo query
 pub fn build_options(

--- a/api/src/api/query.rs
+++ b/api/src/api/query.rs
@@ -1,9 +1,8 @@
-use crate::DB_NAME;
 use crate::models::{query_models::*, response};
 use actix_web::{HttpResponse, get, web};
 use futures::TryStreamExt;
 use mongodb::{
-    Client, Collection, IndexModel,
+    Collection, Database, IndexModel,
     bson::{Document, doc},
 };
 use std::collections::HashMap;
@@ -61,7 +60,7 @@ pub fn build_cone_search_filter(
 }
 
 pub async fn get_catalog_names(
-    db: mongodb::Database,
+    db: web::Data<Database>,
 ) -> Result<Vec<String>, mongodb::error::Error> {
     // get collection names in alphabetical order
     let collection_names = match db.list_collection_names().await {
@@ -78,7 +77,7 @@ pub async fn get_catalog_names(
 }
 
 pub async fn get_catalog_info(
-    db: mongodb::Database,
+    db: web::Data<Database>,
     catalogs: Vec<String>,
 ) -> Result<Vec<Document>, mongodb::error::Error> {
     let mut data = Vec::new();
@@ -97,7 +96,7 @@ pub async fn get_catalog_info(
 }
 
 pub async fn get_index_info(
-    db: mongodb::Database,
+    db: web::Data<Database>,
     catalogs: Vec<String>,
 ) -> Result<Vec<Vec<IndexModel>>, mongodb::error::Error> {
     let mut out_data = Vec::new();
@@ -116,7 +115,7 @@ pub async fn get_index_info(
     return Ok(out_data);
 }
 
-pub async fn get_db_info(db: mongodb::Database) -> Result<Document, mongodb::error::Error> {
+pub async fn get_db_info(db: web::Data<Database>) -> Result<Document, mongodb::error::Error> {
     let data = match db.run_command(doc! { "dbstats": 1 }).await {
         Ok(d) => d,
         Err(e) => return Err(e),
@@ -157,8 +156,7 @@ pub async fn get_collection_sample(
 }
 
 #[get("/query/info")]
-pub async fn get_info(client: web::Data<Client>, body: web::Json<InfoQueryBody>) -> HttpResponse {
-    let db = client.database(DB_NAME);
+pub async fn get_info(db: web::Data<Database>, body: web::Json<InfoQueryBody>) -> HttpResponse {
     let command = match body.command.clone() {
         Some(c) => c,
         None => {
@@ -226,14 +224,13 @@ pub async fn get_info(client: web::Data<Client>, body: web::Json<InfoQueryBody>)
 }
 
 #[get("/query/sample")]
-pub async fn sample(client: web::Data<Client>, body: web::Json<QueryBody>) -> HttpResponse {
+pub async fn sample(db: web::Data<Database>, body: web::Json<QueryBody>) -> HttpResponse {
     let this_query = body.query.clone().unwrap_or_default();
     let catalog = match this_query.catalog {
         Some(c) => c,
         None => return response::bad_request("catalog name required for sample"),
     };
-
-    let collection: Collection<Document> = client.database(DB_NAME).collection(&catalog);
+    let collection: Collection<Document> = db.collection(&catalog);
     let size = this_query.size.unwrap_or(1);
     let docs = match get_collection_sample(collection, size).await {
         Ok(d) => d,
@@ -248,16 +245,13 @@ pub async fn sample(client: web::Data<Client>, body: web::Json<QueryBody>) -> Ht
 }
 
 #[get("/query/count_documents")]
-pub async fn count_documents(
-    client: web::Data<Client>,
-    body: web::Json<QueryBody>,
-) -> HttpResponse {
+pub async fn count_documents(db: web::Data<Database>, body: web::Json<QueryBody>) -> HttpResponse {
     let this_query = body.query.clone().unwrap_or_default();
     let catalog = match this_query.catalog {
         Some(c) => c,
         None => return response::bad_request("catalog name required for count_documents"),
     };
-    let collection: Collection<Document> = client.database(DB_NAME).collection(&catalog);
+    let collection: Collection<Document> = db.collection(&catalog);
     let filter = this_query.filter.unwrap_or(doc! {});
     let doc_count = collection.count_documents(filter).await;
     match doc_count {
@@ -274,7 +268,7 @@ pub async fn count_documents(
 }
 
 #[get("/query/find")]
-pub async fn find(client: web::Data<Client>, body: web::Json<QueryBody>) -> HttpResponse {
+pub async fn find(db: web::Data<Database>, body: web::Json<QueryBody>) -> HttpResponse {
     let this_query = body.query.clone().unwrap_or_default();
     let filter = match this_query.filter {
         Some(f) => f,
@@ -292,7 +286,7 @@ pub async fn find(client: web::Data<Client>, body: web::Json<QueryBody>) -> Http
         this_query.projection,
         body.kwargs.clone().unwrap_or_default(),
     );
-    let collection: Collection<Document> = client.database(DB_NAME).collection(&catalog);
+    let collection: Collection<Document> = db.collection(&catalog);
     let cursor = match collection.find(filter).with_options(find_options).await {
         Ok(c) => c,
         Err(e) => {
@@ -313,10 +307,7 @@ pub async fn find(client: web::Data<Client>, body: web::Json<QueryBody>) -> Http
 }
 
 #[get("/query/cone_search")]
-pub async fn cone_search(
-    client: web::Data<Client>,
-    body: web::Json<ConeSearchBody>,
-) -> HttpResponse {
+pub async fn cone_search(db: web::Data<Database>, body: web::Json<ConeSearchBody>) -> HttpResponse {
     let this_body = body.clone();
     let radius = match this_body.radius {
         Some(r) => r,
@@ -345,7 +336,7 @@ pub async fn cone_search(
         }
     };
 
-    let collection: Collection<Document> = client.database(DB_NAME).collection(&catalog);
+    let collection: Collection<Document> = db.collection(&catalog);
 
     let projection = catalog_details.projection;
     let input_filter = catalog_details.filter.unwrap_or(doc! {});

--- a/api/src/conf.rs
+++ b/api/src/conf.rs
@@ -12,9 +12,20 @@ pub struct AppConfig {
     pub database: DatabaseConfig,
 }
 
-pub fn load_config() -> AppConfig {
+impl AppConfig {
+    pub fn from_default_path() -> Self {
+        load_config(None)
+    }
+
+    pub fn from_path(config_path: &str) -> Self {
+        load_config(Some(config_path))
+    }
+}
+
+pub fn load_config(config_path: Option<&str>) -> AppConfig {
+    let config_fpath = config_path.unwrap_or("config.yaml");
     let config = Config::builder()
-        .add_source(File::with_name("config.yaml"))
+        .add_source(File::with_name(config_fpath))
         .build()
         .expect("a config.yaml file should exist");
     let db_conf = config

--- a/api/src/conf.rs
+++ b/api/src/conf.rs
@@ -1,0 +1,63 @@
+use config::{Config, File};
+
+pub struct DatabaseConfig {
+    pub name: String,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+pub struct AppConfig {
+    pub database: DatabaseConfig,
+}
+
+pub fn load_config() -> AppConfig {
+    let config = Config::builder()
+        .add_source(File::with_name("config.yaml"))
+        .build()
+        .expect("a config.yaml file should exist");
+    let db_conf = config
+        .get_table("database")
+        .expect("a database table should exist in the config file");
+    let host = match db_conf.get("host") {
+        Some(host) => host
+            .clone()
+            .into_string()
+            .unwrap_or_else(|e| panic!("Invalid host: {}", e)),
+        None => "localhost".to_string(),
+    };
+    let port = match db_conf.get("port") {
+        Some(port) => port
+            .clone()
+            .into_int()
+            .unwrap_or_else(|e| panic!("Invalid port: {}", e)) as u16,
+        None => 27017,
+    };
+    let name = match db_conf.get("name") {
+        Some(name) => name
+            .clone()
+            .into_string()
+            .unwrap_or_else(|e| panic!("Invalid name: {}", e)),
+        None => "boom".to_string(),
+    };
+    let username = db_conf
+        .get("username")
+        .and_then(|username| username.clone().into_string().ok())
+        .unwrap_or("mongoadmin".to_string());
+    let password = db_conf
+        .get("password")
+        .and_then(|password| password.clone().into_string().ok())
+        .unwrap_or("mongoadminsecret".to_string());
+    {
+        AppConfig {
+            database: DatabaseConfig {
+                name: name,
+                host,
+                port,
+                username,
+                password,
+            },
+        }
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod api;
 pub mod models;
+
+pub const DB_NAME: &str = "boom";

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod api;
+pub mod conf;
 pub mod models;
-
-pub const DB_NAME: &str = "boom";

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -5,10 +5,34 @@ use mongodb::Client;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let user = "mongoadmin";
-    let pass = "mongoadminsecret";
-    let uri = std::env::var("MONGODB_URI")
-        .unwrap_or_else(|_| format!("mongodb://{user}:{pass}@localhost:27017").into());
+    // Read the config file
+    let config = boom::conf::load_config("config.yaml").expect("a config.yaml file should exist");
+    let db_conf = config
+        .get_table("database")
+        .expect("a database table should exist in the config file");
+    let host = match db_conf.get("host") {
+        Some(host) => host.clone().into_string().map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::Other, format!("Invalid host: {}", e))
+        })?,
+        None => "localhost".to_string(),
+    };
+    let port = match db_conf.get("port") {
+        Some(port) => port.clone().into_int().map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::Other, format!("Invalid port: {}", e))
+        })? as u16,
+        None => 27017,
+    };
+    let username = db_conf
+        .get("username")
+        .and_then(|username| username.clone().into_string().ok())
+        .unwrap_or("mongoadmin".to_string());
+    let password = db_conf
+        .get("password")
+        .and_then(|password| password.clone().into_string().ok())
+        .unwrap_or("mongoadminsecret".to_string());
+    let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| {
+        format!("mongodb://{}:{}@{}:{}", username, password, host, port).into()
+    });
     let client = Client::with_uri_str(uri).await.expect("failed to connect");
 
     HttpServer::new(move || {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,5 +1,5 @@
 use boom_api::api;
-use boom_api::conf::load_config;
+use boom_api::conf::AppConfig;
 
 use actix_web::{App, HttpServer, web};
 use mongodb::{Client, Database};
@@ -7,7 +7,7 @@ use mongodb::{Client, Database};
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Read the config file
-    let config = load_config().database;
+    let config = AppConfig::from_default_path().database;
     let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| {
         format!(
             "mongodb://{}:{}@{}:{}",

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,47 +1,26 @@
 use boom_api::api;
+use boom_api::conf::load_config;
 
 use actix_web::{App, HttpServer, web};
-use config::{Config, File};
-use mongodb::Client;
+use mongodb::{Client, Database};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Read the config file
-    let config = Config::builder()
-        .add_source(File::with_name("config.yaml"))
-        .build()
-        .expect("a config.yaml file should exist");
-    let db_conf = config
-        .get_table("database")
-        .expect("a database table should exist in the config file");
-    let host = match db_conf.get("host") {
-        Some(host) => host.clone().into_string().map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::Other, format!("Invalid host: {}", e))
-        })?,
-        None => "localhost".to_string(),
-    };
-    let port = match db_conf.get("port") {
-        Some(port) => port.clone().into_int().map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::Other, format!("Invalid port: {}", e))
-        })? as u16,
-        None => 27017,
-    };
-    let username = db_conf
-        .get("username")
-        .and_then(|username| username.clone().into_string().ok())
-        .unwrap_or("mongoadmin".to_string());
-    let password = db_conf
-        .get("password")
-        .and_then(|password| password.clone().into_string().ok())
-        .unwrap_or("mongoadminsecret".to_string());
+    let config = load_config().database;
     let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| {
-        format!("mongodb://{}:{}@{}:{}", username, password, host, port).into()
+        format!(
+            "mongodb://{}:{}@{}:{}",
+            config.username, config.password, config.host, config.port
+        )
+        .into()
     });
     let client = Client::with_uri_str(uri).await.expect("failed to connect");
+    let database: Database = client.database(&config.name);
 
     HttpServer::new(move || {
         App::new()
-            .app_data(web::Data::new(client.clone()))
+            .app_data(web::Data::new(database.clone()))
             .service(api::query::get_info)
             .service(api::query::sample)
             .service(api::query::cone_search)

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,12 +1,16 @@
 use boom_api::api;
 
 use actix_web::{App, HttpServer, web};
+use config::{Config, File};
 use mongodb::Client;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     // Read the config file
-    let config = boom::conf::load_config("config.yaml").expect("a config.yaml file should exist");
+    let config = Config::builder()
+        .add_source(File::with_name("config.yaml"))
+        .build()
+        .expect("a config.yaml file should exist");
     let db_conf = config
         .get_table("database")
         .expect("a database table should exist in the config file");

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,5 +1,4 @@
-mod api;
-mod models;
+use boom_api::api;
 
 use actix_web::{App, HttpServer, web};
 use mongodb::Client;

--- a/api/tests/test_query.rs
+++ b/api/tests/test_query.rs
@@ -2,7 +2,7 @@ use actix_web::web;
 #[cfg(test)]
 use boom_api::{
     api::{query, query::build_options},
-    conf::load_config,
+    conf::AppConfig,
     models::query_models::{QueryKwargs, Unit},
 };
 use mongodb::{
@@ -15,7 +15,9 @@ use mongodb::{
 const CATALOG_NAME: &str = "ZTF";
 
 pub async fn get_db() -> web::Data<Database> {
-    let config = load_config().database;
+    // Read config from the root of the project
+    // TODO: Perhaps we should have a special config for tests?
+    let config = AppConfig::from_path("../config.yaml").database;
     let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| {
         format!(
             "mongodb://{}:{}@{}:{}",

--- a/api/tests/test_query.rs
+++ b/api/tests/test_query.rs
@@ -17,7 +17,7 @@ const CATALOG_NAME: &str = "ZTF";
 pub async fn get_db() -> web::Data<Database> {
     // Read config from the root of the project
     // TODO: Perhaps we should have a special config for tests?
-    let config = AppConfig::from_path("../config.yaml").database;
+    let config = AppConfig::default().database;
     let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| {
         format!(
             "mongodb://{}:{}@{}:{}",

--- a/api/tests/test_query.rs
+++ b/api/tests/test_query.rs
@@ -1,12 +1,12 @@
 use actix_web::web;
 #[cfg(test)]
 use boom_api::{
-    DB_NAME,
     api::{query, query::build_options},
+    conf::load_config,
     models::query_models::{QueryKwargs, Unit},
 };
 use mongodb::{
-    Client,
+    Client, Database,
     bson::{Document, doc},
     options::FindOptions,
 };
@@ -14,22 +14,23 @@ use mongodb::{
 // TODO: put in config
 const CATALOG_NAME: &str = "ZTF";
 
-// TODO: get info for client from the config file
-pub async fn get_web_client() -> web::Data<Client> {
-    let user = "mongoadmin";
-    let pass = "mongoadminsecret";
-    let uri = std::env::var("MONGODB_URI")
-        .unwrap_or_else(|_| format!("mongodb://{user}:{pass}@localhost:27017").into());
+pub async fn get_db() -> web::Data<Database> {
+    let config = load_config().database;
+    let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| {
+        format!(
+            "mongodb://{}:{}@{}:{}",
+            config.username, config.password, config.host, config.port
+        )
+    });
     let client = Client::with_uri_str(uri).await.expect("failed to connect");
-    web::Data::new(client)
+    let db = client.database(&config.name);
+    web::Data::new(db)
 }
 
 // returns mongodb collection
 pub async fn get_database_collection() -> mongodb::Collection<Document> {
-    let client = get_web_client().await;
-    let collection = client
-        .database(DB_NAME)
-        .collection(&format!("{}_alerts", CATALOG_NAME));
+    let db = get_db().await;
+    let collection = db.collection(&format!("{}_alerts", CATALOG_NAME));
     collection
 }
 
@@ -127,42 +128,38 @@ fn test_build_cone_search_filter() {
 
 #[actix_rt::test]
 async fn test_get_catalog_names() {
-    let client = get_web_client().await;
-    let _ = query::get_catalog_names(client.database(DB_NAME)).await;
+    let db = get_db().await;
+    let _ = query::get_catalog_names(db).await;
 }
 
 #[actix_rt::test]
 async fn test_get_catalog_info() {
-    let client = get_web_client().await;
-    let catalog_names = query::get_catalog_names(client.database(DB_NAME))
-        .await
-        .unwrap();
+    let db = get_db().await;
+    let catalog_names = query::get_catalog_names(db.clone()).await.unwrap();
     let catalog_name = if catalog_names.len() > 0 {
         vec![catalog_names[0].clone()]
     } else {
         return;
     };
-    let _ = query::get_catalog_info(client.database(DB_NAME), catalog_name);
+    let _ = query::get_catalog_info(db, catalog_name);
 }
 
 #[actix_rt::test]
 async fn test_get_index_info() {
-    let client = get_web_client().await;
-    let catalog_names = query::get_catalog_names(client.database(DB_NAME))
-        .await
-        .unwrap();
+    let db = get_db().await;
+    let catalog_names = query::get_catalog_names(db.clone()).await.unwrap();
     let catalog_name = if catalog_names.len() > 0 {
         vec![catalog_names[0].clone()]
     } else {
         return;
     };
-    let _ = query::get_index_info(client.database(DB_NAME), catalog_name);
+    let _ = query::get_index_info(db, catalog_name);
 }
 
 #[actix_rt::test]
 async fn test_get_db_info() {
-    let client = get_web_client().await;
-    let _ = query::get_db_info(client.database(DB_NAME)).await;
+    let db = get_db().await;
+    let _ = query::get_db_info(db).await;
 }
 
 #[actix_rt::test]

--- a/api/tests/test_query.rs
+++ b/api/tests/test_query.rs
@@ -4,6 +4,7 @@ use actix_web::{
 };
 #[cfg(test)]
 use boom_api::{
+    DB_NAME,
     api::{query, query::build_options},
     models::query_models::{QueryKwargs, Unit},
 };
@@ -14,7 +15,6 @@ use mongodb::{
 };
 
 // TODO: put in config
-const DB_NAME: &str = "boom";
 const CATALOG_NAME: &str = "ZTF";
 
 // TODO: get info for client from the config file

--- a/api/tests/test_query.rs
+++ b/api/tests/test_query.rs
@@ -1,7 +1,4 @@
-use actix_web::{
-    test::{self, TestRequest},
-    web,
-};
+use actix_web::web;
 #[cfg(test)]
 use boom_api::{
     DB_NAME,


### PR DESCRIPTION
Resolves https://github.com/boom-astro/boom-api/issues/7

I also refactored to pass around a `Database` object instead of a `Client` object, since there were many instances where the client was used to create a database from `DB_NAME`.

## TODO

- [x] Implement a default config for when there is no `config.yaml` file present (only testing?)