### PR TITLE
Instrumentation and logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,75 @@ Tests currently require the kafka, valkey, and mongo Docker containers to be run
 
 The test suite also runs automagically on every push to the repository, and on every pull request.
 You can check the status of the tests in the "Actions" tab of the GitHub repository.
+
+## Errors, instrumentation, and logging
+
+Here are some conventions we try to adhere to.
+It's important to emphasize that none of this is set in stone.
+We evolve as our needs change and as we discover better ways of doing things.
+
+### Errors
+
+Panicking via `Result::unwrap`, `Result::expect`, etc. is almost always discouraged.
+
+* Panicking is should be reserved for truly unrecoverable errors.
+
+* Unrecoverable errors include things that go wrong during startup.
+
+All other errors are recoverable errors and should be expressed using custom error types (usually enums) that implement `std::error::Error`.
+These errors should be propagated to the caller using the `?` operator.
+
+* Using `thiserror` to help define custom errors is recommended, but not required.
+
+* Whether to reuse an existing error type in boom versus create a new one isn't always clear, but can be discussed during review.
+
+* (We may at some point shift to using the "accumulator" pattern with types like `anyhow::Error` or `eyre::Report`, reducing the need for as many custom error types).
+
+Each error is propagated until it's *handled*, i.e., when a caller intercepts the error value to either use it for control flow or log it.
+
+### Instrumentation
+
+We use `tracing::Span`s as the foundation for instrumenting boom.
+Briefly, a span represents a duration, e.g., the execution of a function.
+Each span has a name and optionally a set values recorded as fields.
+Spans can be nested.
+When a `tracing::Event` is created, e.g., using `tracing::info!` or `tracing::error!`, it comes with the list of its active parent spans and their fields.
+This provides structured context that helps make events easier to understand.
+
+* The `tracing::instrument` attribute is a preferred way to define a span for a function or method.
+  This is not the only way to define a span, and spans are not required to be tied to functions, but using `instrument` is very convenient.
+
+* `instrument` automatically records each function argument as a field, so we need to be mindful about what gets collected, skipping anything that has a large repr or that doesn't provide useful context.
+  A notable example is `self` in methods, which isn't useful to track, so we skip it by instrumenting methods with `#[instrument(skip(self))]`.
+
+As for deciding *what* to instrument, we should consider instrumenting 1) anything that helps provide context for events (particularly ERROR events) and/or 2) anything that we're interested in profiling for performance.
+
+* Subscribers can be configured to consume "span close" events, which include execution time details (see RUST_LOG_SPAN_EVENTS in the readme).
+
+* The `tracing_flame` crate uses spans to generate flamegraphs.
+
+* Having instrumented functions also unlocks further observability capabilities that we could add in the future, such as metrics.
+
+### Logging
+
+Logging is done by issuing `tracing::Event`s, as with `tracing::info!`, `tracing::error!`, and other similar macros. These events are picked up by a subscriber, which can do various things with them, such as print them to the console or write them to a file. Currently we just log to the console.
+
+Strive to logs things at the appropriate level:
+
+* INFO level events should be reserved for reporting major stages in the app lifecycle.
+
+* WARN is for minor issues or unexpected things that aren't quite errors but are more severe than INFO.
+
+* ERROR is of course for actual errors.
+  In general, we should only log errors where they're handled.
+  A function doesn't need to log an error if it propagates the error back to the caller via `?`.
+
+* DEBUG and TRACE are for when we need to rerun boom, usually locally, to get more information.
+
+When we log an error we want as much context as possible, including the error itself, the cause chain, and any additional context that can be provided.
+
+* The `log_error` and `as_error` macros help standardize how we report errors as ERROR events.
+  See the `o11y` module for details
+
+* Some errors occur more than once in a given function.
+  `log_error`/`as_error` can be used to give each occurrence a unique event callsite and therefore a clear origin when logged, e.g., `foo().inspect_err(as_error!("an optional message for additional context"))?;`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Boom
+
+## Tests
+
+We are currently working on adding tests to the codebase. You can run the tests with:
+```bash
+cargo test
+```
+
+Tests currently require the kafka, valkey, and mongo Docker containers to be running as described above.
+
+*When running the tests, the config file found in `tests/config.test.yaml` will be used.*
+
+The test suite also runs automagically on every push to the repository, and on every pull request.
+You can check the status of the tests in the "Actions" tab of the GitHub repository.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,12 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "apache-avro"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,7 +481,6 @@ dependencies = [
 name = "boom"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "apache-avro",
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,8 +1353,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2134,6 +2134,15 @@ dependencies = [
  "macro_magic_core",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2850,8 +2859,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2862,7 +2880,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2870,6 +2888,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3867,10 +3891,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0.138"
 thiserror = "2.0.11"
 tokio = { version = "1.43.1", features = ["full"] }
 tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "registry"]}
 uuid = { version = "1.12", features = ["v4"] }
 flate2 = "1.1.0"
 anyhow = "1.0.96"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "registry"]}
 uuid = { version = "1.12", features = ["v4"] }
 flate2 = "1.1.0"
-anyhow = "1.0.96"
 reqwest = { version = "0.12.12", features = ["json"] }
 async-trait = "0.1.87"
 serde_with = "3.12.0"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ When you stop the scheduler, it will attempt to gracefully stop all the workers 
 
 **In the next version of the README, we'll provide the user with example scripts to read the output of BOOM (i.e. the alerts that passed the filters) from `Kafka` topics. For now, alerts are send back to `Redis`/`valkey` if they pass any filters.**
 
