### PR TITLE
Provide evidence of filtering in logs

### DIFF
--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -564,18 +564,18 @@ impl FilterWorker for ZtfFilterWorker {
                 )
                 .await?;
 
-                // if the array is empty, continue
+                info!(
+                    "{} alerts passed ztf filter {} with programid {}",
+                    out_documents.len(),
+                    filter.id,
+                    programid,
+                );
+
+                // If we have output documents, we need to process them
+                // and create filter results for each document (which contain annotations)
+                // however, if the array is empty, there's nothing to do
                 if out_documents.is_empty() {
                     continue;
-                } else {
-                    // if we have output documents, we need to process them
-                    // and create filter results for each document (which contain annotations)
-                    info!(
-                        "{} alerts passed ztf filter {} with programid {}",
-                        out_documents.len(),
-                        filter.id,
-                        programid,
-                    );
                 }
 
                 let now_ts = chrono::Utc::now().timestamp_millis() as f64;


### PR DESCRIPTION
Without this, there's no real way to know if filtering was attempted. I do think it would be good to save filter results, even for alerts that don't pass the filters, perhaps inside the alert object itself, like:

```json
{
  "_id": {
    "$numberLong": "2991147293515015045"
  },
  "objectId": "ZTF18acwpwgq",
  "candidate": {
    "jd": 2460745.6472917,
    "band": "r",
    "pid": {
      "$numberLong": "2991147293515"
    }
    ...
  },
  "coordinates": {
    "radec_geojson": {
      "type": "Point",
      "coordinates": [
        -76.0545582,
        -16.742982
      ]
    },
    "l": -131.61575014218297,
    "b": -6.615562065786586
  },
  "created_at": 2460887.227974537,
  "updated_at": 2460887.227974537,
  "classifications": {
    "acai_b": 0.2063591182231903,
    "acai_h": 0.000014662742614746094,
    "acai_n": 0.0006379783153533936,
    "acai_o": 0.2871479392051697,
    "acai_v": 0.00823184847831726,
    "btsbot": 0.001475214958190918
  },
  "filters": [
    {"filter_id": 1, "filter_version": "sdk43k", "result": false}
  ]
}
```

So, we could store filter results indexed by filter ID and filter revision ID, and we could easily check if a filter was run, and if doing a historical query, quickly return results with simple boolean matching.