### PR TITLE
ML dependency update + coreml support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.9.0",
  "sha1",
- "smallvec",
+ "smallvec 1.15.0",
  "tokio",
  "tokio-util",
  "tracing",
@@ -167,7 +167,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "smallvec",
+ "smallvec 1.15.0",
  "socket2",
  "time",
  "tracing",
@@ -428,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bcrypt"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +525,7 @@ dependencies = [
  "ndarray",
  "openssl",
  "ort",
+ "ort-sys",
  "rand 0.9.0",
  "rdkafka",
  "redis",
@@ -1022,6 +1029,16 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1584,7 +1601,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "resolv-conf",
- "smallvec",
+ "smallvec 1.15.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1682,7 +1699,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec",
+ "smallvec 1.15.0",
  "tokio",
  "want",
 ]
@@ -1820,7 +1837,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.15.0",
  "utf16_iter",
  "utf8_iter",
  "write16",
@@ -1895,7 +1912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.15.0",
  "utf8_iter",
 ]
 
@@ -2367,7 +2384,7 @@ dependencies = [
  "tokio-util",
  "typed-builder 0.10.0",
  "uuid",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2582,21 +2599,21 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
 dependencies = [
- "half",
  "ndarray",
  "ort-sys",
+ "smallvec 2.0.0-alpha.10",
  "tracing",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -2640,7 +2657,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.15.0",
  "windows-targets 0.52.6",
 ]
 
@@ -2657,6 +2674,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3201,9 +3227,7 @@ version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.1",
  "subtle",
@@ -3528,6 +3552,12 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "smallvec"
+version = "2.0.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
 name = "socket2"
@@ -4038,7 +4068,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.15.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -4203,18 +4233,33 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
+ "der",
  "log",
- "once_cell",
- "rustls 0.23.26",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "socks",
- "url",
- "webpki-roots 0.26.8",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs 0.26.11",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -4227,6 +4272,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -4451,19 +4502,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.1",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
-]
 
 [[package]]
 name = "widestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,6 @@ dependencies = [
  "ndarray",
  "openssl",
  "ort",
- "ort-sys",
  "rand 0.9.1",
  "rdkafka",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ flate2 = "1.1.0"
 reqwest = { version = "0.12.12", features = ["json", "stream"] }
 async-trait = "0.1.87"
 serde_with = "3.12.0"
