### PR TITLE
API: Basic logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "config",
+ "env_logger",
  "futures",
  "mongodb",
  "serde",
@@ -1131,6 +1132,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1960,6 +1984,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "jobserver"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,6 +11,7 @@ futures = "0.3.31"
 mongodb = "3.1.0"
 serde = "1.0.215"
 serde_json = "1.0.138"
+env_logger = "0.11.8"
 
 [dependencies.uuid]
 version = "1.16.0"


### PR DESCRIPTION
While reviewing #141, I found it very useful to see logs of what I was trying through an API client. This PR adds some basic logging based on the official actix web example: https://actix.rs/docs/middleware/#logging

The formatting is simple but effective (ala nginx), as it records the endpoints being hit, the IP it came from, the time it took to respond, the response status, ...

PS: We might want to NOT use env_logger and somehow use tracing to make it look like the logging system of the rest of boom.