### PR TITLE
Fix subtraction overflow in ml worker

### DIFF
--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -65,9 +65,8 @@ pub async fn run_ml_worker<T: MLWorker>(
             if should_terminate(&mut receiver) {
                 break;
             }
-            command_check_countdown = command_interval + 1;
+            command_check_countdown = command_interval;
         }
-        command_check_countdown -= 1;
         // if the queue is empty, wait for a bit and continue the loop
         let queue_len: i64 = con.llen(&input_queue).await?;
         if queue_len == 0 {
@@ -89,7 +88,7 @@ pub async fn run_ml_worker<T: MLWorker>(
         }
 
         let processed_alerts = ml_worker.process_alerts(&candids).await?;
-        command_check_countdown = command_check_countdown.saturating_sub(nb_candids - 1); // As if iterated this many times
+        command_check_countdown = command_check_countdown.saturating_sub(nb_candids); // As if iterated this many times
 
         // push that back to redis to the output queue
         con.lpush::<&str, Vec<String>, usize>(&output_queue, processed_alerts)

--- a/src/ml/base.rs
+++ b/src/ml/base.rs
@@ -64,9 +64,8 @@ pub async fn run_ml_worker<T: MLWorker>(
         if command_check_countdown == 0 {
             if should_terminate(&mut receiver) {
                 break;
-            } else {
-                command_check_countdown = command_interval + 1;
             }
+            command_check_countdown = command_interval + 1;
         }
         command_check_countdown -= 1;
         // if the queue is empty, wait for a bit and continue the loop
@@ -90,7 +89,7 @@ pub async fn run_ml_worker<T: MLWorker>(
         }
 
         let processed_alerts = ml_worker.process_alerts(&candids).await?;
-        command_check_countdown -= nb_candids - 1; // As if iterated this many times
+        command_check_countdown = command_check_countdown.saturating_sub(nb_candids - 1); // As if iterated this many times
 
         // push that back to redis to the output queue
         con.lpush::<&str, Vec<String>, usize>(&output_queue, processed_alerts)


### PR DESCRIPTION
Closes #182 

The main fix is in the first commit, 09cee74. We now use `saturating_sub` so that decrementing the counter evaluates to zero instead of panicking when the number of candids processed is greater than the counter's value.

The next commit, 3339df3, simplifies the manipulation of the counter. Looking at the code, I realized we didn't need to have little +1/-1 offsets. Hopefully this clarifies the logic a little.

Finally, commit b48f2ce simplifies things a little more by removing what appears to be a redundant check of whether there are any candids to process. In the original code, we first checked the length of the queue, handled the empty-queue case, then later popped from the queue and did another check to handle the empty-vector case. Both checks amount to the same thing, so this commit consolidates that logic. @Theodlz please correct me if I've gotten anything wrong on this point.