### PR TITLE
Kafka Consumer: custom vs hardcoded topic bugfix

### DIFF
--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -73,11 +73,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let consumer = ZtfAlertConsumer::new(
                 processes,
                 Some(max_in_queue),
-                Some(&format!(
-                    "ztf_{}_programid{}",
-                    date.format("%Y%m%d"),
-                    program_id
-                )),
                 None,
                 None,
                 None,
@@ -93,7 +88,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let consumer = LsstAlertConsumer::new(
                 processes,
                 Some(max_in_queue),
-                Some(&format!("lsst_{}_programid1", date.format("%Y%m%d"))),
+                // Default topic for LSST, until we get real data
+                // TODO: let the user specify if they want to consume real or simulated data
+                Some("alerts-simulated"),
                 None,
                 None,
                 None,

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -68,6 +68,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let survey = args.survey;
 
+    // TODO: let the user specify if they want to consume real or simulated LSST data
+    let simulated = match survey {
+        Survey::Lsst => true,
+        _ => false,
+    };
+
     match survey {
         Survey::Ztf => {
             let consumer = ZtfAlertConsumer::new(
@@ -88,12 +94,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let consumer = LsstAlertConsumer::new(
                 processes,
                 Some(max_in_queue),
-                // Default topic for LSST, until we get real data
-                // TODO: let the user specify if they want to consume real or simulated data
-                Some("alerts-simulated"),
                 None,
                 None,
                 None,
+                Some(simulated),
                 &config_path,
             );
             if clear {

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 None,
                 None,
                 None,
-                Some(simulated),
+                simulated,
                 &config_path,
             );
             if clear {

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -34,7 +34,7 @@ impl LsstAlertConsumer {
             panic!("Number of threads should be a factor of 45");
         }
         let max_in_queue = max_in_queue.unwrap_or(15000);
-        let topic = if simulated.unwrap_or(false) {
+        let topic = if simulated.unwrap_or(true) {
             "alerts-simulated".to_string()
         } else {
             "alerts".to_string()

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -23,10 +23,10 @@ impl LsstAlertConsumer {
     pub fn new(
         n_threads: usize,
         max_in_queue: Option<usize>,
-        topic: Option<&str>,
         output_queue: Option<&str>,
         group_id: Option<&str>,
         server_url: Option<&str>,
+        simulated: Option<bool>,
         config_path: &str,
     ) -> Self {
         // 45 should be divisible by n_threads
@@ -34,7 +34,11 @@ impl LsstAlertConsumer {
             panic!("Number of threads should be a factor of 45");
         }
         let max_in_queue = max_in_queue.unwrap_or(15000);
-        let topic = topic.unwrap_or("alerts-simulated").to_string();
+        let topic = if simulated.unwrap_or(false) {
+            "alerts-simulated".to_string()
+        } else {
+            "alerts".to_string()
+        };
         let output_queue = output_queue
             .unwrap_or("LSST_alerts_packets_queue")
             .to_string();

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -8,7 +8,6 @@ use tracing::{error, info};
 const LSST_SERVER_URL: &str = "usdf-alert-stream-dev.lsst.cloud:9094";
 
 pub struct LsstAlertConsumer {
-    topic: String,
     output_queue: String,
     n_threads: usize,
     max_in_queue: usize,
@@ -17,6 +16,7 @@ pub struct LsstAlertConsumer {
     password: String,
     server: String,
     config_path: String,
+    simulated: bool,
 }
 
 impl LsstAlertConsumer {
@@ -26,7 +26,7 @@ impl LsstAlertConsumer {
         output_queue: Option<&str>,
         group_id: Option<&str>,
         server_url: Option<&str>,
-        simulated: Option<bool>,
+        simulated: bool,
         config_path: &str,
     ) -> Self {
         // 45 should be divisible by n_threads
@@ -34,11 +34,6 @@ impl LsstAlertConsumer {
             panic!("Number of threads should be a factor of 45");
         }
         let max_in_queue = max_in_queue.unwrap_or(15000);
-        let topic = if simulated.unwrap_or(true) {
-            "alerts-simulated".to_string()
-        } else {
-            "alerts".to_string()
-        };
         let output_queue = output_queue
             .unwrap_or("LSST_alerts_packets_queue")
             .to_string();
@@ -46,8 +41,8 @@ impl LsstAlertConsumer {
         let server = server_url.unwrap_or(LSST_SERVER_URL).to_string();
 
         info!(
-            "Creating AlertConsumer with {} threads, topic: {}, output_queue: {}, group_id: {}, server: {}",
-            n_threads, topic, output_queue, group_id, server
+            "Creating AlertConsumer with {} threads, output_queue: {}, group_id: {}, server: {} (simulated data: {})",
+            n_threads, output_queue, group_id, server, simulated
         );
 
         // we check that the username and password are set
@@ -64,7 +59,6 @@ impl LsstAlertConsumer {
         group_id = format!("{}-{}", username.as_ref().unwrap(), group_id);
 
         LsstAlertConsumer {
-            topic,
             output_queue,
             n_threads,
             max_in_queue,
@@ -73,6 +67,7 @@ impl LsstAlertConsumer {
             password: password.unwrap(),
             server,
             config_path: config_path.to_string(),
+            simulated,
         }
     }
 }
@@ -80,9 +75,14 @@ impl LsstAlertConsumer {
 #[async_trait::async_trait]
 impl AlertConsumer for LsstAlertConsumer {
     fn default(config_path: &str) -> Self {
-        Self::new(1, None, None, None, None, None, config_path)
+        Self::new(1, None, None, None, None, true, config_path)
     }
     async fn consume(&self, timestamp: i64) -> Result<(), Box<dyn std::error::Error>> {
+        let topic = if self.simulated {
+            "alerts-simulated".to_string()
+        } else {
+            "alerts".to_string()
+        };
         // divide the 45 LSST partitions for the n_threads that will read them
         let partitions_per_thread = 45 / self.n_threads;
         let mut partitions = vec![vec![]; self.n_threads];
@@ -93,7 +93,7 @@ impl AlertConsumer for LsstAlertConsumer {
         // spawn n_threads to consume each partitions subset
         let mut handles = vec![];
         for i in 0..self.n_threads {
-            let topic = self.topic.clone();
+            let topic = topic.clone();
             let partitions = partitions[i].clone();
             let max_in_queue = self.max_in_queue;
             let output_queue = self.output_queue.clone();

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -27,7 +27,6 @@ impl ZtfAlertConsumer {
     pub fn new(
         n_threads: usize,
         max_in_queue: Option<usize>,
-        topic: Option<&str>,
         output_queue: Option<&str>,
         group_id: Option<&str>,
         server: Option<&str>,
@@ -38,12 +37,6 @@ impl ZtfAlertConsumer {
             panic!("Number of threads should be a factor of 15");
         }
         let max_in_queue = max_in_queue.unwrap_or(15000);
-        let topic = topic
-            .unwrap_or(&format!(
-                "ztf_{}_programid1",
-                chrono::Utc::now().format("%Y%m%d")
-            ))
-            .to_string();
         let output_queue = output_queue
             .unwrap_or("ZTF_alerts_packets_queue")
             .to_string();
@@ -53,8 +46,8 @@ impl ZtfAlertConsumer {
         group_id = format!("{}-{}", "ztf", group_id);
 
         info!(
-            "Creating AlertConsumer with {} threads, topic: {}, output_queue: {}, group_id: {}, server: {}",
-            n_threads, topic, output_queue, group_id, server
+            "Creating AlertConsumer with {} threads, output_queue: {}, group_id: {}, server: {}",
+            n_threads, output_queue, group_id, server
         );
 
         ZtfAlertConsumer {
@@ -72,16 +65,7 @@ impl ZtfAlertConsumer {
 #[async_trait::async_trait]
 impl AlertConsumer for ZtfAlertConsumer {
     fn default(config_path: &str) -> Self {
-        Self::new(
-            1,
-            None,
-            None,
-            None,
-            None,
-            None,
-            ProgramId::Public,
-            config_path,
-        )
+        Self::new(1, None, None, None, None, ProgramId::Public, config_path)
     }
 
     async fn consume(&self, timestamp: i64) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
There is some confusion in the kafka consumer structs and associated binary, as we used to be able to pass custom topics to read from (useful before we were able to automagically infer the topic name from a date) but for ZTF the parameter still existed but was ignored, and for LSST it still existed when we always want to read from the same one topic which holds the simulated data from Rubin.

This in this PR:
- remove the unused topic parameter from the `new` function to instantiate the `ZtfAlertConsumer`
- replace the `topic` parameter by a safer and more explicit `simulated` (bool) parameter which for now we forced to true, and will change to a clap parameter once we have real LSST data and an associated topic to read from.