+## Logging
+
+The logging level is controlled with the `RUST_LOG` environment variable, which can be set to either "trace", "debug", "info", "warn", "error", or "off". For example, to see DEBUG messages, set `RUST_LOG=debug`. The default logging level is INFO.
+
+`RUST_LOG` supports more advanced directives described in the [`tracing_subscriber` docs](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html). A particularly useful feature is setting the level for different crates. This makes it possible to disable events from external crates like `ort` that would otherwise be mixed in with those from boom, e.g., `RUST_LOG=info,ort=off`.
+
+Span events can be added to the log by setting the `RUST_LOG_SPAN_EVENTS` environment variable to one or more of the following [span lifecycle options](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Layer.html#method.with_span_events): "new", "enter", "exit", "close", "active", "full", or "none", where multiple values are separated by a comma. For example, to see events for when spans open and close, set `RUST_LOG_SPAN_EVENTS=new,close`. "close" is notable because it creates events with execution time information, which may be useful for profiling.
+
+As a more complete example, the following sets the logging level to DEBUG, disables logs from the `ort` crate, and enables "new" and "close" span events while running the scheduler:
+
+```bash
+RUST_LOG=debug,ort=off RUST_LOG_SPAN_EVENTS=new,close cargo run --bin scheduler -- ZTF
+```
+
 ## Tests
 
 We are currently working on adding tests to the codebase. You can run the tests with:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ BOOM runs on macOS and Linux. You'll need:
 
 - `Docker` and `docker compose`: used to run the database, cache/task queue, and `Kafka`;
 - `Rust` (a systems programming language) `>= 1.55.0`;
-- `Python` (a high-level programming language) `>= 3.10`: we recommend using `uv` to create a virtual environment with the required Python dependencies.
 - `wget` and `tar`: used to download and extract the ZTF alerts for testing purposes.
 - If you're on Windows, you must use WSL2 (Windows Subsystem for Linux) and install a Linux distribution like Ubuntu 24.04.
 
@@ -28,7 +27,6 @@ BOOM runs on macOS and Linux. You'll need:
 
 - Docker: On macOS we recommend using [Docker Desktop](https://www.docker.com/products/docker-desktop) to install docker. You can download it from the website, and follow the installation instructions. The website will ask you to "choose a plan", but really you just need to create an account and stick with the free tier that offers all of the features you will ever need. Once installed, you can verify the installation by running `docker --version` in your terminal, and `docker compose version` to check that docker compose is installed as well.
 - Rust: You can either use [rustup](https://www.rust-lang.org/tools/install) to install Rust, or you can use [Homebrew](https://brew.sh/) to install it. If you choose the latter, you can run `brew install rust` in your terminal. We recommend using rustup, as it allows you to easily switch between different versions of Rust, and to keep your Rust installation up to date. Once installed, you can verify the installation by running `rustc --version` in your terminal. You also want to make sure that cargo is installed, which is the Rust package manager. You can verify this by running `cargo --version` in your terminal.
-- Python: We strongly recommend using [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage your python installation and virtual environments. You can install it with `brew`, `pip`, or using the [install script](https://docs.astral.sh/uv/getting-started/installation/#install-script). We recommend the later. Once installed, you can verify the installation by running `uv --version` in your terminal.
 - `wget` and `tar`: `tar` is already installed on macOS, but you can install `wget` with `brew install wget` or any other package manager you prefer.
 - System packages are essential for compiling and linking some Rust crates that require native libraries like OpenSSL and SASL. Run the following to install necessary system packages:
   ```bash
@@ -40,7 +38,6 @@ BOOM runs on macOS and Linux. You'll need:
 
 - Docker: You can either install Docker Desktop (same instructions as for macOS), or you can just install Docker Engine. The latter is more lightweight. You can follow the [official installation instructions](https://docs.docker.com/engine/install/) for your specific Linux distribution. If you only installed Docker Engine, you'll want to also install [docker compose](https://docs.docker.com/compose/install/). Once installed, you can verify the installation by running `docker --version` in your terminal, and `docker compose version` to check that docker compose is installed as well.
 - Rust: You can use [rustup](https://www.rust-lang.org/tools/install) to install Rust. Once installed, you can verify the installation by running `rustc --version` in your terminal. You also want to make sure that cargo is installed, which is the Rust package manager. You can verify this by running `cargo --version` in your terminal.
-- Python: We strongly recommend using [uv](https://docs.astral.sh/uv/getting-started/installation/) to manage your python installation and virtual environments. You can install it with `pip`, or using the [install script](https://docs.astral.sh/uv/getting-started/installation/#install-script). We recommend the later. Once installed, you can verify the installation by running `uv --version` in your terminal.
 - `wget` and `tar`: Most Linux distributions come with `wget` and `tar` pre-installed. If not, you can install them with your package manager.
 - System packages are essential for compiling and linking some Rust crates that require native libraries like OpenSSL and SASL. Run the following to install necessary system packages:
   ```bash
@@ -50,29 +47,21 @@ BOOM runs on macOS and Linux. You'll need:
 
 ## Setup
 
-1. We'll start by creating a python virtual environment to manage our python install and dependencies. Here's how you can do that with `uv`:
-    ```bash
-    uv venv --python 3.10
-    source .venv/bin/activate
-    uv pip install -r requirements.txt
-    ```
-    Note: If requirements.txt is missing, it can be skipped. It's only required for the ML pipeline.
-   
-3. Next, copy the default config file, `config.default.yaml`, to `config.yaml`:
+1. Copy the default config file, `config.default.yaml`, to `config.yaml`:
     ```bash
     cp config.default.yaml config.yaml
     ```
-4. Same for the `docker-compose.yaml` file:
+2. Same for the `docker-compose.yaml` file:
     ```bash
     cp docker-compose.default.yaml docker-compose.yaml
     ```
-5. Launch `Valkey`, `MongoDB`, and `Kafka` using docker, using the provided `docker compose.yaml` file:
+3. Launch `Valkey`, `MongoDB`, and `Kafka` using docker, using the provided `docker compose.yaml` file:
     ```bash
     docker compose up -d
     ```
     This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
     *To check if the containers are running and healthy, run `docker ps`.*
-6. Last but not least, build the Rust binaries. You can do this with or without the `--release` flag, but we recommend using it for better performance:
+4. Last but not least, build the Rust binaries. You can do this with or without the `--release` flag, but we recommend using it for better performance:
     ```bash
     cargo build --release
     ```
@@ -89,7 +78,6 @@ Where `<date_in_YYYMMDD_format>` is the date of the alerts you want to read. We 
 ```bash
 docker exec -it broker /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker:9092 --delete --topic ztf_YYYYMMDD_programid1
 ```
-
 
 Next, you can start the `Kafka` consumer with:
 ```bash
@@ -108,8 +96,6 @@ Instead of starting each worker manually, we provide the `scheduler`. It reads t
 cargo run --release --bin scheduler <stream_name> <config_path>
 ```
 Where `<stream_name>` is the name of the stream you want to process. In our case, it would be `ZTF`. `<config_path>` is the path to the config file, which is `config.yaml` by default, and can be omitted.
-
-*Before running the scheduler, make sure that you are in your Python virtual environment. This is required for the ML worker, that will run Python-based ML models. If you created it with `uv` as instructed earlier, you can enter the virtual environment with `source .venv/bin/activate`.*
 
 The scheduler prints a variety of messages to your terminal, e.g.:
 - At the start you should see a bunch of `Processed alert with candid: <alert_candid>, queueing for classification` messages, which means that the fake alert worker is picking up on the alerts, processed them, and is queueing them for classification.
@@ -174,10 +160,6 @@ We already went through this process for the ZTF Avro schema (so no need to do i
 ### Dealing with Rust structs and MongoDB BSON documents:
 
 We could in theory just query` MongoDB` in a way that allows us to get Rust structs out of it, and also do the same when writing to the database. However under the hood the `mongodb` crate just serializes back and forth, and since Rust structs can't just "remove" their fields that are null (in a way, they need to enforce a schema), we would end up with a lot of null fields in the database. To avoid this, we use the `bson` crate to serialize the Rust structs to BSON documents, sanitize them (remove the null fields and such), and then write them to the database. When querying the DB, both bson documents or Rust structs can be returned, it depends on the use case.
-
-### Why still using Python for some parts of the pipeline?
-
-For everything ML-related, it's not that easy to just take anyone's model (that was 99% of the time trained with a Python library) and just run it in Rust. We could try (and successfully did for a handful of models) converting them to ONNX, and then running them with `tch-rs` (a Rust wrapper around the `libtorch` C++ library). However, this proved to be a pain on a lot of systems. Thanks to the fact that we use something like `Redis`/`Valkey` as a cache/task queue, we can pretty much send data between whatever language we want, and have the ML models run in Python, and the rest of the pipeline run in Rust. It will also come in handy for the filtering pipeline, as we can leverage any of Python's libraries to do some fancy & complex computation that would be a pain for your average astronomer to write in Rust. So for now, we limit the Rust code to all of the "core" parts of the pipeline where performance is key, and use Python where we can affort to lose a bit of performance for more flexibility.
 
 ### Why `Redis`/`Valkey` as a cache/task queue?
 

--- a/README.md
+++ b/README.md
@@ -148,23 +148,9 @@ As a more complete example, the following sets the logging level to DEBUG, disab
 RUST_LOG=debug,ort=off RUST_LOG_SPAN_EVENTS=new,close cargo run --bin scheduler -- ztf
 ```
 
-## Tests
-
-We are currently working on adding tests to the codebase. You can run the tests with:
-```bash
-cargo test
-```
-
-Tests currently require the kafka, valkey, and mongo Docker containers to be running as described above.
-
-*When running the tests, the config file found in `tests/config.test.yaml` will be used.*
-
-The test suite also runs automagically on every push to the repository, and on every pull request.
-You can check the status of the tests in the "Actions" tab of the GitHub repository.
-
 ## Contributing
 
-We welcome contributions! Please read the [CONTRIBUTING.md](CONTRIBUTING.md) (TBD) file for more information. 
+We welcome contributions! Please read the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information. 
 We rely on [GitHub issues](https://github.com/boom-astro/boom/issues) to track bugs and feature requests.
 
 ## Implementation details:

--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -1,7 +1,11 @@
 use crate::utils::worker::WorkerCmd;
 use crate::{
     conf,
-    utils::{db::CreateIndexError, spatial::XmatchError},
+    utils::{
+        db::CreateIndexError,
+        o11y::{DEBUG, INFO},
+        spatial::XmatchError,
+    },
 };
 use apache_avro::Schema;
 use mongodb::bson::Document;
@@ -9,7 +13,7 @@ use redis::AsyncCommands;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, instrument, trace, warn};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SchemaRegistryError {

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -7,7 +7,7 @@ use serde_with::{serde_as, skip_serializing_none};
 use tracing::trace;
 
 use crate::{
-    alert::base::{AlertError, AlertWorker, AlertWorkerError, SchemaRegistry, SchemaRegistryError},
+    alert::base::{AlertError, AlertWorker, AlertWorkerError, SchemaRegistry},
     conf,
     utils::{
         conversions::{flux2mag, fluxerr2diffmaglim, SNT, ZP_AB},

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -1,20 +1,21 @@
+use crate::{
+    alert::base::{AlertError, AlertInsertResult, AlertWorker, AlertWorkerError, SchemaRegistry},
+    conf,
+    utils::{
+        conversions::{flux2mag, fluxerr2diffmaglim, SNT, ZP_AB},
+        db::{cutout2bsonbinary, get_coordinates, mongify},
+        o11y::as_error,
+        spatial::xmatch,
+    },
+};
+
 use apache_avro::{from_avro_datum, from_value};
 use constcat::concat;
 use flare::Time;
 use mongodb::bson::{doc, Document};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
-use tracing::trace;
-
-use crate::{
-    alert::base::{AlertError, AlertWorker, AlertWorkerError, SchemaRegistry},
-    conf,
-    utils::{
-        conversions::{flux2mag, fluxerr2diffmaglim, SNT, ZP_AB},
-        db::{cutout2bsonbinary, get_coordinates, mongify},
-        spatial::xmatch,
-    },
-};
+use tracing::{instrument, warn};
 
 pub const STREAM_NAME: &str = "LSST";
 pub const ALERT_COLLECTION: &str = concat!(STREAM_NAME, "_alerts");
@@ -667,6 +668,7 @@ pub struct LsstAlertWorker {
 }
 
 impl LsstAlertWorker {
+    #[instrument(skip_all, err)]
     pub async fn alert_from_avro_bytes(
         self: &mut Self,
         avro_bytes: &[u8],
@@ -689,18 +691,157 @@ impl LsstAlertWorker {
 
         Ok(alert)
     }
+
+    #[instrument(
+        skip(self, prv_candidates_doc, prv_nondetections_doc, fp_hist_doc, xmatches,),
+        err
+    )]
+    async fn insert_alert_aux(
+        &self,
+        object_id: String,
+        ra: f64,
+        dec: f64,
+        prv_candidates_doc: &Vec<Document>,
+        prv_nondetections_doc: &Vec<Document>,
+        fp_hist_doc: &Vec<Document>,
+        xmatches: Document,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let alert_aux_doc = doc! {
+            "_id": object_id,
+            "prv_candidates": prv_candidates_doc,
+            "prv_nondetections": prv_nondetections_doc,
+            "fp_hists": fp_hist_doc,
+            "cross_matches": xmatches,
+            "created_at": now,
+            "updated_at": now,
+            "coordinates": {
+                "radec_geojson": {
+                    "type": "Point",
+                    "coordinates": [ra - 180.0, dec],
+                },
+            },
+        };
+
+        self.alert_aux_collection
+            .insert_one(alert_aux_doc)
+            .await
+            .map_err(|e| match *e.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
+                _ => e.into(),
+            })?;
+        Ok(())
+    }
+
+    #[instrument(skip(self, ra, dec, candidate_doc, now), err)]
+    async fn format_and_insert_alert(
+        &self,
+        candid: i64,
+        object_id: &str,
+        ra: f64,
+        dec: f64,
+        candidate_doc: &Document,
+        now: f64,
+    ) -> Result<AlertInsertResult, AlertError> {
+        let alert_doc = doc! {
+            "_id": candid,
+            "objectId": object_id,
+            "candidate": candidate_doc,
+            "coordinates": get_coordinates(ra, dec),
+            "created_at": now,
+            "updated_at": now,
+        };
+
+        let insert_result = self
+            .alert_collection
+            .insert_one(alert_doc)
+            .await
+            .map(|_| AlertInsertResult::Inserted)
+            .or_else(|error| match *error.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => Ok(AlertInsertResult::AlreadyExists),
+                _ => Err(error),
+            })?;
+        Ok(insert_result)
+    }
+
+    #[instrument(skip(self, cutout_science, cutout_template, cutout_difference), err)]
+    async fn format_and_insert_cutout(
+        &self,
+        candid: i64,
+        cutout_science: Option<Vec<u8>>,
+        cutout_template: Option<Vec<u8>>,
+        cutout_difference: Option<Vec<u8>>,
+    ) -> Result<(), AlertError> {
+        let cutout_doc = doc! {
+            "_id": &candid,
+            "cutoutScience": cutout2bsonbinary(cutout_science.ok_or(AlertError::MissingCutout).inspect_err(as_error!())?),
+            "cutoutTemplate": cutout2bsonbinary(cutout_template.ok_or(AlertError::MissingCutout).inspect_err(as_error!())?),
+            "cutoutDifference": cutout2bsonbinary(cutout_difference.ok_or(AlertError::MissingCutout).inspect_err(as_error!())?),
+        };
+
+        self.alert_cutout_collection.insert_one(cutout_doc).await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), err)]
+    async fn check_alert_aux_exists(&self, object_id: &str) -> Result<bool, AlertError> {
+        let alert_aux_exists = self
+            .alert_aux_collection
+            .count_documents(doc! { "_id": object_id })
+            .await?
+            > 0;
+        Ok(alert_aux_exists)
+    }
+
+    #[instrument(skip_all)]
+    fn format_prv_candidates_and_fp_hist(
+        &self,
+        prv_candidates: Option<Vec<Candidate>>,
+        candidate_doc: Document,
+        fp_hist: Option<Vec<ForcedPhot>>,
+        prv_nondetections: Option<Vec<NonDetection>>,
+    ) -> (Vec<Document>, Vec<Document>, Vec<Document>) {
+        let mut prv_candidates_doc = prv_candidates
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(|x| mongify(&x))
+            .collect::<Vec<_>>();
+        prv_candidates_doc.push(candidate_doc);
+
+        let fp_hist_doc = fp_hist
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(|x| mongify(&x))
+            .collect::<Vec<_>>();
+
+        let prv_nondetections_doc = prv_nondetections
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(|x| mongify(&x))
+            .collect::<Vec<_>>();
+        (prv_candidates_doc, prv_nondetections_doc, fp_hist_doc)
+    }
 }
 
 #[async_trait::async_trait]
 impl AlertWorker for LsstAlertWorker {
     type ObjectId = i64;
 
+    #[instrument(err)]
     async fn new(config_path: &str) -> Result<LsstAlertWorker, AlertWorkerError> {
-        let config_file = conf::load_config(&config_path)?;
+        let config_file =
+            conf::load_config(&config_path).inspect_err(as_error!("failed to load config"))?;
 
-        let xmatch_configs = conf::build_xmatch_configs(&config_file, "LSST")?;
+        let xmatch_configs = conf::build_xmatch_configs(&config_file, STREAM_NAME)
+            .inspect_err(as_error!("failed to load xmatch config"))?;
 
-        let db: mongodb::Database = conf::build_db(&config_file).await?;
+        let db: mongodb::Database = conf::build_db(&config_file)
+            .await
+            .inspect_err(as_error!("failed to create mongo client"))?;
 
         let alert_collection = db.collection(&ALERT_COLLECTION);
         let alert_aux_collection = db.collection(&ALERT_AUX_COLLECTION);
@@ -730,6 +871,18 @@ impl AlertWorker for LsstAlertWorker {
         format!("{}_alerts_filter_queue", self.stream_name)
     }
 
+    #[instrument(
+        skip(
+            self,
+            ra,
+            dec,
+            prv_candidates_doc,
+            prv_nondetections_doc,
+            fp_hist_doc,
+            _survey_matches
+        ),
+        err
+    )]
     async fn insert_aux(
         self: &mut Self,
         object_id: &str,
@@ -741,42 +894,31 @@ impl AlertWorker for LsstAlertWorker {
         _survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let start = std::time::Instant::now();
         let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await?;
-        trace!("Xmatch took: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-        let alert_aux_doc = doc! {
-            "_id": object_id,
-            "prv_candidates": prv_candidates_doc,
-            "prv_nondetections": prv_nondetections_doc,
-            "fp_hists": fp_hist_doc,
-            "cross_matches": xmatches,
-            "created_at": now,
-            "updated_at": now,
-            "coordinates": {
-                "radec_geojson": {
-                    "type": "Point",
-                    "coordinates": [ra - 180.0, dec],
-                },
-            },
-        };
-
-        self.alert_aux_collection
-            .insert_one(alert_aux_doc)
-            .await
-            .map_err(|e| match *e.kind {
-                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
-                    write_error,
-                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
-                _ => e.into(),
-            })?;
-
-        trace!("Inserting alert_aux: {:?}", start.elapsed());
-
+        self.insert_alert_aux(
+            object_id.into(),
+            ra,
+            dec,
+            prv_candidates_doc,
+            prv_nondetections_doc,
+            fp_hist_doc,
+            xmatches,
+            now,
+        )
+        .await?;
         Ok(())
     }
 
+    #[instrument(
+        skip(
+            self,
+            prv_candidates_doc,
+            prv_nondetections_doc,
+            fp_hist_doc,
+            _survey_matches
+        ),
+        err
+    )]
     async fn update_aux(
         self: &mut Self,
         object_id: &str,
@@ -786,8 +928,6 @@ impl AlertWorker for LsstAlertWorker {
         _survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let start = std::time::Instant::now();
-
         let update_doc = doc! {
             "$addToSet": {
                 "prv_candidates": { "$each": prv_candidates_doc },
@@ -798,22 +938,19 @@ impl AlertWorker for LsstAlertWorker {
                 "updated_at": now,
             }
         };
-
         self.alert_aux_collection
             .update_one(doc! { "_id": object_id }, update_doc)
             .await?;
-
-        trace!("Updating alert_aux: {:?}", start.elapsed());
-
         Ok(())
     }
 
+    #[instrument(skip_all, err)]
     async fn process_alert(self: &mut Self, avro_bytes: &[u8]) -> Result<i64, AlertError> {
         let now = Time::now().to_jd();
-
-        let mut alert = self.alert_from_avro_bytes(avro_bytes).await?;
-
-        let start = std::time::Instant::now();
+        let mut alert = self
+            .alert_from_avro_bytes(avro_bytes)
+            .await
+            .inspect_err(as_error!())?;
 
         let prv_candidates = alert.prv_candidates.take();
         let fp_hist = alert.fp_hists.take();
@@ -831,72 +968,38 @@ impl AlertWorker for LsstAlertWorker {
 
         let candidate_doc = mongify(&alert.candidate);
 
-        let alert_doc = doc! {
-            "_id": &candid,
-            "objectId": &object_id,
-            "candidate": &candidate_doc,
-            "coordinates": get_coordinates(ra, dec),
-            "created_at": now,
-            "updated_at": now,
-        };
-
-        self.alert_collection
-            .insert_one(alert_doc)
+        let insert_result = self
+            .format_and_insert_alert(candid, &object_id, ra, dec, &candidate_doc, now)
             .await
-            .map_err(|e| match *e.kind {
-                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
-                    write_error,
-                )) if write_error.code == 11000 => AlertError::AlertExists,
-                _ => e.into(),
-            })?;
+            .inspect_err(as_error!())?;
+        match insert_result {
+            AlertInsertResult::AlreadyExists => {
+                warn!(?candid, ?object_id, "alert already exists, skipping?");
+                return Ok(candid);
+            }
+            _ => (),
+        }
 
-        trace!("Formatting & Inserting alert: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-
-        let cutout_doc = doc! {
-            "_id": &candid,
-            "cutoutScience": cutout2bsonbinary(alert.cutout_science.ok_or(AlertError::MissingCutout)?),
-            "cutoutTemplate": cutout2bsonbinary(alert.cutout_template.ok_or(AlertError::MissingCutout)?),
-            "cutoutDifference": cutout2bsonbinary(alert.cutout_difference.ok_or(AlertError::MissingCutout)?),
-        };
-
-        self.alert_cutout_collection.insert_one(cutout_doc).await?;
-
-        trace!("Formatting & Inserting cutout: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-
+        self.format_and_insert_cutout(
+            candid,
+            alert.cutout_science,
+            alert.cutout_template,
+            alert.cutout_difference,
+        )
+        .await
+        .inspect_err(as_error!())?;
         let alert_aux_exists = self
-            .alert_aux_collection
-            .count_documents(doc! { "_id": &object_id })
-            .await?
-            > 0;
+            .check_alert_aux_exists(&object_id)
+            .await
+            .inspect_err(as_error!())?;
 
-        trace!("Checking if alert_aux exists: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-
-        let mut prv_candidates_doc = prv_candidates
-            .unwrap_or(vec![])
-            .into_iter()
-            .map(|x| Ok(mongify(&x)))
-            .collect::<Result<Vec<_>, AlertError>>()?;
-        prv_candidates_doc.push(candidate_doc);
-
-        let fp_hist_doc = fp_hist
-            .unwrap_or(vec![])
-            .into_iter()
-            .map(|x| Ok(mongify(&x)))
-            .collect::<Result<Vec<_>, AlertError>>()?;
-
-        let prv_nondetections_doc = prv_nondetections
-            .unwrap_or(vec![])
-            .into_iter()
-            .map(|x| Ok(mongify(&x)))
-            .collect::<Result<Vec<_>, AlertError>>()?;
-
-        trace!("Formatting prv_candidates & fp_hist: {:?}", start.elapsed());
+        let (prv_candidates_doc, prv_nondetections_doc, fp_hist_doc) = self
+            .format_prv_candidates_and_fp_hist(
+                prv_candidates,
+                candidate_doc,
+                fp_hist,
+                prv_nondetections,
+            );
 
         if !alert_aux_exists {
             let result = self
@@ -920,9 +1023,10 @@ impl AlertWorker for LsstAlertWorker {
                     &None,
                     now,
                 )
-                .await?;
+                .await
+                .inspect_err(as_error!())?;
             } else {
-                result?;
+                result.inspect_err(as_error!())?;
             }
         } else {
             self.update_aux(
@@ -933,7 +1037,8 @@ impl AlertWorker for LsstAlertWorker {
                 &None,
                 now,
             )
-            .await?;
+            .await
+            .inspect_err(as_error!())?;
         }
 
         Ok(candid)

--- a/src/alert/mod.rs
+++ b/src/alert/mod.rs
@@ -1,11 +1,9 @@
 mod base;
 mod lsst;
 mod ztf;
-pub use base::run_alert_worker;
-pub use base::AlertError;
-pub use base::AlertWorker;
-pub use base::AlertWorkerError;
-pub use base::SchemaRegistry;
-pub use base::SchemaRegistryError;
+pub use base::{
+    run_alert_worker, AlertError, AlertWorker, AlertWorkerError, ProcessAlertStatus,
+    SchemaRegistry, SchemaRegistryError,
+};
 pub use lsst::{LsstAlertWorker, LSST_SCHEMA_REGISTRY_URL};
 pub use ztf::{ZtfAlertWorker, LSST_DEC_LIMIT, LSST_XMATCH_RADIUS};

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -1,6 +1,6 @@
 use crate::{
     alert::{
-        base::{AlertError, AlertWorker, AlertWorkerError, SchemaRegistryError},
+        base::{AlertError, AlertInsertResult, AlertWorker, AlertWorkerError, SchemaRegistryError},
         lsst,
     },
     conf,
@@ -451,11 +451,6 @@ where
     Ok(cutout.map(|cutout| cutout.stamp_data))
 }
 
-enum AlertInsertResult {
-    Inserted,
-    AlreadyExists,
-}
-
 pub struct ZtfAlertWorker {
     stream_name: String,
     xmatch_configs: Vec<conf::CatalogXmatchConfig>,
@@ -516,6 +511,7 @@ impl ZtfAlertWorker {
         Ok(alert)
     }
 
+    #[instrument(skip_all, err)]
     async fn get_lsst_matches(&self, ra: f64, dec: f64) -> Result<Vec<String>, AlertError> {
         let lsst_matches = if dec <= LSST_DEC_LIMIT as f64 {
             let result = self
@@ -751,6 +747,8 @@ impl AlertWorker for ZtfAlertWorker {
     #[instrument(
         skip(
             self,
+            ra,
+            dec,
             prv_candidates_doc,
             prv_nondetections_doc,
             fp_hist_doc,

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -1,6 +1,8 @@
 use crate::{
     alert::{
-        base::{AlertError, AlertInsertResult, AlertWorker, AlertWorkerError, SchemaRegistryError},
+        base::{
+            AlertError, AlertWorker, AlertWorkerError, ProcessAlertStatus, SchemaRegistryError,
+        },
         lsst,
     },
     conf,
@@ -613,7 +615,7 @@ impl ZtfAlertWorker {
         dec: f64,
         candidate_doc: &Document,
         now: f64,
-    ) -> Result<AlertInsertResult, AlertError> {
+    ) -> Result<ProcessAlertStatus, AlertError> {
         let alert_doc = doc! {
             "_id": candid,
             "objectId": object_id,
@@ -623,18 +625,18 @@ impl ZtfAlertWorker {
             "updated_at": now,
         };
 
-        let insert_result = self
+        let status = self
             .alert_collection
             .insert_one(alert_doc)
             .await
-            .map(|_| AlertInsertResult::Inserted)
+            .map(|_| ProcessAlertStatus::Added(candid))
             .or_else(|error| match *error.kind {
                 mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
                     write_error,
-                )) if write_error.code == 11000 => Ok(AlertInsertResult::AlreadyExists),
+                )) if write_error.code == 11000 => Ok(ProcessAlertStatus::Exists(candid)),
                 _ => Err(error),
             })?;
-        Ok(insert_result)
+        Ok(status)
     }
 
     #[instrument(skip(self, cutout_science, cutout_template, cutout_difference), err)]
@@ -820,7 +822,10 @@ impl AlertWorker for ZtfAlertWorker {
     }
 
     #[instrument(skip_all, err)]
-    async fn process_alert(self: &mut Self, avro_bytes: &[u8]) -> Result<i64, AlertError> {
+    async fn process_alert(
+        self: &mut Self,
+        avro_bytes: &[u8],
+    ) -> Result<ProcessAlertStatus, AlertError> {
         let now = Time::now().to_jd();
         let mut alert = self
             .alert_from_avro_bytes(avro_bytes)
@@ -837,16 +842,12 @@ impl AlertWorker for ZtfAlertWorker {
 
         let candidate_doc = mongify(&alert.candidate);
 
-        let insert_result = self
+        let status = self
             .format_and_insert_alert(candid, &object_id, ra, dec, &candidate_doc, now)
             .await
             .inspect_err(as_error!())?;
-        match insert_result {
-            AlertInsertResult::AlreadyExists => {
-                warn!(?candid, ?object_id, "alert already exists, skipping");
-                return Ok(candid);
-            }
-            _ => (),
+        if let ProcessAlertStatus::Exists(_) = status {
+            return Ok(status);
         }
 
         self.format_and_insert_cutout(
@@ -911,6 +912,6 @@ impl AlertWorker for ZtfAlertWorker {
             .inspect_err(as_error!())?;
         }
 
-        Ok(candid)
+        Ok(status)
     }
 }

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -7,6 +7,7 @@ use crate::{
     utils::{
         conversions::{flux2mag, fluxerr2diffmaglim, SNT},
         db::{cutout2bsonbinary, get_coordinates, mongify},
+        o11y::{as_error, log_error, DEBUG, WARN},
         spatial::xmatch,
     },
 };
@@ -14,11 +15,11 @@ use apache_avro::from_value;
 use apache_avro::{from_avro_datum, Reader, Schema};
 use constcat::concat;
 use flare::Time;
-use mongodb::bson::{doc, Document};
+use mongodb::bson::{doc, oid::ObjectId, Document};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
-use std::io::Read;
-use tracing::{error, trace};
+use std::{fmt::Debug, io::Read};
+use tracing::{error, instrument, trace};
 
 pub const STREAM_NAME: &str = "ZTF";
 pub const ALERT_COLLECTION: &str = concat!(STREAM_NAME, "_alerts");
@@ -28,6 +29,7 @@ pub const ALERT_CUTOUT_COLLECTION: &str = concat!(STREAM_NAME, "_alerts_cutouts"
 pub const LSST_DEC_LIMIT: f64 = 33.5;
 pub const LSST_XMATCH_RADIUS: f64 = (2.0_f64 / 3600.0_f64).to_radians(); // 2 arcseconds in radians
 
+#[instrument(level = DEBUG, skip_all, err)]
 fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, SchemaRegistryError> {
     let mut i = 0u64;
     let mut buf = [0u8; 1];
@@ -50,6 +52,7 @@ fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, SchemaRegistryError> 
     Ok(i)
 }
 
+#[instrument(level = DEBUG, skip_all, err)]
 pub fn zag_i64<R: Read>(reader: &mut R) -> Result<i64, SchemaRegistryError> {
     let z = decode_variable(reader)?;
     if z & 0x1 == 0 {
@@ -59,14 +62,16 @@ pub fn zag_i64<R: Read>(reader: &mut R) -> Result<i64, SchemaRegistryError> {
     }
 }
 
+#[instrument(level = DEBUG, skip_all, err)]
 fn decode_long<R: Read>(reader: &mut R) -> Result<i64, SchemaRegistryError> {
     Ok(zag_i64(reader)?)
 }
 
+#[instrument(level = DEBUG, skip_all, err)]
 pub fn get_schema_and_startidx(avro_bytes: &[u8]) -> Result<(Schema, usize), SchemaRegistryError> {
     // First, we extract the schema from the avro bytes
     let cursor = std::io::Cursor::new(avro_bytes);
-    let reader = Reader::new(cursor)?;
+    let reader = Reader::new(cursor).inspect_err(as_error!())?;
     let schema = reader.writer_schema();
 
     // Then, we look for the index of the start of the data
@@ -76,27 +81,27 @@ pub fn get_schema_and_startidx(avro_bytes: &[u8]) -> Result<(Schema, usize), Sch
 
     // Four bytes, ASCII 'O', 'b', 'j', followed by 1
     let mut buf = [0; 4];
-    cursor.read_exact(&mut buf)?;
+    cursor.read_exact(&mut buf).inspect_err(as_error!())?;
     if buf != [b'O', b'b', b'j', 1u8] {
         return Err(SchemaRegistryError::MagicBytesError);
     }
 
     // Then there is the file metadata, including the schema
     let meta_schema = Schema::map(Schema::Bytes);
-    from_avro_datum(&meta_schema, &mut cursor, None)?;
+    from_avro_datum(&meta_schema, &mut cursor, None).inspect_err(as_error!())?;
 
     // Then the 16-byte, randomly-generated sync marker for this file.
     let mut buf = [0; 16];
-    cursor.read_exact(&mut buf)?;
+    cursor.read_exact(&mut buf).inspect_err(as_error!())?;
 
     // each avro record is preceded by:
     // 1. a variable-length integer, the number of records in the block
     // 2. a variable-length integer, the number of bytes in the block
-    let nb_records = decode_long(&mut cursor)?;
+    let nb_records = decode_long(&mut cursor).inspect_err(as_error!())?;
     if nb_records != 1 {
         return Err(SchemaRegistryError::InvalidRecordCount(nb_records as usize));
     }
-    let _ = decode_long(&mut cursor)?;
+    let _ = decode_long(&mut cursor).inspect_err(as_error!())?;
 
     // we now have the start index of the data
     let start_idx = cursor.position();
@@ -459,6 +464,7 @@ pub struct ZtfAlertWorker {
 }
 
 impl ZtfAlertWorker {
+    #[instrument(level = DEBUG, skip_all, err)]
     pub async fn alert_from_avro_bytes(
         self: &mut Self,
         avro_bytes: &[u8],
@@ -467,7 +473,8 @@ impl ZtfAlertWorker {
         let (schema_ref, start_idx) = match (self.cached_schema.as_ref(), self.cached_start_idx) {
             (Some(schema), Some(start_idx)) => (schema, start_idx),
             _ => {
-                let (schema, startidx) = get_schema_and_startidx(avro_bytes)?;
+                let (schema, startidx) =
+                    get_schema_and_startidx(avro_bytes).inspect_err(as_error!())?;
                 self.cached_schema = Some(schema);
                 self.cached_start_idx = Some(startidx);
                 (self.cached_schema.as_ref().unwrap(), startidx)
@@ -480,24 +487,31 @@ impl ZtfAlertWorker {
         // as it could be that the schema has changed
         let value = match value {
             Ok(value) => value,
-            Err(e) => {
-                error!("Error deserializing avro message with cached schema: {}", e);
-                let (schema, startidx) = get_schema_and_startidx(avro_bytes)?;
+            Err(error) => {
+                log_error!(
+                    WARN,
+                    error,
+                    "Error deserializing avro message with cached schema"
+                );
+                let (schema, startidx) =
+                    get_schema_and_startidx(avro_bytes).inspect_err(as_error!())?;
 
                 // if it's not an error this time, cache the new schema
                 // otherwise return the error
-                let value = from_avro_datum(&schema, &mut &avro_bytes[startidx..], None)?;
+                let value = from_avro_datum(&schema, &mut &avro_bytes[startidx..], None)
+                    .inspect_err(as_error!())?;
                 self.cached_schema = Some(schema);
                 self.cached_start_idx = Some(startidx);
                 value
             }
         };
 
-        let alert: ZtfAlert = from_value::<ZtfAlert>(&value)?;
+        let alert: ZtfAlert = from_value::<ZtfAlert>(&value).inspect_err(as_error!())?;
 
         Ok(alert)
     }
 
+    #[instrument(level = DEBUG, skip(self), err)]
     async fn get_lsst_matches(&self, ra: f64, dec: f64) -> Result<Vec<i64>, AlertError> {
         let lsst_matches = if dec <= LSST_DEC_LIMIT as f64 {
             let result = self
@@ -518,8 +532,8 @@ impl ZtfAlertWorker {
                     vec![object_id]
                 }
                 Ok(None) => vec![],
-                Err(e) => {
-                    error!("Error cross-matching with LSST: {}", e);
+                Err(error) => {
+                    log_error!(WARN, error, "error cross-matching with LSST");
                     vec![]
                 }
             }
@@ -529,6 +543,7 @@ impl ZtfAlertWorker {
         Ok(lsst_matches)
     }
 
+    #[instrument(level = DEBUG, skip(self), err)]
     async fn get_survey_matches(&self, ra: f64, dec: f64) -> Result<Document, AlertError> {
         let lsst_matches = self.get_lsst_matches(ra, dec).await?;
 
@@ -536,18 +551,155 @@ impl ZtfAlertWorker {
             "LSST": lsst_matches,
         })
     }
+
+    #[instrument(level = DEBUG, err, skip(
+        self, prv_candidates_doc, prv_nondetections_doc, fp_hist_doc, xmatches, survey_matches
+    ))]
+    async fn insert_alert_aux(
+        &self,
+        object_id: String,
+        ra: f64,
+        dec: f64,
+        prv_candidates_doc: &Vec<Document>,
+        prv_nondetections_doc: &Vec<Document>,
+        fp_hist_doc: &Vec<Document>,
+        xmatches: Document,
+        survey_matches: &Option<Document>,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let alert_aux_doc = doc! {
+            "_id": object_id,
+            "prv_candidates": prv_candidates_doc,
+            "prv_nondetections": prv_nondetections_doc,
+            "fp_hists": fp_hist_doc,
+            "cross_matches": xmatches,
+            "aliases": survey_matches,
+            "created_at": now,
+            "updated_at": now,
+            "coordinates": {
+                "radec_geojson": {
+                    "type": "Point",
+                    "coordinates": [ra - 180.0, dec],
+                },
+            },
+        };
+
+        self.alert_aux_collection
+            .insert_one(alert_aux_doc)
+            .await
+            .map_err(|e| match *e.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
+                _ => e.into(),
+            })?;
+        Ok(())
+    }
+
+    #[instrument(level = DEBUG, skip(self, candidate_doc), err)]
+    async fn format_and_insert_alert(
+        &self,
+        candid: i64,
+        object_id: &str,
+        ra: f64,
+        dec: f64,
+        candidate_doc: &Document,
+        now: f64,
+    ) -> Result<(), AlertError> {
+        let alert_doc = doc! {
+            "_id": candid,
+            "objectId": object_id,
+            "candidate": candidate_doc,
+            "coordinates": get_coordinates(ra, dec),
+            "created_at": now,
+            "updated_at": now,
+        };
+
+        self.alert_collection
+            .insert_one(alert_doc)
+            .await
+            .map_err(|e| match *e.kind {
+                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
+                    write_error,
+                )) if write_error.code == 11000 => AlertError::AlertExists,
+                _ => e.into(),
+            })?;
+        Ok(())
+    }
+
+    #[instrument(level = DEBUG, skip(self, cutout_science, cutout_template, cutout_difference), err)]
+    async fn format_and_insert_cutout(
+        &self,
+        candid: i64,
+        cutout_science: Option<Vec<u8>>,
+        cutout_template: Option<Vec<u8>>,
+        cutout_difference: Option<Vec<u8>>,
+    ) -> Result<(), AlertError> {
+        let cutout_doc = doc! {
+            "_id": &candid,
+            "cutoutScience": cutout2bsonbinary(cutout_science.ok_or(AlertError::MissingCutout).inspect_err(as_error!())?),
+            "cutoutTemplate": cutout2bsonbinary(cutout_template.ok_or(AlertError::MissingCutout).inspect_err(as_error!())?),
+            "cutoutDifference": cutout2bsonbinary(cutout_difference.ok_or(AlertError::MissingCutout).inspect_err(as_error!())?),
+        };
+
+        self.alert_cutout_collection.insert_one(cutout_doc).await?;
+        Ok(())
+    }
+
+    #[instrument(level = DEBUG, skip(self), err)]
+    async fn check_alert_aux_exists(&self, object_id: &str) -> Result<bool, AlertError> {
+        let alert_aux_exists = self
+            .alert_aux_collection
+            .count_documents(doc! { "_id": object_id })
+            .await?
+            > 0;
+        Ok(alert_aux_exists)
+    }
+
+    #[instrument(level = DEBUG, skip_all)]
+    fn format_prv_candidates_and_fp_hist(
+        &self,
+        prv_candidates: Option<Vec<PrvCandidate>>,
+        candidate_doc: Document,
+        fp_hist: Option<Vec<ForcedPhot>>,
+    ) -> (Vec<Document>, Vec<Document>, Vec<Document>) {
+        // we split the prv_candidates into detections and non-detections
+        let mut prv_candidates_doc = vec![];
+        let mut prv_nondetections_doc = vec![];
+
+        for prv_candidate in prv_candidates.unwrap_or(vec![]) {
+            if prv_candidate.magpsf.is_some() {
+                prv_candidates_doc.push(mongify(&prv_candidate));
+            } else {
+                prv_nondetections_doc.push(mongify(&prv_candidate));
+            }
+        }
+        prv_candidates_doc.push(candidate_doc);
+
+        let fp_hist_doc = fp_hist
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(|x| mongify(&x))
+            .collect::<Vec<_>>();
+        (prv_candidates_doc, prv_nondetections_doc, fp_hist_doc)
+    }
 }
 
 #[async_trait::async_trait]
 impl AlertWorker for ZtfAlertWorker {
     type ObjectId = String;
 
+    #[instrument(level = DEBUG, err)]
     async fn new(config_path: &str) -> Result<ZtfAlertWorker, AlertWorkerError> {
-        let config_file = conf::load_config(&config_path)?;
+        let config_file =
+            conf::load_config(&config_path).inspect_err(as_error!("failed to load config"))?;
 
-        let xmatch_configs = conf::build_xmatch_configs(&config_file, STREAM_NAME)?;
+        let xmatch_configs = conf::build_xmatch_configs(&config_file, STREAM_NAME)
+            .inspect_err(as_error!("failed to load xmatch config"))?;
 
-        let db: mongodb::Database = conf::build_db(&config_file).await?;
+        let db: mongodb::Database = conf::build_db(&config_file)
+            .await
+            .inspect_err(as_error!("failed to create mongo client"))?;
 
         let alert_collection = db.collection(&ALERT_COLLECTION);
         let alert_aux_collection = db.collection(&ALERT_AUX_COLLECTION);
@@ -582,9 +734,10 @@ impl AlertWorker for ZtfAlertWorker {
         format!("{}_alerts_classifier_queue", self.stream_name)
     }
 
+    #[instrument(level = DEBUG, skip(self, prv_candidates_doc, prv_nondetections_doc, fp_hist_doc, survey_matches), err)]
     async fn insert_aux(
         self: &mut Self,
-        object_id: impl Into<Self::ObjectId> + Send,
+        object_id: impl Into<Self::ObjectId> + Send + Debug,
         ra: f64,
         dec: f64,
         prv_candidates_doc: &Vec<Document>,
@@ -593,54 +746,32 @@ impl AlertWorker for ZtfAlertWorker {
         survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let start = std::time::Instant::now();
         let xmatches = xmatch(ra, dec, &self.xmatch_configs, &self.db).await?;
-        trace!("Xmatch took: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-        let alert_aux_doc = doc! {
-            "_id": object_id.into(),
-            "prv_candidates": prv_candidates_doc,
-            "prv_nondetections": prv_nondetections_doc,
-            "fp_hists": fp_hist_doc,
-            "cross_matches": xmatches,
-            "aliases": survey_matches,
-            "created_at": now,
-            "updated_at": now,
-            "coordinates": {
-                "radec_geojson": {
-                    "type": "Point",
-                    "coordinates": [ra - 180.0, dec],
-                },
-            },
-        };
-
-        self.alert_aux_collection
-            .insert_one(alert_aux_doc)
-            .await
-            .map_err(|e| match *e.kind {
-                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
-                    write_error,
-                )) if write_error.code == 11000 => AlertError::AlertAuxExists,
-                _ => e.into(),
-            })?;
-
-        trace!("Inserting alert_aux: {:?}", start.elapsed());
-
+        self.insert_alert_aux(
+            object_id.into(),
+            ra,
+            dec,
+            prv_candidates_doc,
+            prv_nondetections_doc,
+            fp_hist_doc,
+            xmatches,
+            survey_matches,
+            now,
+        )
+        .await?;
         Ok(())
     }
 
+    #[instrument(level = DEBUG, skip(self, prv_candidates_doc, prv_nondetections_doc, fp_hist_doc, survey_matches), err)]
     async fn update_aux(
         self: &mut Self,
-        object_id: impl Into<Self::ObjectId> + Send,
+        object_id: impl Into<Self::ObjectId> + Send + Debug,
         prv_candidates_doc: &Vec<Document>,
         prv_nondetections_doc: &Vec<Document>,
         fp_hist_doc: &Vec<Document>,
         survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let start = std::time::Instant::now();
-
         let update_doc = doc! {
             "$addToSet": {
                 "prv_candidates": { "$each": prv_candidates_doc },
@@ -652,26 +783,19 @@ impl AlertWorker for ZtfAlertWorker {
                 "aliases": survey_matches,
             }
         };
-
         self.alert_aux_collection
             .update_one(doc! { "_id": object_id.into() }, update_doc)
             .await?;
-
-        trace!("Updating alert_aux: {:?}", start.elapsed());
-
         Ok(())
     }
 
+    #[instrument(level = DEBUG, skip_all, err)]
     async fn process_alert(self: &mut Self, avro_bytes: &[u8]) -> Result<i64, AlertError> {
         let now = Time::now().to_jd();
-
-        let start = std::time::Instant::now();
-
-        let mut alert = self.alert_from_avro_bytes(avro_bytes).await?;
-
-        trace!("Decoding alert: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
+        let mut alert = self
+            .alert_from_avro_bytes(avro_bytes)
+            .await
+            .inspect_err(as_error!())?;
 
         let prv_candidates = alert.prv_candidates.take();
         let fp_hist = alert.fp_hists.take();
@@ -683,78 +807,29 @@ impl AlertWorker for ZtfAlertWorker {
 
         let candidate_doc = mongify(&alert.candidate);
 
-        let alert_doc = doc! {
-            "_id": &candid,
-            "objectId": &object_id,
-            "candidate": &candidate_doc,
-            "coordinates": get_coordinates(ra, dec),
-            "created_at": now,
-            "updated_at": now,
-        };
-
-        self.alert_collection
-            .insert_one(alert_doc)
+        self.format_and_insert_alert(candid, &object_id, ra, dec, &candidate_doc, now)
             .await
-            .map_err(|e| match *e.kind {
-                mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(
-                    write_error,
-                )) if write_error.code == 11000 => AlertError::AlertExists,
-                _ => e.into(),
-            })?;
-
-        trace!("Formatting & Inserting alert: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-
-        let cutout_doc = doc! {
-            "_id": &candid,
-            "cutoutScience": cutout2bsonbinary(alert.cutout_science.ok_or(AlertError::MissingCutout)?),
-            "cutoutTemplate": cutout2bsonbinary(alert.cutout_template.ok_or(AlertError::MissingCutout)?),
-            "cutoutDifference": cutout2bsonbinary(alert.cutout_difference.ok_or(AlertError::MissingCutout)?),
-        };
-
-        self.alert_cutout_collection.insert_one(cutout_doc).await?;
-
-        trace!("Formatting & Inserting cutout: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-
+            .inspect_err(as_error!())?;
+        self.format_and_insert_cutout(
+            candid,
+            alert.cutout_science,
+            alert.cutout_template,
+            alert.cutout_difference,
+        )
+        .await
+        .inspect_err(as_error!())?;
         let alert_aux_exists = self
-            .alert_aux_collection
-            .count_documents(doc! { "_id": &object_id })
-            .await?
-            > 0;
+            .check_alert_aux_exists(&object_id)
+            .await
+            .inspect_err(as_error!())?;
 
-        trace!("Checking if alert_aux exists: {:?}", start.elapsed());
+        let (prv_candidates_doc, prv_nondetections_doc, fp_hist_doc) =
+            self.format_prv_candidates_and_fp_hist(prv_candidates, candidate_doc, fp_hist);
 
-        let start = std::time::Instant::now();
-
-        // we split the prv_candidates into detections and non-detections
-        let mut prv_candidates_doc = vec![];
-        let mut prv_nondetections_doc = vec![];
-
-        for prv_candidate in prv_candidates.unwrap_or(vec![]) {
-            if prv_candidate.magpsf.is_some() {
-                prv_candidates_doc.push(mongify(&prv_candidate));
-            } else {
-                prv_nondetections_doc.push(mongify(&prv_candidate));
-            }
-        }
-        prv_candidates_doc.push(candidate_doc);
-
-        let fp_hist_doc = fp_hist
-            .unwrap_or(vec![])
-            .into_iter()
-            .map(|x| mongify(&x))
-            .collect::<Vec<_>>();
-
-        trace!("Formatting prv_candidates & fp_hist: {:?}", start.elapsed());
-
-        let start = std::time::Instant::now();
-        let survey_matches = Some(self.get_survey_matches(ra, dec).await?);
-        trace!(
-            "Xmatching ZTF alert with other surveys: {:?}",
-            start.elapsed()
+        let survey_matches = Some(
+            self.get_survey_matches(ra, dec)
+                .await
+                .inspect_err(as_error!())?,
         );
 
         if !alert_aux_exists {
@@ -779,9 +854,10 @@ impl AlertWorker for ZtfAlertWorker {
                     &survey_matches,
                     now,
                 )
-                .await?;
+                .await
+                .inspect_err(as_error!())?;
             } else {
-                result?;
+                result.inspect_err(as_error!())?;
             }
         } else {
             self.update_aux(
@@ -792,7 +868,8 @@ impl AlertWorker for ZtfAlertWorker {
                 &survey_matches,
                 now,
             )
-            .await?;
+            .await
+            .inspect_err(as_error!())?;
         }
 
         Ok(candid)

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -608,7 +608,7 @@ impl ZtfAlertWorker {
     // report it? Maybe it would work for the return type to be a status enum
     // instead of unit, so we would have, e.g., Ok(Success), Ok(AlertExists),
     // and Err(AlertError::...)
-    #[instrument(skip(self, candidate_doc), err)]
+    #[instrument(skip(self, ra, dec, candidate_doc, now), err)]
     async fn format_and_insert_alert(
         &self,
         candid: i64,

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -15,11 +15,11 @@ use apache_avro::from_value;
 use apache_avro::{from_avro_datum, Reader, Schema};
 use constcat::concat;
 use flare::Time;
-use mongodb::bson::{doc, oid::ObjectId, Document};
+use mongodb::bson::{doc, Document};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 use std::{fmt::Debug, io::Read};
-use tracing::{error, instrument, trace};
+use tracing::instrument;
 
 pub const STREAM_NAME: &str = "ZTF";
 pub const ALERT_COLLECTION: &str = concat!(STREAM_NAME, "_alerts");

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -16,8 +16,8 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
 #[derive(Parser)]
 struct Cli {
-    #[arg(required = true, help = "Name of stream to ingest")]
-    stream: Option<String>,
+    #[arg(help = "Name of stream to ingest")]
+    stream: String,
 
     #[arg(long, value_name = "FILE", help = "Path to the configuration file")]
     config: Option<String>,
@@ -42,13 +42,7 @@ async fn main() {
 
     let args = Cli::parse();
 
-    let stream_name = match args.stream {
-        Some(stream) => stream,
-        None => {
-            warn!("No stream name provided");
-            std::process::exit(1);
-        }
-    };
+    let stream_name = args.stream;
     info!("Starting scheduler for {} alert processing", stream_name);
 
     if !args.config.is_some() {

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -48,9 +48,9 @@ async fn run(args: Cli) {
         .await
         .expect("could not initialize indexes");
 
-    // setup signal handler thread
+    // setup signal handler task
     let interrupt = Arc::new(Mutex::new(false));
-    spawn_sigint_handler(Arc::clone(&interrupt)).await;
+    spawn_sigint_handler(Arc::clone(&interrupt));
 
     let alert_pool = ThreadPool::new(
         WorkerType::Alert,

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -81,8 +81,8 @@ async fn run(args: Cli) {
     let filter_pool = ThreadPool::new(
         WorkerType::Filter,
         n_filter as usize,
-        args.survey.clone(),
-        config_path.clone(),
+        args.survey,
+        config_path,
     );
 
     // All that's left is to wait for sigint:

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -3,7 +3,7 @@ use boom::{
     scheduler::{get_num_workers, ThreadPool},
     utils::{
         db::initialize_survey_indexes,
-        o11y::build_subscriber,
+        o11y::{build_subscriber, INFO},
         worker::{check_flag, spawn_sigint_handler, WorkerType},
     },
 };
@@ -13,8 +13,6 @@ use std::{
     thread,
 };
 use tracing::{info, instrument, warn};
-
-const INFO: tracing::Level = tracing::Level::INFO;
 
 #[derive(Parser)]
 struct Cli {

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -90,7 +90,7 @@ async fn run(args: Cli) {
         async {
             loop {
                 info!("heartbeat");
-                tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(60)).await;
             }
         }
         .instrument(info_span!("heartbeat task")),

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -3,7 +3,7 @@ use boom::{
     scheduler::{get_num_workers, ThreadPool},
     utils::{
         db::initialize_survey_indexes,
-        o11y::{build_subscriber, INFO},
+        o11y::build_subscriber,
         worker::{check_flag, spawn_sigint_handler, WorkerType},
     },
 };
@@ -23,7 +23,7 @@ struct Cli {
     config: Option<String>,
 }
 
-#[instrument(level = INFO, skip_all)]
+#[instrument(skip_all)]
 async fn run(args: Cli) {
     let default_config_path = "config.yaml".to_string();
     let config_path = args.config.unwrap_or_else(|| {
@@ -75,8 +75,7 @@ async fn run(args: Cli) {
         info!("heart beat");
         let exit = check_flag(Arc::clone(&interrupt));
         if exit {
-            warn!("killed thread(s)");
-            // TODO: instrument drop and friends
+            info!("shutting down");
             drop(alert_pool);
             drop(ml_pool);
             drop(filter_pool);

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -25,7 +25,7 @@ struct Cli {
     config: Option<String>,
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, fields(survey = %args.survey))]
 async fn run(args: Cli) {
     let default_config_path = "config.yaml".to_string();
     let config_path = args.config.unwrap_or_else(|| {

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -4,7 +4,7 @@ use boom::{
     utils::{
         db::initialize_survey_indexes,
         o11y::build_subscriber,
-        worker::{check_flag, sig_int_handler, WorkerType},
+        worker::{check_flag, spawn_sigint_handler, WorkerType},
     },
 };
 use clap::Parser;
@@ -52,7 +52,7 @@ async fn run(args: Cli) {
 
     // setup signal handler thread
     let interrupt = Arc::new(Mutex::new(false));
-    sig_int_handler(Arc::clone(&interrupt)).await;
+    spawn_sigint_handler(Arc::clone(&interrupt)).await;
 
     let alert_pool = ThreadPool::new(
         WorkerType::Alert,

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -75,8 +75,8 @@ async fn run(args: Cli) {
         info!("heart beat");
         let exit = check_flag(Arc::clone(&interrupt));
         if exit {
-            // TODO: fields/context.
             warn!("killed thread(s)");
+            // TODO: instrument drop and friends
             drop(alert_pool);
             drop(ml_pool);
             drop(filter_pool);

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,11 +1,11 @@
+use crate::utils::o11y::DEBUG;
+
 use config::{Config, Value};
 // TODO: we do not want to get in the habit of making 3rd party types part of
 // our public API. It's almost always asking for trouble.
 use config::File;
 use std::path::Path;
 use tracing::{error, instrument};
-
-const DEBUG: tracing::Level = tracing::Level::DEBUG;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BoomConfigError {

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -3,7 +3,9 @@ use config::{Config, Value};
 // our public API. It's almost always asking for trouble.
 use config::File;
 use std::path::Path;
-use tracing::error;
+use tracing::{error, instrument};
+
+const DEBUG: tracing::Level = tracing::Level::DEBUG;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BoomConfigError {
@@ -19,6 +21,7 @@ pub enum BoomConfigError {
     MissingKeyError,
 }
 
+#[instrument(level = DEBUG, err)]
 pub fn load_config(filepath: &str) -> Result<Config, BoomConfigError> {
     let path = Path::new(filepath);
 
@@ -54,6 +57,7 @@ pub fn build_xmatch_configs(
     Ok(catalog_xmatch_configs)
 }
 
+#[instrument(level = DEBUG, skip_all, err)]
 pub async fn build_db(conf: &Config) -> Result<mongodb::Database, BoomConfigError> {
     let db_conf = conf.get_table("database")?;
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,4 +1,4 @@
-use crate::utils::o11y::{as_error, DEBUG};
+use crate::utils::o11y::as_error;
 
 use config::{Config, Value};
 // TODO: we do not want to get in the habit of making 3rd party types part of
@@ -21,7 +21,7 @@ pub enum BoomConfigError {
     MissingKeyError,
 }
 
-#[instrument(level = DEBUG, err)]
+#[instrument(err)]
 pub fn load_config(filepath: &str) -> Result<Config, BoomConfigError> {
     let path = Path::new(filepath);
 
@@ -35,7 +35,7 @@ pub fn load_config(filepath: &str) -> Result<Config, BoomConfigError> {
     Ok(conf)
 }
 
-#[instrument(level = DEBUG, skip(conf), err)]
+#[instrument(skip(conf), err)]
 pub fn build_xmatch_configs(
     conf: &Config,
     stream_name: &str,
@@ -58,7 +58,7 @@ pub fn build_xmatch_configs(
     Ok(catalog_xmatch_configs)
 }
 
-#[instrument(level = DEBUG, skip_all, err)]
+#[instrument(skip_all, err)]
 pub async fn build_db(conf: &Config) -> Result<mongodb::Database, BoomConfigError> {
     let db_conf = conf.get_table("database")?;
 
@@ -172,7 +172,7 @@ pub async fn build_db(conf: &Config) -> Result<mongodb::Database, BoomConfigErro
     Ok(db)
 }
 
-#[instrument(level = DEBUG, skip_all, err)]
+#[instrument(skip_all, err)]
 pub async fn build_redis(
     conf: &Config,
 ) -> Result<redis::aio::MultiplexedConnection, BoomConfigError> {
@@ -213,7 +213,6 @@ pub struct CatalogXmatchConfig {
 }
 
 impl CatalogXmatchConfig {
-    #[instrument(level = DEBUG, skip(projection))]
     pub fn new(
         catalog: &str,
         radius: f64,
@@ -235,7 +234,7 @@ impl CatalogXmatchConfig {
     }
 
     // based on the code in the main function, create a from_config function
-    #[instrument(level = DEBUG, skip_all, err)]
+    #[instrument(skip_all, err)]
     pub fn from_config(config_value: Value) -> Result<CatalogXmatchConfig, BoomConfigError> {
         let hashmap_xmatch = config_value.into_table()?;
 

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -356,10 +356,7 @@ pub async fn run_filter_worker<T: FilterWorker>(
     let mut filter_worker = T::new(config_path).await?;
 
     if !filter_worker.has_filters() {
-        info!(
-            "No filters available for filter worker {} to process alerts",
-            &id
-        );
+        info!("no filters available for processing");
         return Ok(());
     }
 

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -344,7 +344,7 @@ pub trait FilterWorker {
 }
 
 #[tokio::main]
-#[instrument(skip(receiver, config_path), err)]
+#[instrument(skip_all, err)]
 pub async fn run_filter_worker<T: FilterWorker>(
     id: String,
     mut receiver: mpsc::Receiver<WorkerCmd>,

--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -50,29 +50,23 @@ pub async fn run_ml_worker<T: MLWorker>(
     let input_queue = ml_worker.input_queue_name();
     let output_queue = ml_worker.output_queue_name();
 
-    let command_interval: i64 = 500;
+    let command_interval: usize = 500;
     let mut command_check_countdown = command_interval;
 
     loop {
         if command_check_countdown == 0 {
-            match receiver.try_recv() {
-                Ok(WorkerCmd::TERM) => {
-                    info!("alert worker {} received termination command", &id);
-                    break;
-                }
-                Err(TryRecvError::Disconnected) => {
-                    warn!("alert worker {} receiver disconnected, terminating", &id);
-                    break;
-                }
-                Err(TryRecvError::Empty) => {
-                    command_check_countdown = command_interval;
-                }
+            if should_terminate(&mut receiver) {
+                break;
+            } else {
+                command_check_countdown = command_interval + 1;
             }
         }
+        command_check_countdown -= 1;
         // if the queue is empty, wait for a bit and continue the loop
         let queue_len: i64 = con.llen(&input_queue).await?;
         if queue_len == 0 {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            command_check_countdown = 0;
             continue;
         }
 
@@ -89,12 +83,11 @@ pub async fn run_ml_worker<T: MLWorker>(
         }
 
         let processed_alerts = ml_worker.process_alerts(&candids).await?;
+        command_check_countdown -= nb_candids - 1; // As if iterated this many times
 
         // push that back to redis to the output queue
         con.lpush::<&str, Vec<String>, usize>(&output_queue, processed_alerts)
             .await?;
-
-        command_check_countdown -= nb_candids as i64;
     }
 
     Ok(())

--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -44,9 +44,8 @@ pub trait MLWorker {
 }
 
 #[tokio::main]
-#[instrument(skip(receiver, config_path), err)]
+#[instrument(skip_all, err)]
 pub async fn run_ml_worker<T: MLWorker>(
-    id: String,
     mut receiver: mpsc::Receiver<WorkerCmd>,
     config_path: &str,
 ) -> Result<(), MLWorkerError> {

--- a/src/scheduler/base.rs
+++ b/src/scheduler/base.rs
@@ -180,6 +180,7 @@ impl Worker {
             WorkerType::Alert => thread::spawn(move || {
                 let tid = std::thread::current().id();
                 span!(INFO, "alert worker", ?tid, ?stream_name).in_scope(|| {
+                    info!("starting alert worker");
                     debug!(?config_path);
                     let run = match stream_name.as_str() {
                         "ZTF" => run_alert_worker::<ZtfAlertWorker>,
@@ -195,6 +196,7 @@ impl Worker {
             WorkerType::Filter => thread::spawn(move || {
                 let tid = std::thread::current().id();
                 span!(INFO, "filter worker", ?tid, ?stream_name).in_scope(|| {
+                    info!("starting filter worker");
                     debug!(?config_path);
                     let run = match stream_name.as_str() {
                         "ZTF" => run_filter_worker::<ZtfFilterWorker>,
@@ -212,6 +214,7 @@ impl Worker {
             WorkerType::ML => thread::spawn(move || {
                 let tid = std::thread::current().id();
                 span!(INFO, "ml worker", ?tid, ?stream_name).in_scope(|| {
+                    info!("starting ml worker");
                     debug!(?config_path);
                     let run = match stream_name.as_str() {
                         "ZTF" => run_ml_worker::<ZtfMLWorker>,

--- a/src/scheduler/base.rs
+++ b/src/scheduler/base.rs
@@ -2,15 +2,15 @@ use crate::{
     alert::{run_alert_worker, LsstAlertWorker, ZtfAlertWorker},
     filter::{run_filter_worker, LsstFilterWorker, ZtfFilterWorker},
     ml::{run_ml_worker, ZtfMLWorker},
-    utils::worker::{WorkerCmd, WorkerType},
+    utils::{
+        o11y::{DEBUG, INFO},
+        worker::{WorkerCmd, WorkerType},
+    },
 };
 use std::thread;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
 use tracing::{error, info, instrument, span, warn};
-
-const DEBUG: tracing::Level = tracing::Level::DEBUG;
-const INFO: tracing::Level = tracing::Level::INFO;
 
 #[derive(thiserror::Error, Debug)]
 pub enum SchedulerError {

--- a/src/scheduler/base.rs
+++ b/src/scheduler/base.rs
@@ -222,7 +222,7 @@ impl Worker {
                             return;
                         }
                     };
-                    run(id, receiver, &config_path).unwrap_or_else(as_error!("ml worker failed"));
+                    run(receiver, &config_path).unwrap_or_else(as_error!("ml worker failed"));
                 })
             }),
         };

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,3 +1,5 @@
+use crate::utils::o11y::INFO;
+
 use flare::spatial::radec2lb;
 use mongodb::{
     bson::{doc, to_document, Document},
@@ -6,8 +8,6 @@ use mongodb::{
 };
 use serde::Serialize;
 use tracing::instrument;
-
-const INFO: tracing::Level = tracing::Level::INFO;
 
 #[derive(thiserror::Error, Debug)]
 #[error("failed to create index")]

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,5 +1,3 @@
-use crate::utils::o11y::{DEBUG, INFO};
-
 use flare::spatial::radec2lb;
 use mongodb::{
     bson::{doc, to_document, Document},
@@ -13,7 +11,7 @@ use tracing::instrument;
 #[error("failed to create index")]
 pub struct CreateIndexError(#[from] mongodb::error::Error);
 
-#[instrument(level = INFO, skip(collection, index), fields(collection = collection.name()), err)]
+#[instrument(skip(collection, index), fields(collection = collection.name()), err)]
 pub async fn create_index(
     collection: &Collection<Document>,
     index: Document,
@@ -27,7 +25,7 @@ pub async fn create_index(
     Ok(())
 }
 
-#[instrument(level = DEBUG, skip_all)]
+#[instrument(skip_all)]
 pub fn mongify<T: Serialize>(value: &T) -> Document {
     // we removed all the sanitizing logic
     // in favor of using serde's attributes to clean up the data
@@ -36,7 +34,7 @@ pub fn mongify<T: Serialize>(value: &T) -> Document {
     to_document(value).unwrap()
 }
 
-#[instrument(level = DEBUG)]
+#[instrument]
 pub fn get_coordinates(ra: f64, dec: f64) -> Document {
     let (l, b) = radec2lb(ra, dec);
     doc! {
@@ -49,7 +47,7 @@ pub fn get_coordinates(ra: f64, dec: f64) -> Document {
     }
 }
 
-#[instrument(level = DEBUG)]
+#[instrument]
 pub fn cutout2bsonbinary(cutout: Vec<u8>) -> mongodb::bson::Binary {
     return mongodb::bson::Binary {
         subtype: mongodb::bson::spec::BinarySubtype::Generic,
@@ -59,7 +57,7 @@ pub fn cutout2bsonbinary(cutout: Vec<u8>) -> mongodb::bson::Binary {
 
 // This function, for a given survey name (ZTF, LSST), will create
 // the required indexes on the alerts and alerts_aux collections
-#[instrument(level = INFO, skip(db), fields(database = db.name()), err)]
+#[instrument(skip(db), fields(database = db.name()), err)]
 pub async fn initialize_survey_indexes(
     survey: &str,
     db: &Database,

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -7,6 +7,8 @@ use mongodb::{
 use serde::Serialize;
 use tracing::instrument;
 
+const INFO: tracing::Level = tracing::Level::INFO;
+
 #[derive(thiserror::Error, Debug)]
 #[error("failed to create index")]
 pub struct CreateIndexError(#[from] mongodb::error::Error);
@@ -54,6 +56,7 @@ pub fn cutout2bsonbinary(cutout: Vec<u8>) -> mongodb::bson::Binary {
 
 // This function, for a given survey name (ZTF, LSST), will create
 // the required indexes on the alerts and alerts_aux collections
+#[instrument(level = INFO, skip(db), err)]
 pub async fn initialize_survey_indexes(
     survey: &str,
     db: &Database,

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,4 +1,4 @@
-use crate::utils::o11y::INFO;
+use crate::utils::o11y::{DEBUG, INFO};
 
 use flare::spatial::radec2lb;
 use mongodb::{
@@ -13,7 +13,7 @@ use tracing::instrument;
 #[error("failed to create index")]
 pub struct CreateIndexError(#[from] mongodb::error::Error);
 
-#[instrument(skip(collection, index), err, fields(collection = collection.name()))]
+#[instrument(level = INFO, skip(collection, index), fields(collection = collection.name()), err)]
 pub async fn create_index(
     collection: &Collection<Document>,
     index: Document,
@@ -27,6 +27,7 @@ pub async fn create_index(
     Ok(())
 }
 
+#[instrument(level = DEBUG, skip_all)]
 pub fn mongify<T: Serialize>(value: &T) -> Document {
     // we removed all the sanitizing logic
     // in favor of using serde's attributes to clean up the data
@@ -35,6 +36,7 @@ pub fn mongify<T: Serialize>(value: &T) -> Document {
     to_document(value).unwrap()
 }
 
+#[instrument(level = DEBUG)]
 pub fn get_coordinates(ra: f64, dec: f64) -> Document {
     let (l, b) = radec2lb(ra, dec);
     doc! {
@@ -47,6 +49,7 @@ pub fn get_coordinates(ra: f64, dec: f64) -> Document {
     }
 }
 
+#[instrument(level = DEBUG)]
 pub fn cutout2bsonbinary(cutout: Vec<u8>) -> mongodb::bson::Binary {
     return mongodb::bson::Binary {
         subtype: mongodb::bson::spec::BinarySubtype::Generic,
@@ -56,7 +59,7 @@ pub fn cutout2bsonbinary(cutout: Vec<u8>) -> mongodb::bson::Binary {
 
 // This function, for a given survey name (ZTF, LSST), will create
 // the required indexes on the alerts and alerts_aux collections
-#[instrument(level = INFO, skip(db), err)]
+#[instrument(level = INFO, skip(db), fields(database = db.name()), err)]
 pub async fn initialize_survey_indexes(
     survey: &str,
     db: &Database,
@@ -73,7 +76,7 @@ pub async fn initialize_survey_indexes(
         "_id": 1,
     };
     create_index(&alerts_collection, index.clone(), false).await?;
-    create_index(&alerts_aux_collection, index.clone(), false).await?;
+    create_index(&alerts_aux_collection, index, false).await?;
 
     // create a simple index on the objectId field of the alerts collection
     let index = doc! {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod conversions;
 pub mod db;
 pub mod fits;
+pub mod o11y;
 pub mod spatial;
 pub mod testing;
 pub mod worker;

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -1,12 +1,19 @@
+//! Common observability utilities.
+//!
+//! This module provides a collection of tools for instrumentation and logging
+//! throughout the application.
+//!
 use tracing::Subscriber;
 use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter, Layer};
 
+/// The error type returned when building a subscriber.
 #[derive(Debug, thiserror::Error)]
 pub enum BuildSubscriberError {
     #[error("failed to parse filtering directive")]
     Parse(#[from] tracing_subscriber::filter::ParseError),
 }
 
+/// Build a tracing subscriber.
 pub fn build_subscriber() -> Result<impl Subscriber, BuildSubscriberError> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_thread_names(true)

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -1,0 +1,18 @@
+use tracing::Subscriber;
+use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter, Layer};
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildSubscriberError {
+    #[error("failed to parse filtering directive")]
+    Parse(#[from] tracing_subscriber::filter::ParseError),
+}
+
+pub fn build_subscriber() -> Result<impl Subscriber, BuildSubscriberError> {
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_thread_names(true)
+        .with_file(true)
+        .with_line_number(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+    let env_filter = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
+    Ok(tracing_subscriber::registry().with(fmt_layer.with_filter(env_filter)))
+}

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -144,18 +144,19 @@ pub use log_error;
 /// Examples:
 ///
 /// ```no_run
-/// use boom::utils::o11y::{as_error, WARN};
+/// use boom::utils::o11y::{as_error, log_error, WARN};
 /// use std::io::{Error, ErrorKind};
 ///
-/// let error = Error::new(ErrorKind::Other, "borked");
-/// let result: Result<(), Error>
+/// fn f() -> Result<(), Error> {
+///     Err(Error::new(ErrorKind::Other, "borked"))
+/// }
 ///
-/// result.unwrap_or_else(as_error!());
-/// result.inspect_err(as_error!(WARN, "oh no"));
+/// f().unwrap_or_else(as_error!());
+/// let _ = f().inspect_err(as_error!(WARN, "oh no"));
 ///
 /// // The above are equivalent to,
-/// result.unwrap_or_else(|error| log_error!(error));
-/// result.inspect_err(|error| log_error!(WARN, error, "oh no"));
+/// f().unwrap_or_else(|error| log_error!(error));
+/// let _ = f().inspect_err(|error| log_error!(WARN, error, "oh no"));
 /// ```
 #[macro_export]
 macro_rules! as_error {

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -211,7 +211,7 @@ pub fn build_subscriber() -> Result<impl Subscriber, BuildSubscriberError> {
         .ok()
         .and_then(|string| {
             string
-                .split('|')
+                .split(',')
                 .map(|part| match part.trim().to_lowercase().as_str() {
                     "new" => Some(FmtSpan::NEW),
                     "enter" => Some(FmtSpan::ENTER),

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -3,8 +3,193 @@
 //! This module provides a collection of tools for instrumentation and logging
 //! throughout the application.
 //!
+use std::iter::successors;
+
 use tracing::Subscriber;
 use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter, Layer};
+
+/// Iterate over the `Display` representations of the sources of the given error
+/// by recursively calling `std::error::Error::source()`.
+pub fn iter_sources<T: std::error::Error>(
+    error: &T,
+) -> impl std::iter::Iterator<Item = String> + use<'_, T> {
+    successors(error.source(), |&error| error.source()).map(ToString::to_string)
+}
+
+/// Alias for `tracing::Level::ERROR`.
+pub const ERROR: tracing::Level = tracing::Level::ERROR;
+
+/// Alias for `tracing::Level::WARN`.
+pub const WARN: tracing::Level = tracing::Level::WARN;
+
+/// Alias for `tracing::Level::INFO`.
+pub const INFO: tracing::Level = tracing::Level::INFO;
+
+/// Alias for `tracing::Level::DEBUG`.
+pub const DEBUG: tracing::Level = tracing::Level::DEBUG;
+
+/// Alias for `tracing::Level::TRACE`.
+pub const TRACE: tracing::Level = tracing::Level::TRACE;
+
+/// Default separator used by `log_error` to format error sources.
+pub const SEP: &str = " | ";
+
+/// Create a `tracing::event!` wrapper to standardize the creation of events for
+/// errors.
+///
+/// The created event has fields for both the `Display` and `Debug`
+/// representations of the error as well as a field showing the error's sources.
+///
+/// Examples:
+///
+/// ```no_run
+/// use boom::utils::o11y::{log_error, WARN};
+/// use std::io::{Error, ErrorKind};
+///
+/// let error = Error::new(ErrorKind::Other, "borked");
+///
+/// log_error!(error); // An ERROR with just the details of the error.
+/// log_error!(error, "oh no"); // With added context
+///
+/// let n = 5;
+/// log_error!(error, "oh no: {} attempts", n); // Context with format args
+///
+/// // Optionaly, a level may be provided to get an event other than ERROR:
+/// log_error!(WARN, error);
+/// log_error!(WARN, error, "oh no");
+/// log_error!(WARN, error, "oh no: {} attempts", n);
+/// ```
+#[macro_export]
+macro_rules! log_error {
+    // NOTE: The order of the patterns seems to matter, don't scramble them.
+    // TODO: add support for fields?
+
+    // Error + Format string + args
+    ($error:expr, $fmt:literal, $($arg:tt)*) => {
+        tracing::event!(
+            $crate::utils::o11y::ERROR,
+            error = %$error,
+            source = %$crate::utils::o11y::iter_sources(&$error).collect::<Vec<_>>().join($crate::utils::o11y::SEP),
+            debug = ?$error,
+            $fmt,
+            $($arg)*
+        )
+    };
+
+    // Level + Error + Format string + args
+    ($lvl:expr, $error:expr, $fmt:literal, $($arg:tt)*) => {
+        tracing::event!(
+            $lvl,
+            error = %$error,
+            source = %$crate::utils::o11y::iter_sources(&$error).collect::<Vec<_>>().join($crate::utils::o11y::SEP),
+            debug = ?$error,
+            $fmt,
+            $($arg)*
+        )
+    };
+
+    // Error + Message string
+    ($error:expr, $msg:literal) => {
+        tracing::event!(
+            $crate::utils::o11y::ERROR,
+            error = %$error,
+            source = %$crate::utils::o11y::iter_sources(&$error).collect::<Vec<_>>().join($crate::utils::o11y::SEP),
+            debug = ?$error,
+            $msg
+        )
+    };
+
+    // Level + Error + Message string
+    ($lvl:expr, $error:expr, $msg:literal) => {
+        tracing::event!(
+            $lvl,
+            error = %$error,
+            source = %$crate::utils::o11y::iter_sources(&$error).collect::<Vec<_>>().join($crate::utils::o11y::SEP),
+            debug = ?$error,
+            $msg
+        )
+    };
+
+    // Error
+    ($error:expr) => {
+        tracing::event!(
+            $crate::utils::o11y::ERROR,
+            error = %$error,
+            source = %$crate::utils::o11y::iter_sources(&$error).collect::<Vec<_>>().join($crate::utils::o11y::SEP),
+            debug = ?$error
+        )
+    };
+
+    // Level + Error
+    ($lvl:expr, $error:expr) => {
+        tracing::event!(
+            $lvl,
+            error = %$error,
+            source = %$crate::utils::o11y::iter_sources(&$error).collect::<Vec<_>>().join($crate::utils::o11y::SEP),
+            debug = ?$error
+        )
+    };
+}
+
+pub use log_error;
+
+/// Create a closure that calls `log_error` with a given error.
+///
+/// This macro has exactly the same interface as `log_error` except it doesn't
+/// take an `error` argument (the error is instead passed to the closure). It is
+/// particularly useful in `Result` methods like `unwrap_or_else` and
+/// `inspect_err`.
+///
+/// Examples:
+///
+/// ```no_run
+/// use boom::utils::o11y::{as_error, WARN};
+/// use std::io::{Error, ErrorKind};
+///
+/// let error = Error::new(ErrorKind::Other, "borked");
+/// let result: Result<(), Error>
+///
+/// result.unwrap_or_else(as_error!());
+/// result.inspect_err(as_error!(WARN, "oh no"));
+///
+/// // The above are equivalent to,
+/// result.unwrap_or_else(|error| log_error!(error));
+/// result.inspect_err(|error| log_error!(WARN, error, "oh no"));
+/// ```
+#[macro_export]
+macro_rules! as_error {
+    // Format string + args
+    ($fmt:literal, $($arg:tt)*) => {
+        |error| $crate::utils::o11y::log_error!(error, $fmt, $($arg)*)
+    };
+
+    // Level + Format string + args
+    ($lvl:expr, $fmt:literal, $($arg:tt)*) => {
+        |error| $crate::utils::o11y::log_error!($lvl, error, $fmt, $($arg)*)
+    };
+
+    // Message string
+    ($msg:literal) => {
+        |error| $crate::utils::o11y::log_error!(error, $msg)
+    };
+
+    // Level + Message string
+    ($lvl:expr, $msg:literal) => {
+        |error| $crate::utils::o11y::log_error!($lvl, error, $msg)
+    };
+
+    // Nullary
+    () => {
+        |error| $crate::utils::o11y::log_error!(error)
+    };
+
+    // Level
+    ($lvl:expr) => {
+        |error| $crate::utils::o11y::log_error!($lvl, error)
+    };
+}
+
+pub use as_error;
 
 /// The error type returned when building a subscriber.
 #[derive(Debug, thiserror::Error)]

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -203,7 +203,7 @@ pub enum BuildSubscriberError {
 /// Build a tracing subscriber.
 pub fn build_subscriber() -> Result<impl Subscriber, BuildSubscriberError> {
     let mut fmt_layer = tracing_subscriber::fmt::layer()
-        .with_thread_names(true)
+        .with_target(false)
         .with_file(true)
         .with_line_number(true);
 

--- a/src/utils/o11y.rs
+++ b/src/utils/o11y.rs
@@ -133,11 +133,12 @@ macro_rules! log_error {
 
 pub use log_error;
 
-/// Create a closure that calls `log_error` with a given error.
+/// Create a closure that takes an error and emits it as an event (as an ERROR
+/// event by default) using `log_error`.
 ///
 /// This macro has exactly the same interface as `log_error` except it doesn't
-/// take an `error` argument (the error is instead passed to the closure). It is
-/// particularly useful in `Result` methods like `unwrap_or_else` and
+/// take the error as an argument (the error is instead passed to the closure).
+/// It is particularly useful in `Result` methods like `unwrap_or_else` and
 /// `inspect_err`.
 ///
 /// Examples:

--- a/src/utils/spatial.rs
+++ b/src/utils/spatial.rs
@@ -1,9 +1,12 @@
+use crate::{
+    conf,
+    utils::o11y::{as_error, DEBUG},
+};
+
 use flare::spatial::great_circle_distance;
 use futures::stream::StreamExt;
 use mongodb::bson::doc;
-use tracing::warn;
-
-use crate::conf;
+use tracing::{instrument, warn};
 
 #[derive(thiserror::Error, Debug)]
 pub enum XmatchError {
@@ -21,6 +24,7 @@ pub enum XmatchError {
     AsDocumentError,
 }
 
+#[instrument(level = DEBUG, skip(xmatch_configs), fields(database = db.name()), err)]
 pub async fn xmatch(
     ra: f64,
     dec: f64,
@@ -104,7 +108,10 @@ pub async fn xmatch(
 
     let collection: mongodb::Collection<mongodb::bson::Document> =
         db.collection(&xmatch_configs[0].catalog);
-    let mut cursor = collection.aggregate(x_matches_pipeline).await?;
+    let mut cursor = collection
+        .aggregate(x_matches_pipeline)
+        .await
+        .inspect_err(as_error!("failed to aggregate"))?;
 
     let mut xmatch_docs = doc! {};
     // pre add the catalogs + empty vec to the xmatch_docs
@@ -114,9 +121,13 @@ pub async fn xmatch(
     }
 
     while let Some(result) = cursor.next().await {
-        let doc = result?;
-        let catalog = doc.get_str("catalog")?;
-        let matches = doc.get_array("matches")?;
+        let doc = result.inspect_err(as_error!("failed to get next document"))?;
+        let catalog = doc
+            .get_str("catalog")
+            .inspect_err(as_error!("failed to get catalog"))?;
+        let matches = doc
+            .get_array("matches")
+            .inspect_err(as_error!("failed to get matches"))?;
 
         let xmatch_config = xmatch_configs
             .iter()
@@ -143,15 +154,15 @@ pub async fn xmatch(
                     .as_document()
                     .ok_or(XmatchError::AsDocumentError)?;
                 let Ok(xmatch_ra) = xmatch_doc.get_f64("ra") else {
-                    warn!("No ra in xmatch doc");
+                    warn!("no ra in xmatch doc");
                     continue;
                 };
                 let Ok(xmatch_dec) = xmatch_doc.get_f64("dec") else {
-                    warn!("No dec in xmatch doc");
+                    warn!("no dec in xmatch doc");
                     continue;
                 };
                 let Ok(doc_z) = xmatch_doc.get_f64(&distance_key) else {
-                    warn!("No z in xmatch doc");
+                    warn!("no z in xmatch doc");
                     continue;
                 };
 

--- a/src/utils/spatial.rs
+++ b/src/utils/spatial.rs
@@ -1,7 +1,4 @@
-use crate::{
-    conf,
-    utils::o11y::{as_error, DEBUG},
-};
+use crate::{conf, utils::o11y::as_error};
 
 use flare::spatial::great_circle_distance;
 use futures::stream::StreamExt;
@@ -24,7 +21,7 @@ pub enum XmatchError {
     AsDocumentError,
 }
 
-#[instrument(level = DEBUG, skip(xmatch_configs), fields(database = db.name()), err)]
+#[instrument(skip(xmatch_configs), fields(database = db.name()), err)]
 pub async fn xmatch(
     ra: f64,
     dec: f64,

--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -6,15 +6,15 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tokio::sync::mpsc::{error::TryRecvError, Receiver};
-use tracing::{instrument, span, warn, Instrument};
+use tracing::{info, instrument, span, warn, Instrument};
 
 // spawns a thread which listens for interrupt signal. Sets flag to true upon signal interruption
-#[instrument(level = DEBUG, skip_all)]
+#[instrument(skip_all)]
 pub async fn spawn_sigint_handler(flag: Arc<Mutex<bool>>) {
     tokio::spawn(
         async move {
             tokio::signal::ctrl_c().await.unwrap();
-            warn!("received interrupt signal, finishing up");
+            warn!("received interrupt signal");
             let mut flag = flag.try_lock().unwrap();
             *flag = true;
         }
@@ -35,7 +35,7 @@ pub fn check_exit(flag: Arc<Mutex<bool>>) {
 }
 
 // checks returns value of flag
-#[instrument(level = DEBUG, skip_all)]
+#[instrument(skip_all)]
 pub fn check_flag(flag: Arc<Mutex<bool>>) -> bool {
     match flag.try_lock() {
         Ok(x) => {

--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -3,11 +3,15 @@ use std::{
     fmt,
     sync::{Arc, Mutex},
 };
-use tracing::warn;
+use tracing::{instrument, warn};
+
+const DEBUG: tracing::Level = tracing::Level::DEBUG;
 
 // spawns a thread which listens for interrupt signal. Sets flag to true upon signal interruption
+#[instrument(level = DEBUG, skip_all)]
 pub async fn sig_int_handler(flag: Arc<Mutex<bool>>) {
     tokio::spawn(async move {
+        // TODO: instrument this?
         tokio::signal::ctrl_c().await.unwrap();
         warn!("Received interrupt signal. Finishing up...");
         let mut flag = flag.try_lock().unwrap();
@@ -28,6 +32,7 @@ pub fn check_exit(flag: Arc<Mutex<bool>>) {
 }
 
 // checks returns value of flag
+#[instrument(level = DEBUG, skip_all)]
 pub fn check_flag(flag: Arc<Mutex<bool>>) -> bool {
     match flag.try_lock() {
         Ok(x) => {

--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -10,7 +10,7 @@ use tracing::{info, instrument, span, warn, Instrument};
 
 // spawns a thread which listens for interrupt signal. Sets flag to true upon signal interruption
 #[instrument(skip_all)]
-pub async fn spawn_sigint_handler(flag: Arc<Mutex<bool>>) {
+pub fn spawn_sigint_handler(flag: Arc<Mutex<bool>>) {
     tokio::spawn(
         async move {
             tokio::signal::ctrl_c().await.unwrap();

--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -1,26 +1,10 @@
-use crate::utils::o11y::DEBUG;
-
 use config::Config;
 use std::{
     fmt,
     sync::{Arc, Mutex},
 };
 use tokio::sync::mpsc::{error::TryRecvError, Receiver};
-use tracing::{info, instrument, span, warn, Instrument};
-
-// spawns a thread which listens for interrupt signal. Sets flag to true upon signal interruption
-#[instrument(skip_all)]
-pub fn spawn_sigint_handler(flag: Arc<Mutex<bool>>) {
-    tokio::spawn(
-        async move {
-            tokio::signal::ctrl_c().await.unwrap();
-            warn!("received interrupt signal");
-            let mut flag = flag.try_lock().unwrap();
-            *flag = true;
-        }
-        .instrument(span!(DEBUG, "sigint handler")),
-    );
-}
+use tracing::{info, instrument, warn};
 
 // checks if a flag is set to true and, if so, exits the program
 pub fn check_exit(flag: Arc<Mutex<bool>>) {
@@ -31,21 +15,6 @@ pub fn check_exit(flag: Arc<Mutex<bool>>) {
             }
         }
         _ => {}
-    }
-}
-
-// checks returns value of flag
-#[instrument(skip_all)]
-pub fn check_flag(flag: Arc<Mutex<bool>>) -> bool {
-    match flag.try_lock() {
-        Ok(x) => {
-            if *x {
-                true
-            } else {
-                false
-            }
-        }
-        _ => false,
     }
 }
 

--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -1,11 +1,11 @@
+use crate::utils::o11y::DEBUG;
+
 use config::Config;
 use std::{
     fmt,
     sync::{Arc, Mutex},
 };
 use tracing::{instrument, span, warn, Instrument};
-
-const DEBUG: tracing::Level = tracing::Level::DEBUG;
 
 // spawns a thread which listens for interrupt signal. Sets flag to true upon signal interruption
 #[instrument(level = DEBUG, skip_all)]

--- a/tests/test_lsst.rs
+++ b/tests/test_lsst.rs
@@ -83,10 +83,9 @@ async fn test_process_lsst_alert() {
     let result = alert_worker.process_alert(&bytes_content).await.unwrap();
     assert_eq!(result, candid);
 
-    // now that it has been inserted in the database, calling process alert should return an error
+    // Attempting to insert the error again is a no-op, not an error:
     let result = alert_worker.process_alert(&bytes_content).await;
-
-    assert!(result.is_err());
+    assert!(result.is_ok());
 
     // let's query the database to check if the alert was inserted
     let config = conf::load_config(TEST_CONFIG_FILE).unwrap();

--- a/tests/test_lsst.rs
+++ b/tests/test_lsst.rs
@@ -1,5 +1,5 @@
 use boom::{
-    alert::AlertWorker,
+    alert::{AlertWorker, ProcessAlertStatus},
     conf,
     filter::{alert_to_avro_bytes, load_alert_schema, FilterWorker, LsstFilterWorker},
     utils::testing::{
@@ -80,12 +80,12 @@ async fn test_process_lsst_alert() {
     let mut alert_worker = lsst_alert_worker().await;
 
     let (candid, object_id, ra, dec, bytes_content) = LsstAlertRandomizer::default().get().await;
-    let result = alert_worker.process_alert(&bytes_content).await.unwrap();
-    assert_eq!(result, candid);
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Added(candid));
 
     // Attempting to insert the error again is a no-op, not an error:
-    let result = alert_worker.process_alert(&bytes_content).await;
-    assert!(result.is_ok());
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Exists(candid));
 
     // let's query the database to check if the alert was inserted
     let config = conf::load_config(TEST_CONFIG_FILE).unwrap();
@@ -151,8 +151,8 @@ async fn test_filter_lsst_alert() {
     let mut alert_worker = lsst_alert_worker().await;
 
     let (candid, object_id, _ra, _dec, bytes_content) = LsstAlertRandomizer::default().get().await;
-    let result = alert_worker.process_alert(&bytes_content).await.unwrap();
-    assert_eq!(result, candid);
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Added(candid));
 
     let filter_id = insert_test_lsst_filter().await.unwrap();
 

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -1,5 +1,5 @@
 use boom::{
-    alert::{AlertWorker, LSST_DEC_LIMIT, LSST_XMATCH_RADIUS},
+    alert::{AlertWorker, ProcessAlertStatus, LSST_DEC_LIMIT, LSST_XMATCH_RADIUS},
     conf,
     filter::{alert_to_avro_bytes, load_alert_schema, FilterWorker, ZtfFilterWorker},
     ml::{MLWorker, ZtfMLWorker},
@@ -158,13 +158,12 @@ async fn test_process_ztf_alert() {
     let mut alert_worker = ztf_alert_worker().await;
 
     let (candid, object_id, ra, dec, bytes_content) = ZtfAlertRandomizer::default().get().await;
-    let result = alert_worker.process_alert(&bytes_content).await;
-    assert!(result.is_ok(), "{:?}", result);
-    assert_eq!(result.unwrap(), candid);
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Added(candid));
 
     // Attempting to insert the error again is a no-op, not an error:
-    let result = alert_worker.process_alert(&bytes_content).await;
-    assert!(result.is_ok());
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Exists(candid));
 
     // let's query the database to check if the alert was inserted
     let config = conf::load_config(TEST_CONFIG_FILE).unwrap();
@@ -402,9 +401,8 @@ async fn test_ml_ztf_alert() {
         .rand_object_id()
         .get()
         .await;
-    let result = alert_worker.process_alert(&bytes_content).await;
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), candid);
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Added(candid));
 
     let ml_worker = ZtfMLWorker::new(TEST_CONFIG_FILE).await.unwrap();
     let result = ml_worker.process_alerts(&[candid]).await;
@@ -451,9 +449,8 @@ async fn test_filter_ztf_alert() {
     let mut alert_worker = ztf_alert_worker().await;
 
     let (candid, object_id, _ra, _dec, bytes_content) = ZtfAlertRandomizer::default().get().await;
-    let result = alert_worker.process_alert(&bytes_content).await;
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), candid);
+    let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Added(candid));
 
     // then run the ML worker to get the classifications
     let ml_worker = ZtfMLWorker::new(TEST_CONFIG_FILE).await.unwrap();

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -162,10 +162,9 @@ async fn test_process_ztf_alert() {
     assert!(result.is_ok(), "{:?}", result);
     assert_eq!(result.unwrap(), candid);
 
-    // now that it has been inserted in the database, calling process alert should return an error
+    // Attempting to insert the error again is a no-op, not an error:
     let result = alert_worker.process_alert(&bytes_content).await;
-
-    assert!(result.is_err());
+    assert!(result.is_ok());
 
     // let's query the database to check if the alert was inserted
     let config = conf::load_config(TEST_CONFIG_FILE).unwrap();


### PR DESCRIPTION
Closes #105.

There's a lot going on in this PR. Highlights:

* The tracing subscriber has been configured so that each log line includes the thread name, the module name/file name/line number where the event was emitted, and span details (which spans were in scope and any context/fields associated with them). Examples are shown (way, way) below.

* Many of our functions and methods now have the `tracing::instrument` attribute, which automatically creates a span for whatever it's attached to. Spans are nice because they collect values stored in fields (e.g., function arguments), which help provide context for events. They're also nice because we can configure the subscriber to show events when spans open/enter and close/exit, helping us understand where in the flow of our program various events happen. It's kind of like getting print debugging for free, and it lets us stop writing explicit app lifecycle messages like "Starting X" or "Done with Y". Another thing we get for free with spans are execution time details, so we shouldn't need to write manual timing code except maybe in some special cases.

* This PR introduces an `EnvFilter` for our subscriber, so we can control level and target filtering with directives in the `RUST_LOG` environment variable, e.g.,

  ```
  RUST_LOG=info,ort=off cargo run --bin scheduler -- ZTF
  ```

  which tells the subscriber to enable the INFO level (which is already the default) and to disable logging from the `ort` crate (most crates don't pollute logs, but `ort` is unfortunately one that does). The `tracing_subscriber` docs discuss `RUST_LOG` directive syntax in more detail.

* The display of span events can be controlled using the `RUST_LOG_SPAN_EVENTS` environment variable. This is my own invention, not something standard. The purpose is to be able to change how spans show up in the logs without having to recompile boom. It's meant to work exactly the same as the `tracing_subscriber::fmt::Layer::with_span_events` method, so if you wanted to see both NEW and CLOSE span events, then you would write,

  ```
  RUST_LOG=info,ort=off RUST_LOG_SPAN_EVENTS='new|close' cargo run --bin scheduler -- ZTF
  ```

  By default, no span events are emitted.

* Last but not least, there are two new macros, `log_err!` and `as_err!`, that are used to emit an event based on an error value. `log_err!` is basically an opinionated version of `tracing::error!`. `as_err!` is like a higher-order version of `log_err!`: it creates a closure that calls `log_err!` with a given error. You'll see me use this with `Result::inspect_err` to log an event just before the `?` operator. One benefit of the macros is it helps keep our error reporting consistent. Another benefit is that, because they expand to `error!`, they're a convenient way to give an error a unique callsite, which is especially important when a function can produce the same error in multiple places (the `instrument` attribute can't tell us where inside a function an error occurs).

On to some examples from a real run. First, we can see the main scheduler thread spawning the workers and then starting the heart beat loop. Notice the "context" that's collected by the spans and automatically displayed with each event; here it's the worker type, the number of workers, and the stream name. Events can have fields in addition to those provided by the spans, and that's what we see here with the "id" field after each "adding worker" message:

```
2025-05-31T22:17:50.147975Z  WARN main run: scheduler: src/bin/scheduler.rs:30: no config file provided, using config.yaml
2025-05-31T22:17:50.534607Z  INFO main run:new{worker_type=Alert size=1 stream_name="ZTF"}:add_worker: boom::scheduler::base: src/scheduler/base.rs:133: adding worker id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5"
2025-05-31T22:17:50.534876Z  INFO main run:new{worker_type=ML size=1 stream_name="ZTF"}:add_worker: boom::scheduler::base: src/scheduler/base.rs:133: adding worker id="ab246aae-ea98-4257-a6b0-b11417055cbe"
2025-05-31T22:17:50.535135Z  INFO main run:new{worker_type=Filter size=1 stream_name="ZTF"}:add_worker: boom::scheduler::base: src/scheduler/base.rs:133: adding worker id="38e46481-8cb7-4f72-bfd2-812e272094bf"
2025-05-31T22:17:50.535353Z  INFO main run: scheduler: src/bin/scheduler.rs:75: heart beat
```

The lines are structured as follows, taking the first INFO event above (the second line) as an example:

* `main` is the thread name.

* `run:new{worker_type=Alert size=1 stream_name="ZTF"}:add_worker` are the spans that were active when INFO event was fired.

  * The first one is named "run", corresponding to the new `run` function in `bin/scheduler.rs`. It exists because `run` has the `instrument` attribute, which automatically creates a span named after the function/method it decorates.

  * "new" corresponds to `ThreadPool::new`, and the stuff within the `{...}` are the arguments to `ThreadPool::new` that `instrument` collected as fields. It is the child/inner span of "run".

  * "add_worker" is the innermost span. It comes from `ThreadPool::add_worker` and does not collect any fields.

* `src/scheduler/base.rs:133` is the file and line number of the event callsite (where the event was emitted). In this case the event was manually created using the `info!` macro within `ThreadPool::add_worker`, but the `instrument` attribute can also create events (in which case the file and line number would point to it).

* `adding worker` is of course the message. Messages are optional, events aren't required to have them.

* `id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5"` is an additional field collected by the event (in the call to `info!`), because sometimes it's useful to include values that aren't already recorded by a span.

Keep in mind that just about everything you see is configurable on the subscriber. For instance, we can toggle thread name, thread ID, and so on. We can also emit log lines in JSON format, which would allow us to use structured logging tools if we wanted to do that at some point.

Continuing on with the example, next we see the filter worker thread announcing that it has no filters to process. The `ThreadId(11)` part is the name of the filter worker thread. If we want, we can set this to "filter thread" or whatever when we spawn the thread:

```
2025-05-31T22:17:50.602246Z  INFO ThreadId(11) filter worker{id="38e46481-8cb7-4f72-bfd2-812e272094bf" stream_name="ZTF"}:run_filter_worker: boom::filter::base: src/filter/base.rs:359: no filters available for processing
```

Then there's a bunch of heartbeat messages while the alert worker is busy doing stuff, and then we see that the queue is finally empty, which point I hit ctrl-c to initiate the shutdown sequence (the filter thread already terminated when there were no filters to process):

```
... (alert worker is doing stuff) ...
2025-05-31T22:18:20.368596Z  INFO ThreadId(08) alert worker{id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5" stream_name="ZTF"}:run_alert_worker: boom::alert::base: src/alert/base.rs:258: queue is empty
... (etc) ...
^C2025-05-31T22:18:25.452386Z  WARN tokio-runtime-worker boom::utils::worker: src/utils/worker.rs:17: received interrupt signal
2025-05-31T22:18:25.647129Z  INFO                 main run: scheduler: src/bin/scheduler.rs:75: heart beat
2025-05-31T22:18:25.647407Z  INFO                 main run: scheduler: src/bin/scheduler.rs:78: shutting down
2025-05-31T22:18:25.647595Z  INFO                 main run:terminate: boom::scheduler::base: src/scheduler/base.rs:100: sending termination signal id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5"
2025-05-31T22:18:26.376209Z  INFO ThreadId(08) alert worker{id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5" stream_name="ZTF"}:run_alert_worker:should_terminate: boom::utils::worker: src/utils/worker.rs:112: received termination command
2025-05-31T22:18:26.376333Z  INFO ThreadId(08) alert worker{id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5" stream_name="ZTF"}:run_alert_worker: boom::alert::base: src/alert/base.rs:208: summary stream="ZTF" count=710 elapsed=35 average_rate=20.285714285714285
2025-05-31T22:18:26.378937Z  INFO                 main run:join: boom::scheduler::base: src/scheduler/base.rs:113: successfully shut down worker id="08906784-8f8f-4bbc-aebc-f411aa2cf9a5"
2025-05-31T22:18:26.379309Z  INFO                 main run:terminate: boom::scheduler::base: src/scheduler/base.rs:100: sending termination signal id="ab246aae-ea98-4257-a6b0-b11417055cbe"
2025-05-31T22:18:26.568010Z  INFO ThreadId(09) ml worker{id="ab246aae-ea98-4257-a6b0-b11417055cbe" stream_name="ZTF"}:run_ml_worker{id="ab246aae-ea98-4257-a6b0-b11417055cbe"}:should_terminate: boom::utils::worker: src/utils/worker.rs:112: received termination command
2025-05-31T22:18:26.575471Z  INFO                 main run:join: boom::scheduler::base: src/scheduler/base.rs:113: successfully shut down worker id="ab246aae-ea98-4257-a6b0-b11417055cbe"
2025-05-31T22:18:26.575580Z  INFO                 main run:terminate: boom::scheduler::base: src/scheduler/base.rs:100: sending termination signal id="38e46481-8cb7-4f72-bfd2-812e272094bf"
2025-05-31T22:18:26.575650Z  WARN                 main run:terminate: boom::scheduler::base: src/scheduler/base.rs:102: failed to send termination signal (thread likely already terminated) id="38e46481-8cb7-4f72-bfd2-812e272094bf"
2025-05-31T22:18:26.575784Z  INFO                 main run:join: boom::scheduler::base: src/scheduler/base.rs:113: successfully shut down worker id="38e46481-8cb7-4f72-bfd2-812e272094bf"
```

Here's what errors look like:

```
2025-06-01T03:08:12.973473Z ERROR ThreadId(08) alert worker{id="f3532503-1d32-418d-aeec-6a1fa2e21b87" stream_name="ZTF"}:run_alert_worker:process_alert:format_and_insert_alert{candid=2724194532815015005 object_id="ZTF18abafxrs" ra=198.2862663 dec=54.3542752 now=2460827.6306944443}: boom::alert::ztf: src/alert/ztf.rs:611: error=error from mongodb
2025-06-01T03:08:13.000020Z ERROR ThreadId(08) alert worker{id="f3532503-1d32-418d-aeec-6a1fa2e21b87" stream_name="ZTF"}:run_alert_worker:process_alert: boom::alert::ztf: src/alert/ztf.rs:843: error=error from mongodb source=Kind: Custom user error, labels: {} debug=Mongodb(Error { kind: Custom(Any { .. }), labels: {}, wire_version: None, source: None })
2025-06-01T03:08:13.000670Z ERROR ThreadId(08) alert worker{id="f3532503-1d32-418d-aeec-6a1fa2e21b87" stream_name="ZTF"}:run_alert_worker:process_alert: boom::alert::ztf: src/alert/ztf.rs:823: error=error from mongodb
2025-06-01T03:08:13.000773Z  WARN ThreadId(08) alert worker{id="f3532503-1d32-418d-aeec-6a1fa2e21b87" stream_name="ZTF"}:run_alert_worker: boom::alert::base: src/alert/base.rs:288: error processing alert, skipping error=error from mongodb source=Kind: Custom user error, labels: {} debug=Mongodb(Error { kind: Custom(Any { .. }), labels: {}, wire_version: None, source: None })
```

Say we noticed the warning first because it's the most recent message. We can see something happened in the alert worker, specifically in the `boom::alert::base::run_alert_worker` function. In vscode, we can cmd-click on `src/alert/base.rs:288` to take us right to the `warn!` callsite. This is where we handle the result of `ZtfAlertWorker::process_alert`. After the "error processing alert, skipping" message, the warning also shows fields named "error", "source", and "debug". These fields give the `Display` representation of the error, the chain of inner errors (when possible), and the `Debug` representation of the error, respectively. All of this information clearly tell us we're dealing with some kind of error from mongo (actually, a custom one I put in there to make this fail on purpose).

This kind of error reporting is achieved using the new `log_err` and `as_err` macros I introduce in this PR. The idea is that using these macros gives us a consistent structure for reporting errors where they're handled. We can of course still use the usual tracing macros, but then it's harder to keep our fields consistent, so maybe we should only reach for those only when we really need them.

Note that we can trace the error back by scrolling up the log and looking for errors from deeper and deeper spans. Eventually we get to the first error in the list above, telling us to check out line 611 in `src/alert/ztf.rs` and that there was an issue inserting the alert for candid 2724194532815015005 into mongo.

One thing I would love to do is make it easier to trace through the log from the last warning down to where inserting into mongo failed for that particular candid. This could make it easier for people (and tools) to make sense of the logs without having to know a lot about how the code is organized. Simply including candid in the error value itself is probably the way to go.
