### PR TITLE
make consumer able to use given offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ dependencies = [
  "serde_json",
  "slab",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4", features = ["derive"] }
 flare = "0.1.0"
 futures = "0.3.31"
 mongodb = "3.2.0"
-rdkafka = { version = "0.37.0", features = ["gssapi", "ssl"] }
+rdkafka = { version = "0.37.0", features = ["gssapi", "ssl", "tracing"] }
 redis = { version = "0.28.2", features = ["tokio-comp"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.138"

--- a/docker-compose.default.yaml
+++ b/docker-compose.default.yaml
@@ -66,6 +66,9 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
       KAFKA_NUM_PARTITIONS: 15
+    healthcheck:
+      test: /opt/kafka/bin/kafka-cluster.sh cluster-id --bootstrap-server broker:9092
+      interval: 10s
   api:
     image: boom/boom-api:latest
     hostname: api

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -6,60 +6,59 @@ use boom::{
     },
 };
 
-use chrono::TimeZone;
+use chrono::{NaiveDate, NaiveDateTime};
 use clap::Parser;
 use tracing::instrument;
 
 #[derive(Parser)]
 struct Cli {
-    #[arg(value_enum, help = "Survey to consume alerts from.")]
+    /// Survey to consume alerts from
+    #[arg(value_enum)]
     survey: Survey,
-    #[arg(help = "UTC date for which we want to consume alerts, with format YYYYMMDD")]
-    date: Option<String>,
-    #[arg(
-        default_value_t,
-        value_enum,
-        help = "ID of the program to consume the alerts (ZTF-only)."
-    )]
+
+    /// UTC date for which we want to consume alerts, with format YYYYMMDD
+    /// [default: yesterday's date]
+    #[arg(value_parser = parse_date)]
+    date: Option<NaiveDate>, // Easier to deal with the default value after clap
+
+    /// ID of the program to consume the alerts (ZTF-only)
+    #[arg(default_value_t, value_enum)]
     program_id: ProgramId,
-    #[arg(long, value_name = "FILE", help = "Path to the configuration file")]
-    config: Option<String>,
-    #[arg(
-        long,
-        help = "Number of processes to use to read the Kafka stream in parallel"
-    )]
-    processes: Option<usize>,
-    #[arg(
-        long,
-        help = "Clear the in-memory (Valkey) queue of alerts already consumed from Kafka"
-    )]
-    clear: Option<bool>,
-    #[arg(
-        long,
-        help = "Set a maximum number of alerts to hold in memory (Valkey), default is 15000",
-        value_name = "MAX"
-    )]
-    max_in_queue: Option<usize>,
+
+    /// Path to the configuration file
+    #[arg(long, value_name = "FILE", default_value = "config.yaml")]
+    config: String,
+
+    /// Number of processes to use to read the Kafka stream in parallel
+    #[arg(long, default_value_t = 1)]
+    processes: usize,
+
+    /// Clear the in-memory (Valkey) queue of alerts already consumed from Kafka
+    #[arg(long)]
+    clear: bool,
+
+    /// Set a maximum number of alerts to hold in memory (Valkey), default is
+    /// 15000
+    #[arg(long, value_name = "MAX", default_value_t = 15000)]
+    max_in_queue: usize,
+}
+
+fn parse_date(s: &str) -> Result<NaiveDate, String> {
+    let date =
+        NaiveDate::parse_from_str(s, "%Y%m%d").map_err(|_| "expected a date in YYYYMMDD format")?;
+    Ok(date)
 }
 
 #[instrument(skip_all, fields(survey = %args.survey))]
 async fn run(args: Cli) {
-    let date = match args.date {
-        Some(date) => chrono::NaiveDate::parse_from_str(&date, "%Y%m%d")
-            .expect("failed to parse date string {date}"),
-        None => chrono::Utc::now().date_naive().pred_opt().unwrap(),
-    };
-    let date = date.and_hms_opt(0, 0, 0).unwrap();
-    let timestamp = chrono::Utc.from_utc_datetime(&date).timestamp();
-
-    let processes = args.processes.unwrap_or(1);
-    let max_in_queue = args.max_in_queue.unwrap_or(15000);
-    let clear = args.clear.unwrap_or(false);
-
-    let config_path = match args.config {
-        Some(path) => path,
-        None => "config.yaml".to_string(),
-    };
+    let timestamp = NaiveDateTime::from(args.date.unwrap_or_else(|| {
+        chrono::Utc::now()
+            .date_naive()
+            .pred_opt()
+            .expect("previous date is not representable")
+    }))
+    .and_utc()
+    .timestamp();
 
     // TODO: let the user specify if they want to consume real or simulated LSST data
     let simulated = match args.survey {
@@ -70,30 +69,30 @@ async fn run(args: Cli) {
     match args.survey {
         Survey::Ztf => {
             let consumer = ZtfAlertConsumer::new(
-                processes,
-                Some(max_in_queue),
+                args.processes,
+                Some(args.max_in_queue),
                 None,
                 None,
                 None,
                 args.program_id,
-                &config_path,
+                &args.config,
             );
-            if clear {
+            if args.clear {
                 let _ = consumer.clear_output_queue();
             }
             consumer.consume(timestamp).await;
         }
         Survey::Lsst => {
             let consumer = LsstAlertConsumer::new(
-                processes,
-                Some(max_in_queue),
+                args.processes,
+                Some(args.max_in_queue),
                 None,
                 None,
                 None,
                 simulated,
-                &config_path,
+                &args.config,
             );
-            if clear {
+            if args.clear {
                 let _ = consumer.clear_output_queue();
             }
             consumer.consume(timestamp).await;

--- a/src/bin/kafka_producer.rs
+++ b/src/bin/kafka_producer.rs
@@ -1,9 +1,13 @@
-use clap::Parser;
-use tracing::{error, Level};
-use tracing_subscriber::FmtSubscriber;
+use boom::{
+    kafka::{AlertProducer, ZtfAlertProducer},
+    utils::{
+        enums::{ProgramId, Survey},
+        o11y::build_subscriber,
+    },
+};
 
-use boom::kafka::{AlertProducer, ZtfAlertProducer};
-use boom::utils::enums::{ProgramId, Survey};
+use clap::Parser;
+use tracing::error;
 
 #[derive(Parser)]
 struct Cli {
@@ -25,11 +29,8 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    let (subscriber, _guard) = build_subscriber().expect("failed to build subscriber");
+    tracing::subscriber::set_global_default(subscriber).expect("failed to install subscriber");
 
     let args = Cli::parse();
 

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -43,29 +43,25 @@ pub async fn consume_partitions(
     config_path: &str,
 ) -> Result<(), ConsumerError> {
     debug!(?config_path);
-    let mut producer_config = ClientConfig::new();
-    producer_config
+    let mut client_config = ClientConfig::new();
+    client_config
         .set("bootstrap.servers", server)
         .set("security.protocol", "SASL_PLAINTEXT")
         .set("group.id", group_id)
         .set("debug", "consumer,cgrp,topic,fetch");
 
     if let (Some(username), Some(password)) = (username, password) {
-        producer_config
+        client_config
             .set("sasl.mechanisms", "SCRAM-SHA-512")
             .set("sasl.username", username)
             .set("sasl.password", password);
     } else {
-        producer_config.set("security.protocol", "PLAINTEXT");
+        client_config.set("security.protocol", "PLAINTEXT");
     }
 
-    let consumer: BaseConsumer = producer_config
+    let consumer: BaseConsumer = client_config
         .create()
         .inspect_err(as_error!("failed to create consumer"))?;
-
-    consumer
-        .subscribe(&[topic])
-        .inspect_err(as_error!("failed to subscribe to topic"))?;
 
     let mut timestamps = rdkafka::TopicPartitionList::new();
     let offset = rdkafka::Offset::Offset(timestamp);

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -1,16 +1,34 @@
+use crate::{conf, utils::o11y::as_error};
+
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::message::Message;
 use redis::AsyncCommands;
-use tracing::{error, info, trace};
-
-use crate::conf;
+use tracing::{debug, error, info, instrument, trace};
 
 #[async_trait::async_trait]
 pub trait AlertProducer {
     async fn produce(&self, topic: Option<String>) -> Result<i64, Box<dyn std::error::Error>>;
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ConsumerError {
+    #[error("error from boom::conf")]
+    Config(#[from] conf::BoomConfigError),
+    #[error("error from rdkafka")]
+    Kafka(#[from] rdkafka::error::KafkaError),
+    #[error("error from redis")]
+    Redis(#[from] redis::RedisError),
+}
+
+#[async_trait::async_trait]
+pub trait AlertConsumer: Sized {
+    fn default(config_path: &str) -> Self;
+    async fn consume(&self, timestamp: i64);
+    async fn clear_output_queue(&self) -> Result<(), ConsumerError>;
+}
+
+#[instrument(skip(username, password, config_path))]
 pub async fn consume_partitions(
     id: &str,
     topic: &str,
@@ -23,7 +41,8 @@ pub async fn consume_partitions(
     username: Option<&str>,
     password: Option<&str>,
     config_path: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), ConsumerError> {
+    debug!(?config_path);
     let mut producer_config = ClientConfig::new();
     producer_config
         .set("bootstrap.servers", server)
@@ -39,28 +58,34 @@ pub async fn consume_partitions(
         producer_config.set("security.protocol", "PLAINTEXT");
     }
 
-    let consumer: BaseConsumer = producer_config.create().unwrap();
+    let consumer: BaseConsumer = producer_config
+        .create()
+        .inspect_err(as_error!("failed to create consumer"))?;
 
-    consumer.subscribe(&[topic]).unwrap();
+    consumer
+        .subscribe(&[topic])
+        .inspect_err(as_error!("failed to subscribe to topic"))?;
 
     let mut timestamps = rdkafka::TopicPartitionList::new();
     let offset = rdkafka::Offset::Offset(timestamp);
     for i in &partitions {
-        let result = timestamps.add_partition(topic, *i).set_offset(offset);
-        if let Err(e) = result {
-            return Err(format!("Error adding partition: {:?}", e).into());
-        }
+        timestamps
+            .add_partition(topic, *i)
+            .set_offset(offset)
+            .inspect_err(as_error!("failed to add partition"))?
     }
-    let result = consumer.offsets_for_times(timestamps, std::time::Duration::from_secs(5));
-    if let Err(e) = result {
-        return Err(format!("Error fetching offsets: {:?}", e).into());
-    }
-    let tpl = result.unwrap();
+    let tpl = consumer
+        .offsets_for_times(timestamps, std::time::Duration::from_secs(5))
+        .inspect_err(as_error!("failed to fetch offsets"))?;
 
-    consumer.assign(&tpl).unwrap();
+    consumer
+        .assign(&tpl)
+        .inspect_err(as_error!("failed to assign topic partition list"))?;
 
-    let config = conf::load_config(config_path)?;
-    let mut con = conf::build_redis(&config).await?;
+    let config = conf::load_config(config_path).inspect_err(as_error!("failed to load config"))?;
+    let mut con = conf::build_redis(&config)
+        .await
+        .inspect_err(as_error!("failed to connect to redis"))?;
 
     let mut total = 0;
 
@@ -70,7 +95,10 @@ pub async fn consume_partitions(
     loop {
         if max_in_queue > 0 && total % 1000 == 0 {
             loop {
-                let nb_in_queue = con.llen::<&str, usize>(&output_queue).await.unwrap();
+                let nb_in_queue = con
+                    .llen::<&str, usize>(&output_queue)
+                    .await
+                    .inspect_err(as_error!("failed to get queue length"))?;
                 if nb_in_queue >= max_in_queue {
                     info!(
                         "{} (limit: {}) items in queue, sleeping...",
@@ -82,13 +110,13 @@ pub async fn consume_partitions(
                 break;
             }
         }
-        let message = consumer.poll(tokio::time::Duration::from_secs(5));
-        match message {
-            Some(Ok(msg)) => {
-                let payload = msg.payload().unwrap();
+        match consumer.poll(tokio::time::Duration::from_secs(5)) {
+            Some(result) => {
+                let message = result.inspect_err(as_error!("failed to get message"))?;
+                let payload = message.payload().unwrap_or_default();
                 con.rpush::<&str, Vec<u8>, usize>(&output_queue, payload.to_vec())
                     .await
-                    .unwrap();
+                    .inspect_err(as_error!("failed to push message to queue"))?;
                 trace!("Pushed message to redis");
                 total += 1;
                 if total % 1000 == 0 {
@@ -100,19 +128,9 @@ pub async fn consume_partitions(
                     );
                 }
             }
-            Some(Err(err)) => {
-                error!("Error: {:?}", err);
-            }
             None => {
                 trace!("No message available");
             }
         }
     }
-}
-
-#[async_trait::async_trait]
-pub trait AlertConsumer: Sized {
-    fn default(config_path: &str) -> Self;
-    async fn consume(&self, timestamp: i64) -> Result<(), Box<dyn std::error::Error>>;
-    async fn clear_output_queue(&self) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -47,7 +47,8 @@ pub async fn consume_partitions(
     producer_config
         .set("bootstrap.servers", server)
         .set("security.protocol", "SASL_PLAINTEXT")
-        .set("group.id", group_id);
+        .set("group.id", group_id)
+        .set("debug", "consumer,cgrp,topic,fetch");
 
     if let (Some(username), Some(password)) = (username, password) {
         producer_config

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::o11y::{as_error, log_error},
 };
 use redis::AsyncCommands;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 const LSST_SERVER_URL: &str = "usdf-alert-stream-dev.lsst.cloud:9094";
 

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -267,6 +267,7 @@ impl AlertProducer for ZtfAlertProducer {
             .set("acks", "1")
             .set("max.in.flight.requests.per.connection", "5")
             .set("retries", "3")
+            .set("debug", "broker,topic,msg")
             .create()
             .expect("Producer creation error");
 

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::{
         data::{count_files_in_dir, download_to_file},
         enums::ProgramId,
-        o11y::as_error,
+        o11y::{as_error, log_error},
     },
 };
 use indicatif::ProgressBar;
@@ -108,15 +108,17 @@ impl AlertConsumer for ZtfAlertConsumer {
                     &config_path,
                 )
                 .await;
-                if let Err(e) = result {
-                    error!("Error consuming partitions: {:?}", e);
+                if let Err(error) = result {
+                    log_error!(error, "failed to consume partitions");
                 }
             });
             handles.push(handle);
         }
 
         for handle in handles {
-            handle.await.unwrap();
+            if let Err(error) = handle.await {
+                log_error!(error, "failed to join task");
+            }
         }
     }
 

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -1,15 +1,18 @@
 use crate::{
     conf,
-    kafka::base::{consume_partitions, AlertConsumer, AlertProducer},
-    utils::data::{count_files_in_dir, download_to_file},
-    utils::enums::ProgramId,
+    kafka::base::{consume_partitions, AlertConsumer, AlertProducer, ConsumerError},
+    utils::{
+        data::{count_files_in_dir, download_to_file},
+        enums::ProgramId,
+        o11y::as_error,
+    },
 };
 use indicatif::ProgressBar;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use redis::AsyncCommands;
 use tempfile::NamedTempFile;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 
 const ZTF_SERVER_URL: &str = "localhost:9092";
 
@@ -24,6 +27,7 @@ pub struct ZtfAlertConsumer {
 }
 
 impl ZtfAlertConsumer {
+    #[instrument]
     pub fn new(
         n_threads: usize,
         max_in_queue: Option<usize>,
@@ -68,7 +72,8 @@ impl AlertConsumer for ZtfAlertConsumer {
         Self::new(1, None, None, None, None, ProgramId::Public, config_path)
     }
 
-    async fn consume(&self, timestamp: i64) -> Result<(), Box<dyn std::error::Error>> {
+    #[instrument(skip(self))]
+    async fn consume(&self, timestamp: i64) {
         let partitions_per_thread = 15 / self.n_threads;
         let mut partitions = vec![vec![]; self.n_threads];
         for i in 0..15 {
@@ -113,15 +118,20 @@ impl AlertConsumer for ZtfAlertConsumer {
         for handle in handles {
             handle.await.unwrap();
         }
-
-        Ok(())
     }
 
-    async fn clear_output_queue(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let config = conf::load_config(&self.config_path)?;
-        let mut con = conf::build_redis(&config).await?;
-        let _: () = con.del(&self.output_queue).await.unwrap();
-        info!("Cleared redis queued for ZTF Kafka consumer");
+    #[instrument(skip(self))]
+    async fn clear_output_queue(&self) -> Result<(), ConsumerError> {
+        let config =
+            conf::load_config(&self.config_path).inspect_err(as_error!("failed to load config"))?;
+        let mut con = conf::build_redis(&config)
+            .await
+            .inspect_err(as_error!("failed to connect to redis"))?;
+        let _: () = con
+            .del(&self.output_queue)
+            .await
+            .inspect_err(as_error!("failed to delete queue"))?;
+        info!("Cleared redis queue for ZTF Kafka consumer");
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #170.

The call to `consumer.subscribe` is removed so that `consumer.assign` can work properly. tl;dr `subscribe` and `assign` are incompatible APIs, and calling `subscribe` was preventing the subscriber from using the timestamp-based offsets we assign to it. See https://github.com/boom-astro/boom/issues/170#issuecomment-3034302595 for a more detailed explanation.

I've run this a number of times on the same topic (only running the producer once, not touching the topic after that), and it has worked every time. *If* there is still an issue with the consumer, I'm confident that it's going to be pretty rare.

Other changes in this PR:
* I Added some tracing stuff for rdkafka/librdkafka so we can now optionally log their events. For instance, by setting `RUST_LOG=librdkafka=trace,rdkafka=debug,boom=info`.
* I added some instrumentation
* I added `ConsumerError` for a little extra error handling
* I added a healthcheck for the kafka container. This isn't critical for anything in our workflow, but our other containers had healthchecks so it seemed good for kafka to have one, too.
* I've touched up the consumer CLI (see commit message for details)