### PR TITLE
Add GitHub Actions workflow to build Docker image on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Create and publish Docker image
+name: Create and publish Docker images
 
 on:
   release:
@@ -9,7 +9,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  build-and-push-images:
     runs-on: ubuntu-latest
 
     permissions:
@@ -29,34 +29,59 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image
-        id: push
+      - name: Extract metadata (tags, labels) for API image
+        id: meta_api
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-api
+
+      - name: Extract metadata (tags, labels) for API image
+        id: meta_scheduler
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-scheduler
+
+      - name: Build and push API image
+        id: push_api
         uses: docker/build-push-action@v6
         with:
           context: .
+          target: api
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_api.outputs.tags }}
+          labels: ${{ steps.meta_api.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push scheduler image
+        id: push_scheduler
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: scheduler
+          push: true
+          tags: ${{ steps.meta_scheduler.outputs.tags }}
+          labels: ${{ steps.meta_scheduler.outputs.labels }}
           platforms: linux/amd64,linux/arm64
 
       # This step generates an artifact attestation for the image,
       # which is an unforgettable statement about where and how it was built
       # It increases supply chain security for people who consume the image.
-      - name: Generate artifact attestation
+      - name: Generate artifact attestation for API image
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-api
+          subject-digest: ${{ steps.push_api.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for scheduler image
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-scheduler
+          subject-digest: ${{ steps.push_scheduler.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,62 @@
+name: Create and publish Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+      # This step generates an artifact attestation for the image,
+      # which is an unforgettable statement about where and how it was built
+      # It increases supply chain security for people who consume the image.
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Towards #184 

We may need to enable the public container package feature for this repo, but this workflow, upon publishing a new release, will build a Docker image and push it to the GitHub Container Registry. This way, anyone who wants to deploy BOOM (including Caltech), can use the image `ghcr.io/boom-astro/boom:vX.X.X-scheduler` and Docker Compose, Kubernetes, etc., will pull the scheduler image to run on their server or cluster. To run the API server, they can replace `scheduler` with `api`. We'll probably need to add a Kafka consumer image at some point too.