### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ WORKDIR /app
 # Copy the Cargo.toml and Cargo.lock files
 COPY Cargo.toml Cargo.lock ./
 
-# Build dependencies (this will be cached if Cargo.toml and Cargo.lock don't change)
-# TODO: This doesn't work without a lib or bin section in Cargo.toml
-# RUN cargo build --release --target x86_64-unknown-linux-gnu
-
 RUN apt-get update && \
     apt-get install -y curl gcc g++ libhdf5-dev perl make libsasl2-dev && \
     apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,6 @@ WORKDIR /app
 # Copy the built executable from the builder stage
 COPY --from=builder /app/target/release/boom-api /app/boom-api
 
-# Copy the config file
-# TODO: This should probably be set some other way, e.g., all configuration
-# should be done via environmental variables set by Docker Compose or
-# Kubernetes
-COPY config.yaml /usr/local/etc/config.yaml
-
 # Expose the port your application listens on
 EXPOSE 4000
 
@@ -45,12 +39,6 @@ WORKDIR /app
 
 # Copy the built executable from the builder stage
 COPY --from=builder /app/target/release/scheduler /app/scheduler
-
-# Copy the config file
-# TODO: This should probably be set some other way, e.g., all configuration
-# should be done via environmental variables set by Docker Compose or
-# Kubernetes
-COPY config.yaml /usr/local/etc/config.yaml
 
 # Set the entrypoint
 CMD ["/app/scheduler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM rust:1.87-slim-bookworm AS builder
+
+WORKDIR /app
+
+# Copy the Cargo.toml and Cargo.lock files
+COPY Cargo.toml Cargo.lock ./
+
+# Build dependencies (this will be cached if Cargo.toml and Cargo.lock don't change)
+# TODO: This doesn't work without a lib or bin section in Cargo.toml
+# RUN cargo build --release --target x86_64-unknown-linux-gnu
+
+RUN apt-get update && \
+    apt-get install -y curl gcc g++ libhdf5-dev perl make libsasl2-dev && \
+    apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy the source code
+COPY src ./src
+COPY api ./api
+
+# Build the application (all of the binaries)
+RUN cargo build --release --workspace
+
+
+## Create a minimal runtime image for API
+FROM debian:bookworm-slim AS api
+
+WORKDIR /app
+
+# Copy the built executable from the builder stage
+COPY --from=builder /app/target/release/boom-api /app/boom-api
+
+# Copy the config file
+# TODO: This should probably be set some other way, e.g., all configuration
+# should be done via environmental variables set by Docker Compose or
+# Kubernetes
+COPY config.yaml /usr/local/etc/config.yaml
+
+# Expose the port your application listens on
+EXPOSE 4000
+
+# Set the entrypoint
+CMD ["/app/boom-api"]
+
+
+## Create a minimal runtime image for scheduler
+FROM debian:bookworm-slim AS scheduler
+
+WORKDIR /app
+
+# Copy the built executable from the builder stage
+COPY --from=builder /app/target/release/scheduler /app/scheduler
+
+# Copy the config file
+# TODO: This should probably be set some other way, e.g., all configuration
+# should be done via environmental variables set by Docker Compose or
+# Kubernetes
+COPY config.yaml /usr/local/etc/config.yaml
+
+# Set the entrypoint
+CMD ["/app/scheduler"]

--- a/docker-compose.default.yaml
+++ b/docker-compose.default.yaml
@@ -66,3 +66,31 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
       KAFKA_NUM_PARTITIONS: 15
+  api:
+    image: boom/boom-api:latest
+    hostname: api
+    ports:
+      - "4000:4000"
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: api
+    networks:
+      - boom
+    profiles:
+      - prod
+    volumes:
+      - ${PWD}/config.yaml:/app/config.yaml
+  scheduler:
+    image: boom/boom-scheduler:latest
+    hostname: scheduler
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: scheduler
+    networks:
+      - boom
+    profiles:
+      - prod
+    volumes:
+      - ${PWD}/config.yaml:/app/config.yaml


### PR DESCRIPTION
This is set up to be able to build a different image for each executable, e.g., with `docker build --target api -t boom-api .`. I've never done this before, but it looks pretty convenient since Docker Compose can set the `target` as a build arg:

```yaml
services:
  api:
    build:
      context: .
      dockerfile: Dockerfile
      target: api
    image: boom/boom-api:latest
    ports:
      - "4000:4000"
  scheduler:
    build:
      context: .
      dockerfile: Dockerfile
      target: scheduler
    image: boom/boom-scheduler:latest
 ```

The ultimate goal is to be able to run the entire app (all services) with `docker compose up`, merging in a separate dev Docker Compose config for local development, which would ideally use `cargo-watch` and mount the local working directory.