### PR TITLE
WIP - API Authentication w/ JWT

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,6 +13,8 @@ mongodb = "3.1.0"
 serde = "1.0.215"
 serde_json = "1.0.138"
 env_logger = "0.11.8"
+jsonwebtoken = "9.3.1"
+chrono = "0.4.41"
 
 [dependencies.uuid]
 version = "1.16.0"

--- a/api/src/api/auth.rs
+++ b/api/src/api/auth.rs
@@ -1,0 +1,24 @@
+use crate::auth::AuthProvider;
+use actix_web::{HttpResponse, post, web};
+use mongodb::bson::doc;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize, Clone)]
+pub struct AuthPost {
+    pub username: String,
+    pub password: String,
+}
+
+#[post("/auth")]
+pub async fn post_auth(auth: web::Data<AuthProvider>, body: web::Json<AuthPost>) -> HttpResponse {
+    // Check if the user exists and the password matches
+    match auth.authenticate_user(&body.username, &body.password).await {
+        Ok(token) => HttpResponse::Ok().json(json!({
+            "status": "success",
+            "token": token,
+            "message": "authentication successful"
+        })),
+        Err(e) => HttpResponse::Unauthorized().body(format!("authentication failed: {}", e)),
+    }
+}

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod alerts;
+pub mod auth;
 pub mod filters;
 pub mod query;
 pub mod users;

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -1,0 +1,145 @@
+use mongodb::bson::doc;
+
+use crate::{api::users::User, conf::AppConfig, conf::AuthConfig};
+
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
+
+/// Our claims struct, it needs to derive `Serialize` and/or `Deserialize`
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    sub: String,
+    iat: usize,
+    exp: usize,
+}
+
+#[derive(Clone)]
+pub struct AuthProvider {
+    encoding_key: EncodingKey,
+    decoding_key: DecodingKey,
+    validation: Validation,
+    users_collection: mongodb::Collection<User>,
+    token_expiration: usize,
+}
+
+impl AuthProvider {
+    pub async fn new(config: AuthConfig, db: &mongodb::Database) -> Self {
+        let encoding_key = EncodingKey::from_secret(config.secret_key.as_bytes());
+        let decoding_key = DecodingKey::from_secret(config.secret_key.as_bytes());
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_exp = config.token_expiration > 0; // Set to true if tokens should expire
+
+        let users_collection: mongodb::Collection<User> = db.collection("users");
+
+        // always create the admin user if it doesn't exist
+        // using the admin_username from the config and admin_password
+        let admin_username = config.admin_username.clone();
+        // first check if the admin user already exists
+        match users_collection
+            .find_one(doc! { "username": &admin_username })
+            .await
+        {
+            Ok(Some(_)) => {
+                // Admin user already exists
+            }
+            Ok(None) => {
+                // Admin user does not exist, create it
+                let user_id = uuid::Uuid::new_v4().to_string();
+                let admin_password = config.admin_password.clone();
+                let hashed_admin_password = bcrypt::hash(&admin_password, bcrypt::DEFAULT_COST)
+                    .expect("failed to hash admin password");
+                let admin_user = User {
+                    id: user_id,
+                    username: admin_username.clone(),
+                    email: "<admin_email@example.com>".to_string(),
+                    password: hashed_admin_password,
+                };
+                // DEBUG print the username, password
+                println!("Creating admin user:");
+                println!("Username: {}", &admin_username);
+                println!("Password: {}", &admin_password);
+                match users_collection.insert_one(admin_user).await {
+                    Ok(_) => {
+                        println!("Admin user created successfully.");
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to create admin user: {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to check for admin user: {}", e);
+            }
+        }
+
+        AuthProvider {
+            encoding_key,
+            decoding_key,
+            validation,
+            users_collection,
+            token_expiration: config.token_expiration,
+        }
+    }
+
+    pub async fn create_token(&self, user: &User) -> Result<String, jsonwebtoken::errors::Error> {
+        let iat = chrono::Utc::now().timestamp() as usize;
+        let exp = iat + self.token_expiration;
+        let claims = Claims {
+            sub: user.id.clone(),
+            iat,
+            exp,
+        };
+
+        encode(&Header::default(), &claims, &self.encoding_key)
+    }
+
+    pub async fn decode_token(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
+        decode::<Claims>(token, &self.decoding_key, &self.validation).map(|data| data.claims)
+    }
+
+    pub async fn validate_token(&self, token: &str) -> Result<String, jsonwebtoken::errors::Error> {
+        let claims = self.decode_token(token).await?;
+        Ok(claims.sub)
+    }
+
+    pub async fn authenticate_user(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<String, std::io::Error> {
+        let filter = mongodb::bson::doc! { "username": username };
+        let user = self.users_collection.find_one(filter).await.map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Database query failed: {}", e),
+            )
+        })?;
+
+        // if the user exists and the password matches, create a token
+        // otherwise return an error
+        if let Some(user) = user {
+            match bcrypt::verify(&password, &user.password) {
+                Ok(true) => self.create_token(&user).await.map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("Token creation failed: {}", e),
+                    )
+                }),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "Invalid credentials",
+                )),
+            }
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "User not found",
+            ))
+        }
+    }
+}
+
+pub async fn get_auth(db: &mongodb::Database) -> AuthProvider {
+    let config = AppConfig::from_default_path().auth;
+    AuthProvider::new(config, db).await
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod auth;
 pub mod conf;
 pub mod db;
 pub mod models;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,7 +1,38 @@
+use actix_web::body::MessageBody;
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::middleware::{Next, from_fn};
+use actix_web::{App, Error, HttpResponse, HttpServer, get, middleware::Logger, web};
 use boom_api::api;
+use boom_api::auth::{AuthProvider, get_auth};
 use boom_api::db::get_db;
 
-use actix_web::{App, HttpResponse, HttpServer, get, middleware::Logger, web};
+async fn auth_middleware(
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, Error> {
+    let auth_app_data: &web::Data<AuthProvider> = req.app_data().unwrap();
+    match req.headers().get("Authorization") {
+        Some(auth_header) if auth_header.to_str().unwrap_or("").starts_with("Bearer ") => {
+            let token = auth_header.to_str().unwrap()[7..].trim();
+            match auth_app_data.validate_token(token).await {
+                Ok(user_id) => {
+                    println!("Valid token for user ID: {}", user_id);
+                }
+                Err(e) => {
+                    println!("Invalid token: {}", e);
+                    return Err(actix_web::error::ErrorUnauthorized("Invalid token"));
+                }
+            }
+        }
+        _ => {
+            println!("No valid Authorization header");
+            return Err(actix_web::error::ErrorUnauthorized(
+                "Missing or invalid Authorization header",
+            ));
+        }
+    }
+    next.call(req).await
+}
 
 #[get("/")]
 pub async fn get_health() -> HttpResponse {
@@ -14,6 +45,7 @@ pub async fn get_health() -> HttpResponse {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let database = get_db().await;
+    let auth = get_auth(&database).await;
 
     // Initialize logging
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
@@ -21,18 +53,23 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(database.clone()))
-            .service(get_health)
-            .service(api::query::get_info)
-            .service(api::query::sample)
-            .service(api::query::cone_search)
-            .service(api::query::count_documents)
-            .service(api::query::find)
-            .service(api::alerts::get_object)
-            .service(api::filters::post_filter)
-            .service(api::filters::add_filter_version)
-            .service(api::users::post_user)
-            .service(api::users::get_users)
-            .service(api::users::delete_user)
+            .app_data(web::Data::new(auth.clone()))
+            .service(api::auth::post_auth)
+            .service(
+                actix_web::web::scope("")
+                    .wrap(from_fn(auth_middleware))
+                    .service(api::query::get_info)
+                    .service(api::query::sample)
+                    .service(api::query::cone_search)
+                    .service(api::query::count_documents)
+                    .service(api::query::find)
+                    .service(api::alerts::get_object)
+                    .service(api::filters::post_filter)
+                    .service(api::filters::add_filter_version)
+                    .service(api::users::post_user)
+                    .service(api::users::get_users)
+                    .service(api::users::delete_user),
+            )
             .wrap(Logger::default())
     })
     .bind(("0.0.0.0", 4000))?

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -7,6 +7,11 @@ database:
   username: mongoadmin
   password: mongoadminsecret
   srv: false
+auth:
+  secret_key: "1234"
+  token_expiration: 0 # in seconds, 0 to disable
+  admin_username: admin
+  admin_password: adminsecret
 redis:
   host: localhost
   port: 6379


### PR DESCRIPTION
In this PR, we implement JWT-based authentication for the API. Here's how it works:
- When the API starts, we create an `AuthProvider` which defines some of the parameters of the JWT auth we are trying to set up (such as if we set expiration time for tokens and validate them, and also creates an admin user using credentials defined in the config for convenience), and adds it as `AppData` to actix web.
- During that setup stage, we also wrap all endpoints (but a newly added `auth` endpoint, described next) behind an `auth_middleware` which valides JWT tokens sent by the client as regular `Bearer Auth`.
- A client first queries the `/auth` endpoint, providing username/password. The password is compared to its hash saved in the database's user table, and if valid creates a new JWT token that is returned to the client. This way the password hashing and comparison against the database is only performed once (otherwise it can be a somewhat lengthy process! Hashing takes ~200 ms in release mode and you have the round trip to the DB. So using username/password as auth for every query is bad for performance and also not great for security, as the users share their password constantly over the internet).
- Thereafter, the client uses the JWT token to authenticate instead of username/password.

What I noticed while working on this is that there isn't any nice error handling yet in the API (which I probably just forgot about!), so I need to work a little bit on that before merging this first PR.

PS: By default, the config is set so that tokens do not expire at all. This makes it easier for development, and one can just set the expiration. Similarly in production one has to change the config's `secret_key` so the JWT auth remains secure.