-ort-sys = "2.0.0-rc.10"
 zune-inflate = { version = "0.2", default-features = false, features = [
     "gzip",
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ flate2 = "1.1.0"
 reqwest = { version = "0.12.12", features = ["json", "stream"] }
 async-trait = "0.1.87"
 serde_with = "3.12.0"
-ort = { version = "=2.0.0-rc.9", features = ["cuda"] }
+ort-sys = "2.0.0-rc.10"
 zune-inflate = { version = "0.2", default-features = false, features = [
     "gzip",
     "std",
@@ -40,6 +40,14 @@ rand = "0.9.0"
 openssl = { version = "0.10.72", features = ["vendored"] }
 tempfile = "3.20.0"
 indicatif = "0.17.11"
+
+# on mac os silicon platform, install ort with the coreml feature
+[target.'cfg(target_os = "macos")'.dependencies]
+ort = { version = "=2.0.0-rc.10", features = ["coreml"] }
+
+# otherwise, install ort with the cuda feature
+[target.'cfg(target_os = "linux")'.dependencies]
+ort = { version = "=2.0.0-rc.10", features = ["cuda"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -233,6 +233,7 @@ pub trait AlertWorker {
     ) -> Result<ProcessAlertStatus, AlertError>;
 }
 
+#[instrument(skip_all)]
 fn report_progress(start: &std::time::Instant, stream: &str, count: u64, message: &str) {
     let elapsed = start.elapsed().as_secs();
     info!(
@@ -244,6 +245,58 @@ fn report_progress(start: &std::time::Instant, stream: &str, count: u64, message
         message,
     );
 }
+
+#[instrument(skip_all, err)]
+async fn retrieve_avro_bytes(
+    con: &mut redis::aio::MultiplexedConnection,
+    input_queue_name: &str,
+    temp_queue_name: &str,
+) -> Result<Option<Vec<u8>>, AlertWorkerError> {
+    let result: Option<Vec<Vec<u8>>> = con
+        .rpoplpush(&input_queue_name, &temp_queue_name)
+        .await
+        .inspect_err(as_error!("failed to pop from input queue"))?;
+
+    match result {
+        Some(mut value) => match value.remove(0) {
+            avro_bytes if !avro_bytes.is_empty() => Ok(Some(avro_bytes)),
+            _ => Err(AlertWorkerError::GetAvroBytesError),
+        },
+        None => Ok(None),
+    }
+}
+
+#[instrument(skip_all, err)]
+async fn handle_process_result(
+    con: &mut redis::aio::MultiplexedConnection,
+    temp_queue_name: &str,
+    output_queue_name: &str,
+    avro_bytes: Vec<u8>,
+    result: Result<ProcessAlertStatus, AlertError>,
+) -> Result<(), AlertWorkerError> {
+    match result {
+        Ok(ProcessAlertStatus::Added(candid)) => {
+            // queue the candid for processing by the classifier
+            con.lpush::<&str, i64, isize>(&output_queue_name, candid)
+                .await
+                .inspect_err(as_error!("failed to push to output queue"))?;
+            con.lrem::<&str, Vec<u8>, isize>(temp_queue_name, 1, avro_bytes)
+                .await
+                .inspect_err(as_error!("failed to remove new alert from temp queue"))?;
+        }
+        Ok(ProcessAlertStatus::Exists(candid)) => {
+            debug!(?candid, "alert already exists");
+            con.lrem::<&str, Vec<u8>, isize>(temp_queue_name, 1, avro_bytes)
+                .await
+                .inspect_err(as_error!("failed to remove existing alert from temp queue"))?;
+        }
+        Err(error) => {
+            log_error!(WARN, error, "error processing alert, skipping");
+        }
+    }
+    Ok(())
+}
+
 #[tokio::main]
 #[instrument(skip_all, err)]
 pub async fn run_alert_worker<T: AlertWorker>(
@@ -279,50 +332,33 @@ pub async fn run_alert_worker<T: AlertWorker>(
             }
         }
         command_check_countdown -= 1;
-        // retrieve candids from redis
-        let Some(mut value): Option<Vec<Vec<u8>>> = con
-            .rpoplpush(&input_queue_name, &temp_queue_name)
-            .await
-            .inspect_err(as_error!("failed to pop from input queue"))?
-        else {
-            info!("queue is empty");
-            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-            command_check_countdown = 0;
-            continue;
+
+        let result = retrieve_avro_bytes(&mut con, &input_queue_name, &temp_queue_name).await;
+
+        let avro_bytes = match result {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => {
+                info!("queue is empty");
+                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                command_check_countdown = 0;
+                continue;
+            }
+            Err(e) => {
+                error!(?e, "failed to retrieve avro bytes");
+                continue;
+            }
         };
-        let avro_bytes = (!value.is_empty())
-            .then_some(value.remove(0))
-            .ok_or(AlertWorkerError::GetAvroBytesError)?;
 
         let result = alert_processor.process_alert(&avro_bytes).await;
-        match result {
-            Ok(ProcessAlertStatus::Added(candid)) => {
-                // queue the candid for processing by the classifier
-                con.lpush::<&str, i64, isize>(&output_queue_name, candid)
-                    .await
-                    .inspect_err(as_error!("failed to push to output queue"))?;
-                con.lrem::<&str, Vec<u8>, isize>(&temp_queue_name, 1, avro_bytes)
-                    .await
-                    .inspect_err(as_error!("failed to remove new alert from temp queue"))?;
-            }
-            Ok(ProcessAlertStatus::Exists(candid)) => {
-                debug!(?candid, "alert already exists");
-                con.lrem::<&str, Vec<u8>, isize>(&temp_queue_name, 1, avro_bytes)
-                    .await
-                    .inspect_err(as_error!("failed to remove existing alert from temp queue"))?;
-            }
-            Err(error) => {
-                log_error!(WARN, error, "error processing alert, skipping");
-                // TODO: Handle alerts that we could not parse from avro
-                // so we don't re-push them to the queue
-                // con.lpush::<&str, Vec<u8>, isize>(&input_queue_name, avro_bytes.clone())
-                //     .await
-                //     .map_err(AlertWorkerError::PushAlertError)?;
-                // con.lrem::<&str, Vec<u8>, isize>(&temp_queue_name, 1, avro_bytes)
-                //     .await
-                //     .map_err(AlertWorkerError::RemoveAlertError)?;
-            }
-        }
+        handle_process_result(
+            &mut con,
+            &temp_queue_name,
+            &output_queue_name,
+            avro_bytes,
+            result,
+        )
+        .await
+        .inspect_err(as_error!("failed to handle process result"))?;
         if count > 0 && count % 1000 == 0 {
             report_progress(&start, &stream_name, count, "progress");
         }

--- a/src/alert/mod.rs
+++ b/src/alert/mod.rs
@@ -2,8 +2,8 @@ mod base;
 mod lsst;
 mod ztf;
 pub use base::{
-    run_alert_worker, AlertError, AlertWorker, AlertWorkerError, ProcessAlertStatus,
-    SchemaRegistry, SchemaRegistryError,
+    run_alert_worker, run_alert_worker_v2, AlertError, AlertWorker, AlertWorkerError,
+    ProcessAlertStatus, SchemaRegistry, SchemaRegistryError,
 };
 pub use lsst::{LsstAlertWorker, LSST_SCHEMA_REGISTRY_URL};
 pub use ztf::{ZtfAlertWorker, LSST_DEC_LIMIT, LSST_XMATCH_RADIUS};

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -54,7 +54,7 @@ async fn run(args: Cli) {
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     tokio::spawn(
         async {
-            info!("wating for ctrl-c");
+            info!("waiting for ctrl-c");
             tokio::signal::ctrl_c()
                 .await
                 .expect("failed to listen for ctrl-c event");

--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -40,7 +40,7 @@ pub trait MLWorker {
         &self,
         candids: &[i64], // this is a slice of candids to process
     ) -> Result<Vec<Document>, MLWorkerError>;
-    async fn process_alerts(&self, alerts: &[i64]) -> Result<Vec<String>, MLWorkerError>;
+    async fn process_alerts(&mut self, alerts: &[i64]) -> Result<Vec<String>, MLWorkerError>;
 }
 
 #[tokio::main]
@@ -50,7 +50,7 @@ pub async fn run_ml_worker<T: MLWorker>(
     config_path: &str,
 ) -> Result<(), MLWorkerError> {
     debug!(?config_path);
-    let ml_worker = T::new(config_path).await?;
+    let mut ml_worker = T::new(config_path).await?;
 
     let config = conf::load_config(config_path)?;
     let mut con = conf::build_redis(&config).await?;

--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -6,7 +6,6 @@ use crate::{
         worker::{should_terminate, WorkerCmd},
     },
 };
-
 use mongodb::bson::Document;
 use redis::AsyncCommands;
 use std::num::NonZero;

--- a/src/ml/models/acai.rs
+++ b/src/ml/models/acai.rs
@@ -1,20 +1,22 @@
-use ndarray::{Array, Dim};
-use ort::{inputs, session::Session, value::TensorRef};
-
 use crate::ml::models::{load_model, Model, ModelError};
 use mongodb::bson::Document;
+use ndarray::{Array, Dim};
+use ort::{inputs, session::Session, value::TensorRef};
+use tracing::instrument;
 
 pub struct AcaiModel {
     model: Session,
 }
 
 impl Model for AcaiModel {
+    #[instrument(err)]
     fn new(path: &str) -> Result<Self, ModelError> {
         Ok(Self {
             model: load_model(&path)?,
         })
     }
 
+    #[instrument(skip_all, err)]
     fn get_metadata(&self, alerts: &[Document]) -> Result<Array<f32, Dim<[usize; 2]>>, ModelError> {
         let mut features_batch: Vec<f32> = Vec::with_capacity(alerts.len() * 25);
 
@@ -89,6 +91,7 @@ impl Model for AcaiModel {
         Ok(features_array)
     }
 
+    #[instrument(skip_all, err)]
     fn predict(
         &mut self,
         metadata_features: &Array<f32, Dim<[usize; 2]>>,

--- a/src/ml/models/base.rs
+++ b/src/ml/models/base.rs
@@ -1,9 +1,6 @@
 use ndarray::{Array, Dim};
 use ort::{
-    execution_providers::{
-        CUDAExecutionProvider,
-        // CoreMLExecutionProvider
-    },
+    execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider},
     session::{builder::GraphOptimizationLevel, Session},
 };
 
@@ -32,6 +29,7 @@ pub fn load_model(path: &str) -> Result<Session, ModelError> {
     let model = builder
         .with_execution_providers([
             CUDAExecutionProvider::default().build(),
+            CoreMLExecutionProvider::default().build(),
             // adding the coreml feature in Cargo.toml is creating some issues
             // at compile time. Needs to be fixed so we can add this back
             // CoreMLExecutionProvider::default().build(),
@@ -65,7 +63,7 @@ pub trait Model {
         Ok(triplets)
     }
     fn predict(
-        &self,
+        &mut self,
         metadata_features: &Array<f32, Dim<[usize; 2]>>,
         image_features: &Array<f32, Dim<[usize; 4]>>,
     ) -> Result<Vec<f32>, ModelError>;

--- a/src/ml/models/base.rs
+++ b/src/ml/models/base.rs
@@ -1,8 +1,8 @@
-use ndarray::{Array, Dim};
-use ort::session::{builder::GraphOptimizationLevel, Session};
-
 use crate::utils::fits::{prepare_triplet, CutoutError};
 use mongodb::bson::Document;
+use ndarray::{Array, Dim};
+use ort::session::{builder::GraphOptimizationLevel, Session};
+use tracing::instrument;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ModelError {
@@ -42,6 +42,7 @@ pub trait Model {
     where
         Self: Sized;
     fn get_metadata(&self, alerts: &[Document]) -> Result<Array<f32, Dim<[usize; 2]>>, ModelError>;
+    #[instrument(skip_all, err)]
     fn get_triplet(&self, alerts: &[Document]) -> Result<Array<f32, Dim<[usize; 4]>>, ModelError> {
         let mut triplets = Array::zeros((alerts.len(), 63, 63, 3));
         for i in 0..alerts.len() {

--- a/src/ml/models/base.rs
+++ b/src/ml/models/base.rs
@@ -28,11 +28,10 @@ pub fn load_model(path: &str) -> Result<Session, ModelError> {
     // it will fall back to CPU execution provider
     let model = builder
         .with_execution_providers([
+            #[cfg(target_os = "linux")]
             CUDAExecutionProvider::default().build(),
+            #[cfg(target_os = "macos")]
             CoreMLExecutionProvider::default().build(),
-            // adding the coreml feature in Cargo.toml is creating some issues
-            // at compile time. Needs to be fixed so we can add this back
-            // CoreMLExecutionProvider::default().build(),
         ])?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
         .with_intra_threads(1)?

--- a/src/ml/models/base.rs
+++ b/src/ml/models/base.rs
@@ -1,8 +1,5 @@
 use ndarray::{Array, Dim};
-use ort::{
-    execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider},
-    session::{builder::GraphOptimizationLevel, Session},
-};
+use ort::session::{builder::GraphOptimizationLevel, Session};
 
 use crate::utils::fits::{prepare_triplet, CutoutError};
 use mongodb::bson::Document;
@@ -29,9 +26,9 @@ pub fn load_model(path: &str) -> Result<Session, ModelError> {
     let model = builder
         .with_execution_providers([
             #[cfg(target_os = "linux")]
-            CUDAExecutionProvider::default().build(),
+            ort::execution_providers::CUDAExecutionProvider::default().build(),
             #[cfg(target_os = "macos")]
-            CoreMLExecutionProvider::default().build(),
+            ort::execution_providers::CoreMLExecutionProvider::default().build(),
         ])?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
         .with_intra_threads(1)?

--- a/src/ml/models/btsbot.rs
+++ b/src/ml/models/btsbot.rs
@@ -1,5 +1,5 @@
 use ndarray::{Array, Dim};
-use ort::{inputs, session::Session};
+use ort::{inputs, session::Session, value::TensorRef};
 
 use crate::ml::models::{load_model, Model, ModelError};
 use mongodb::bson::Document;
@@ -120,20 +120,20 @@ impl Model for BtsBotModel {
     }
 
     fn predict(
-        &self,
+        &mut self,
         metadata_features: &Array<f32, Dim<[usize; 2]>>,
         image_features: &Array<f32, Dim<[usize; 4]>>,
     ) -> Result<Vec<f32>, ModelError> {
         let model_inputs = inputs! {
-            "triplet" => image_features.clone(),
-            "metadata" =>  metadata_features.clone(),
-        }?;
+            "triplet" => TensorRef::from_array_view(image_features)?,
+            "metadata" => TensorRef::from_array_view(metadata_features)?,
+        };
 
         let outputs = self.model.run(model_inputs)?;
 
-        match outputs["fc_out"].try_extract_tensor::<f32>()?.as_slice() {
-            Some(scores) => Ok(scores.to_vec()),
-            None => Err(ModelError::ModelOutputToVecError),
+        match outputs["fc_out"].try_extract_tensor::<f32>() {
+            Ok((_, scores)) => Ok(scores.to_vec()),
+            Err(_) => Err(ModelError::ModelOutputToVecError),
         }
     }
 }

--- a/src/ml/models/btsbot.rs
+++ b/src/ml/models/btsbot.rs
@@ -1,20 +1,22 @@
-use ndarray::{Array, Dim};
-use ort::{inputs, session::Session, value::TensorRef};
-
 use crate::ml::models::{load_model, Model, ModelError};
 use mongodb::bson::Document;
+use ndarray::{Array, Dim};
+use ort::{inputs, session::Session, value::TensorRef};
+use tracing::instrument;
 
 pub struct BtsBotModel {
     model: Session,
 }
 
 impl Model for BtsBotModel {
+    #[instrument(err)]
     fn new(path: &str) -> Result<Self, ModelError> {
         Ok(Self {
             model: load_model(&path)?,
         })
     }
 
+    #[instrument(skip_all, err)]
     fn get_metadata(&self, alerts: &[Document]) -> Result<Array<f32, Dim<[usize; 2]>>, ModelError> {
         let mut features_batch: Vec<f32> = Vec::with_capacity(alerts.len() * 25);
 
@@ -119,6 +121,7 @@ impl Model for BtsBotModel {
         Ok(features_array)
     }
 
+    #[instrument(skip_all, err)]
     fn predict(
         &mut self,
         metadata_features: &Array<f32, Dim<[usize; 2]>>,

--- a/src/ml/ztf.rs
+++ b/src/ml/ztf.rs
@@ -62,7 +62,7 @@ impl MLWorker for ZtfMLWorker {
         self.output_queue.clone()
     }
 
-    #[instrument(skip(self, candids), err)]
+    #[instrument(skip_all, err)]
     async fn fetch_alerts(
         &self,
         candids: &[i64], // this is a slice of candids to process
@@ -190,7 +190,7 @@ impl MLWorker for ZtfMLWorker {
         Ok(alerts)
     }
 
-    #[instrument(skip(self, candids), err)]
+    #[instrument(skip_all, err)]
     async fn process_alerts(&mut self, candids: &[i64]) -> Result<Vec<String>, MLWorkerError> {
         let alerts = self.fetch_alerts(&candids).await?;
 

--- a/src/ml/ztf.rs
+++ b/src/ml/ztf.rs
@@ -3,7 +3,7 @@ use crate::ml::{MLWorker, MLWorkerError};
 use futures::StreamExt;
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 pub struct ZtfMLWorker {
     input_queue: String,
@@ -20,6 +20,7 @@ pub struct ZtfMLWorker {
 
 #[async_trait::async_trait]
 impl MLWorker for ZtfMLWorker {
+    #[instrument(err)]
     async fn new(config_path: &str) -> Result<Self, MLWorkerError> {
         let config_file = crate::conf::load_config(&config_path)?;
         let db: mongodb::Database = crate::conf::build_db(&config_file).await?;
@@ -61,6 +62,7 @@ impl MLWorker for ZtfMLWorker {
         self.output_queue.clone()
     }
 
+    #[instrument(skip(self, candids), err)]
     async fn fetch_alerts(
         &self,
         candids: &[i64], // this is a slice of candids to process
@@ -188,7 +190,8 @@ impl MLWorker for ZtfMLWorker {
         Ok(alerts)
     }
 
-    async fn process_alerts(&self, candids: &[i64]) -> Result<Vec<String>, MLWorkerError> {
+    #[instrument(skip(self, candids), err)]
+    async fn process_alerts(&mut self, candids: &[i64]) -> Result<Vec<String>, MLWorkerError> {
         let alerts = self.fetch_alerts(&candids).await?;
 
         if alerts.len() != candids.len() {

--- a/src/utils/spatial.rs
+++ b/src/utils/spatial.rs
@@ -21,7 +21,7 @@ pub enum XmatchError {
     AsDocumentError,
 }
 
-#[instrument(skip(xmatch_configs), fields(database = db.name()), err)]
+#[instrument(skip(xmatch_configs, db), fields(database = db.name()), err)]
 pub async fn xmatch(
     ra: f64,
     dec: f64,

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -404,7 +404,7 @@ async fn test_ml_ztf_alert() {
     let status = alert_worker.process_alert(&bytes_content).await.unwrap();
     assert_eq!(status, ProcessAlertStatus::Added(candid));
 
-    let ml_worker = ZtfMLWorker::new(TEST_CONFIG_FILE).await.unwrap();
+    let mut ml_worker = ZtfMLWorker::new(TEST_CONFIG_FILE).await.unwrap();
     let result = ml_worker.process_alerts(&[candid]).await;
     assert!(result.is_ok());
 
@@ -453,7 +453,7 @@ async fn test_filter_ztf_alert() {
     assert_eq!(status, ProcessAlertStatus::Added(candid));
 
     // then run the ML worker to get the classifications
-    let ml_worker = ZtfMLWorker::new(TEST_CONFIG_FILE).await.unwrap();
+    let mut ml_worker = ZtfMLWorker::new(TEST_CONFIG_FILE).await.unwrap();
     let result = ml_worker.process_alerts(&[candid]).await;
     assert!(result.is_ok());
     // the result should be a vec of String, for ZTF with the format


### PR DESCRIPTION
In this PR we:
- update to ort version rc10 + fix some breaking changes
- conditional dependencies declaration for the execution provider features of ort, to add the coreml feature on macos and cuda on linux. Previously we could not take advantage of the coreml API on mac as adding it as a feature to Cargo.toml caused the build to fail on non-mac systems
- conditionally register the execution provider based on the target os (same logic as for the dependency)
- added instrumentation to all ML worker methods for which monitoring performance at our stage of the development can prove useful (which for now, is most!).

Also (and somewhat unrelated to this one):
- we wrap some of the code in the  main loop of the `run_alert_worker` function, so we can have a slightly better coverage of the content of this function.
- update the Cargo.lock overall, doesn't hurt to keep things fresh!

PS: 
- Unclear how the `Cargo.lock` behaves once you have conditional dependencies (which in general seems to be a common practice and not an anti-pattern), should we still add it to the repo? 
- Also what about the old intel macs, that are on macos but don't have silicon processors. Do they still have some version of `coreml` or it is silicon specific? Maybe @jesaerys can be the one validating that this works there too, or if I need to do a target os + architecture exception (which is fine!)