### PR TITLE
API docs improvements

### DIFF
--- a/api/src/docs.rs
+++ b/api/src/docs.rs
@@ -1,0 +1,57 @@
+use crate::routes;
+use utoipa::Modify;
+use utoipa::OpenApi;
+use utoipa::openapi::Components;
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if openapi.components.is_none() {
+            openapi.components = Some(Components::new());
+        }
+
+        openapi.components.as_mut().unwrap().add_security_scheme(
+            "api_jwt_token",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .bearer_format("JWT")
+                    .build(),
+            ),
+        );
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "BOOM API",
+        version = "0.1.0",
+        description = "An HTTP REST interface to BOOM."
+    ),
+    paths(
+        routes::info::get_health,
+        routes::info::get_db_info,
+        routes::users::post_user,
+        routes::users::get_users,
+        routes::users::delete_user,
+        routes::auth::post_auth,
+        routes::surveys::get_object,
+        routes::catalogs::get_catalogs,
+        routes::catalogs::get_catalog_indexes,
+        routes::catalogs::get_catalog_sample,
+        routes::filters::post_filter,
+        routes::filters::add_filter_version,
+        routes::queries::post_count_query,
+        routes::queries::post_estimated_count_query,
+        routes::queries::post_find_query,
+        routes::queries::post_cone_search_query,
+    ),
+    security(
+        ("api_jwt_token" = [])
+    ),
+    modifiers(&SecurityAddon)
+)]
+pub struct ApiDoc;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod catalogs;
 pub mod conf;
 pub mod db;
+pub mod docs;
 pub mod filters;
 pub mod models;
 pub mod routes;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,70 +1,11 @@
 use actix_web::middleware::from_fn;
-use actix_web::{App, HttpResponse, HttpServer, get, middleware::Logger, web};
+use actix_web::{App, HttpServer, middleware::Logger, web};
 use boom_api::auth::{auth_middleware, get_auth};
 use boom_api::db::get_db;
-use boom_api::models::response;
+use boom_api::docs::ApiDoc;
 use boom_api::routes;
 use utoipa::OpenApi;
 use utoipa_scalar::{Scalar, Servable};
-
-/// Check the health of the API server
-#[utoipa::path(
-    get,
-    path = "/",
-    responses(
-        (status = 200, description = "Health check successful")
-    )
-)]
-#[get("/")]
-pub async fn get_health() -> HttpResponse {
-    HttpResponse::Ok().json(serde_json::json!({
-        "status": "success",
-        "message": "Greetings from BOOM!"
-    }))
-}
-
-/// Get information about the database
-#[utoipa::path(
-    get,
-    path = "/db-info",
-    responses(
-        (status = 200, description = "Database information retrieved successfully"),
-    )
-)]
-#[get("/db-info")]
-pub async fn get_db_info(db: web::Data<mongodb::Database>) -> HttpResponse {
-    match db.run_command(mongodb::bson::doc! { "dbstats": 1 }).await {
-        Ok(stats) => response::ok("success", serde_json::to_value(stats).unwrap()),
-        Err(e) => response::internal_error(&format!("Error getting database info: {:?}", e)),
-    }
-}
-
-#[derive(OpenApi)]
-#[openapi(
-    info(
-        title = "BOOM API",
-        version = "0.1.0",
-        description = "An HTTP REST interface to BOOM."
-    ),
-    paths(
-        get_health,
-        get_db_info,
-        routes::users::post_user,
-        routes::users::get_users,
-        routes::users::delete_user,
-        routes::surveys::get_object,
-        routes::catalogs::get_catalogs,
-        routes::catalogs::get_catalog_indexes,
-        routes::catalogs::get_catalog_sample,
-        routes::filters::post_filter,
-        routes::filters::add_filter_version,
-        routes::queries::post_count_query,
-        routes::queries::post_estimated_count_query,
-        routes::queries::post_find_query,
-        routes::queries::post_cone_search_query,
-    )
-)]
-struct ApiDoc;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -82,8 +23,8 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(database.clone()))
             .app_data(web::Data::new(auth.clone()))
             .service(Scalar::with_url("/docs", api_doc.clone()))
