### PR TITLE
WIP - AlertFilter: Aux table look-up optimization

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -3,8 +3,8 @@ mod lsst;
 mod ztf;
 
 use base::{
-    get_filter_object, parse_programid_candid_tuple, Alert, FilterResults, Origin, Photometry,
-    Survey,
+    get_filter_object, parse_programid_candid_tuple, uses_field_in_filter, Alert, FilterResults,
+    Origin, Photometry, Survey,
 };
 pub use base::{
     run_filter, run_filter_worker, Filter, FilterError, FilterWorker, FilterWorkerError,


### PR DESCRIPTION
One thing that always bugged me in Kowalski is how we prepend ALL user-defined filters with the same stages (lookup to the _alerts_aux table, then a project to formatt the prv_candidates, fp_hists, fp_hists, cross_matches, ...) regardless of what the filter actually made use of. This meant that filters that didn't make use of crossmatches still carried those around, filters that didn't use forced photometry still scanned through all these datapoints to apply data access rules, ...

Also, if a user-defined filter only used the _alerts_aux table content in later stages (e.g. starts with a match that only needs the alert itself and cuts down on most documents before needing the lightcurves and/or cross matches) we still make that join at the very beginning. 

This PR is an attempt at:
- scanning the user-defined filters to understand at what stage of the pipeline do we need to run that `$lookup` to the aux table, to make sure we only add the relevant stages where needed and not necessarily at the very beginning.
- iscanning the user-defined filters to understand which fields from the aux table are used, to make sure we only bother formatting those and get rid of the other after the lookup.

For that to happen we:
- add a function dedicated to scanning mongodb aggregation pipeline stages to look for mentions of specific variables
- add a wrapper around that function that takes a whole pipeline and tells us if a variable is used, and at what stage (by index).
- we trade the `$lookup` -> `$project` stages for `$lookup` -> `$addFields` -> `$unset` stages, required since a project inserted somewhere other than the start of a pipeline would need to somehow figure out what existing variables from previous stages need to be specified, which seems too complex and not worth the hassle.
- we start with an empty `$addFields` stage and only add the variables from the aux table that the user-defined filter uses.
- add the lookup + addfields + unset stages where needed in the user-defined filter, which is at the lowest index out of each aux variables being used by a filter.

There are a few things I still need to do:
- [ ] since the lookup needs the objectId, I need to make sure that any project stages before the lookup we insert make sure to pass the `objectId` (or don't delete it, same thing if there are any unset stages). Such a check is missing in general since we need the objectId and candid to make their way through the entire user defined filters since we need them to be in the output document, so maybe it could be its own PR.
- [ ] add unit tests (already written for the most part actually, just need to clean them up a bit

PS: I'm adding this now and will add similar mechanisms for the lookups we'll have to add in the context of multi-survey filtering. I'm hoping that these optimizations will speed up filters quite a lot. Given that filters won't be written in mongodb anymore but through a dedicated UI that Thomas Culino is writing, we'll anyway make sure that the filters we generate are optimized to first filter as much as possible on the alerts themselves, then on the aux table of the same survey, then on other crossmatches surveys, so these optimizations added in this PR will really make a difference.