-            .service(get_health)
-            .service(get_db_info)
+            .service(routes::info::get_health)
+            .service(routes::info::get_db_info)
             .service(routes::auth::post_auth)
             .service(
                 actix_web::web::scope("")

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -26,6 +26,7 @@ pub struct FailedAuthResponse {
     pub error_description: String,
 }
 
+/// Authenticate a user
 #[utoipa::path(
     post,
     path = "/auth",
@@ -34,7 +35,8 @@ pub struct FailedAuthResponse {
         (status = 200, description = "Successful authentication", body = AuthResponse),
         (status = 401, description = "Invalid Client", body = FailedAuthResponse),
         (status = 400, description = "Invalid Request", body = FailedAuthResponse),
-    )
+    ),
+    tags=["Auth"]
 )]
 #[post("/auth")]
 pub async fn post_auth(auth: web::Data<AuthProvider>, body: web::Json<AuthPost>) -> HttpResponse {

--- a/api/src/routes/catalogs.rs
+++ b/api/src/routes/catalogs.rs
@@ -25,7 +25,8 @@ impl Default for CatalogsQueryParams {
     responses(
         (status = 200, description = "List of catalogs", body = Vec<serde_json::Value>),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Catalogs"]
 )]
 #[get("/catalogs")]
 pub async fn get_catalogs(
@@ -92,7 +93,8 @@ pub async fn get_catalogs(
         (status = 200, description = "List of indexes in the catalog", body = Vec<serde_json::Value>),
         (status = 400, description = "Bad request"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Catalogs"]
 )]
 #[get("/catalogs/{catalog_name}/indexes")]
 pub async fn get_catalog_indexes(
@@ -140,7 +142,8 @@ impl Default for SampleQuery {
         (status = 200, description = "Sample records from the catalog", body = Vec<serde_json::Value>),
         (status = 400, description = "Bad request"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Catalogs"]
 )]
 #[get("/catalogs/{catalog_name}/sample")]
 pub async fn get_catalog_sample(

--- a/api/src/routes/filters.rs
+++ b/api/src/routes/filters.rs
@@ -179,7 +179,8 @@ struct FilterPipelinePatch {
         (status = 200, description = "Filter version added successfully"),
         (status = 400, description = "Invalid filter submitted"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Filters"]
 )]
 #[patch("/filters/{filter_id}")]
 pub async fn add_filter_version(
@@ -284,7 +285,8 @@ pub struct FilterPost {
         (status = 200, description = "Filter created successfully", body = Filter),
         (status = 400, description = "Invalid filter submitted"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Filters"]
 )]
 #[post("/filters")]
 pub async fn post_filter(

--- a/api/src/routes/info.rs
+++ b/api/src/routes/info.rs
@@ -1,0 +1,36 @@
+use crate::models::response;
+use actix_web::{HttpResponse, get, web};
+
+/// Check the health of the API server
+#[utoipa::path(
+    get,
+    path = "/",
+    responses(
+        (status = 200, description = "Health check successful")
+    ),
+    tags=["Info"]
+)]
+#[get("/")]
+pub async fn get_health() -> HttpResponse {
+    HttpResponse::Ok().json(serde_json::json!({
+        "status": "success",
+        "message": "Greetings from BOOM!"
+    }))
+}
+
+/// Get information about the database
+#[utoipa::path(
+    get,
+    path = "/db-info",
+    responses(
+        (status = 200, description = "Database information retrieved successfully"),
+    ),
+    tags=["Info"]
+)]
+#[get("/db-info")]
+pub async fn get_db_info(db: web::Data<mongodb::Database>) -> HttpResponse {
+    match db.run_command(mongodb::bson::doc! { "dbstats": 1 }).await {
+        Ok(stats) => response::ok("success", serde_json::to_value(stats).unwrap()),
+        Err(e) => response::internal_error(&format!("Error getting database info: {:?}", e)),
+    }
+}

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod catalogs;
 pub mod filters;
+pub mod info;
 pub mod queries;
 pub mod surveys;
 pub mod users;

--- a/api/src/routes/queries.rs
+++ b/api/src/routes/queries.rs
@@ -28,7 +28,8 @@ struct CountQuery {
         (status = 200, description = "Count of documents in the catalog", body = serde_json::Value),
         (status = 404, description = "Catalog does not exist"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Queries"]
 )]
 #[post("/queries/count")]
 pub async fn post_count_query(
@@ -71,7 +72,8 @@ struct EstimatedCountQuery {
         (status = 200, description = "Approximately count documents in the catalog", body = serde_json::Value),
         (status = 404, description = "Catalog does not exist"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Queries"]
 )]
 #[post("/queries/estimated-count")]
 pub async fn post_estimated_count_query(
@@ -137,7 +139,8 @@ impl FindQuery {
         (status = 200, description = "Documents found in the catalog", body = serde_json::Value),
         (status = 400, description = "Bad request"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Queries"]
 )]
 #[post("/queries/find")]
 pub async fn post_find_query(db: web::Data<Database>, body: web::Json<FindQuery>) -> HttpResponse {
@@ -254,7 +257,8 @@ impl ConeSearchQuery {
         (status = 200, description = "Cone search results", body = serde_json::Value),
         (status = 400, description = "Bad request"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Queries"]
 )]
 #[post("/queries/cone-search")]
 pub async fn post_cone_search_query(

--- a/api/src/routes/surveys.rs
+++ b/api/src/routes/surveys.rs
@@ -55,7 +55,8 @@ fn bson_docs_to_json_values(
         (status = 200, description = "Object found", body = ObjResponse),
         (status = 404, description = "Object not found"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Surveys"]
 )]
 #[get("/surveys/{survey_name}/objects/{object_id}")]
 pub async fn get_object(

--- a/api/src/routes/users.rs
+++ b/api/src/routes/users.rs
@@ -22,6 +22,7 @@ pub struct User {
     pub is_admin: bool,   // Indicates if the user is an admin
 }
 
+/// Add a new user (admin only)
 #[utoipa::path(
     post,
     path = "/users",
@@ -30,7 +31,8 @@ pub struct User {
         (status = 200, description = "User created successfully", body = User),
         (status = 409, description = "User already exists"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Users"]
 )]
 #[post("/users")]
 pub async fn post_user(
@@ -90,13 +92,15 @@ pub struct UserGet {
     pub is_admin: bool,
 }
 
+/// Get a list of users
 #[utoipa::path(
     get,
     path = "/users",
     responses(
         (status = 200, description = "Users retrieved successfully", body = [User]),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Users"]
 )]
 #[get("/users")]
 pub async fn get_users(db: web::Data<Database>) -> HttpResponse {
@@ -123,6 +127,7 @@ pub async fn get_users(db: web::Data<Database>) -> HttpResponse {
     }
 }
 
+/// Delete a user by ID (admin only)
 #[utoipa::path(
     delete,
     path = "/users/{user_id}",
@@ -130,7 +135,8 @@ pub async fn get_users(db: web::Data<Database>) -> HttpResponse {
         (status = 200, description = "User deleted successfully"),
         (status = 404, description = "User not found"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    tags=["Users"]
 )]
 #[delete("/users/{user_id}")]
 pub async fn delete_user(


### PR DESCRIPTION
In this PR, we:
- add JWT authentication information to the docs
- add tags to openapi description to have proper menus in the docs (tags are used to group endpoints),
- add description (as comments) to some endpoints which are rendered on the docs
- add a dedicated `docs.rs` where the documentation is instantiated.
- add a `routes/info.rs` where the ping and db info endpoints now live, instead of being directly in main (required to be documented in `docs.rs`)

Note: While the JWT auth is documented, the docs ask the user for their token. Ideally, the docs should ask for username/password and somehow know which endpoint to hit to get a JWT it can use thereafter when testing endpoints from the web page. I couldn't find that option in utoipa so I opened a ticket on its GitHub repo. That should be added in a future PR