### PR TITLE
Timeseries update: fix + improvements

### DIFF
--- a/src/alert/decam.rs
+++ b/src/alert/decam.rs
@@ -227,16 +227,16 @@ impl AlertWorker for DecamAlertWorker {
         survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let update_doc = doc! {
+        let update_pipeline = vec![doc! {
             "$set": {
                 "fp_hists": update_timeseries_op("fp_hists", "jd", fp_hist_doc),
                 "aliases": survey_matches,
                 "updated_at": now,
             }
-        };
+        }];
 
         self.alert_aux_collection
-            .update_one(doc! { "_id": object_id }, update_doc)
+            .update_one(doc! { "_id": object_id }, update_pipeline)
             .await?;
 
         Ok(())

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -911,16 +911,16 @@ impl AlertWorker for LsstAlertWorker {
         _survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let update_doc = doc! {
+        let update_pipeline = vec![doc! {
             "$set": {
                 "prv_candidates": update_timeseries_op("prv_candidates", "jd", prv_candidates_doc),
                 "prv_nondetections": update_timeseries_op("prv_nondetections", "jd", prv_nondetections_doc),
                 "fp_hists": update_timeseries_op("fp_hists", "jd", fp_hist_doc),
                 "updated_at": now,
             }
-        };
+        }];
         self.alert_aux_collection
-            .update_one(doc! { "_id": object_id }, update_doc)
+            .update_one(doc! { "_id": object_id }, update_pipeline)
             .await?;
         Ok(())
     }

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -631,7 +631,7 @@ impl AlertWorker for ZtfAlertWorker {
         survey_matches: &Option<Document>,
         now: f64,
     ) -> Result<(), AlertError> {
-        let update_doc = doc! {
+        let update_pipeline = vec![doc! {
             "$set": {
                 "prv_candidates": update_timeseries_op("prv_candidates", "jd", prv_candidates_doc),
                 "prv_nondetections": update_timeseries_op("prv_nondetections", "jd", prv_nondetections_doc),
@@ -639,9 +639,9 @@ impl AlertWorker for ZtfAlertWorker {
                 "aliases": survey_matches,
                 "updated_at": now,
             }
-        };
+        }];
         self.alert_aux_collection
-            .update_one(doc! { "_id": object_id }, update_doc)
+            .update_one(doc! { "_id": object_id }, update_pipeline)
             .await?;
         Ok(())
     }

--- a/src/ml/ztf.rs
+++ b/src/ml/ztf.rs
@@ -202,6 +202,10 @@ impl MLWorker for ZtfMLWorker {
             );
         }
 
+        if alerts.is_empty() {
+            return Ok(vec![]);
+        }
+
         // we keep it very simple for now, let's run on 1 alert at a time
         // we will move to batch processing later
         let mut updates = Vec::new();

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -96,22 +96,27 @@ pub fn update_timeseries_op(
     value: &Vec<mongodb::bson::Document>,
 ) -> mongodb::bson::Document {
     doc! {
-        "$reduce": {
+        "$sortArray": {
             "input": {
-                "$concatArrays": [
-                    // handle the case where the array_field is not present
-                    { "$ifNull": [format!("${}", array_field), []] },
-                    value
-                ]
-            },
-            "initialValue": [],
-            "in": {
-                "$cond": {
-                    "if": { "$in": [format!("$$this.{}", time_field), format!("$$value.{}", time_field)] },
-                    "then": "$$value",
-                    "else": { "$concatArrays": ["$$value", ["$$this"]] }
+                "$reduce": {
+                    "input": {
+                        "$concatArrays": [
+                            // handle the case where the array_field is not present
+                            { "$ifNull": [format!("${}", array_field), []] },
+                            value
+                        ]
+                    },
+                    "initialValue": [],
+                    "in": {
+                        "$cond": {
+                            "if": { "$in": [format!("$$this.{}", time_field), format!("$$value.{}", time_field)] },
+                            "then": "$$value",
+                            "else": { "$concatArrays": ["$$value", ["$$this"]] }
+                        }
+                    }
                 }
-            }
+            },
+            "sortBy": { time_field: 1 }
         }
     }
 }

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -99,7 +99,13 @@ pub fn update_timeseries_op(
         "$sortArray": {
             "input": {
                 "$reduce": {
-                    "input": { "$concatArrays": [format!("${}", array_field), value] },
+                    "input": {
+                        "$concatArrays": [
+                            // handle the case where the array_field is not present
+                            { "$ifNull": [format!("${}", array_field), []] },
+                            value
+                        ]
+                    },
                     "initialValue": [],
                     "in": {
                         "$cond": {

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -99,7 +99,7 @@ pub fn update_timeseries_op(
         "$sortArray": {
             "input": {
                 "$reduce": {
-                    "input": { "$concatArrays": [array_field, value] },
+                    "input": { "$concatArrays": [format!("${}", array_field), value] },
                     "initialValue": [],
                     "in": {
                         "$cond": {

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -96,27 +96,22 @@ pub fn update_timeseries_op(
     value: &Vec<mongodb::bson::Document>,
 ) -> mongodb::bson::Document {
     doc! {
-        "$sortArray": {
+        "$reduce": {
             "input": {
-                "$reduce": {
-                    "input": {
-                        "$concatArrays": [
-                            // handle the case where the array_field is not present
-                            { "$ifNull": [format!("${}", array_field), []] },
-                            value
-                        ]
-                    },
-                    "initialValue": [],
-                    "in": {
-                        "$cond": {
-                            "if": { "$in": [format!("$$this.{}", time_field), format!("$$value.{}", time_field)] },
-                            "then": "$$value",
-                            "else": { "$concatArrays": ["$$value", ["$$this"]] }
-                        }
-                    }
-                }
+                "$concatArrays": [
+                    // handle the case where the array_field is not present
+                    { "$ifNull": [format!("${}", array_field), []] },
+                    value
+                ]
             },
-            "sortBy": { time_field: 1 }
+            "initialValue": [],
+            "in": {
+                "$cond": {
+                    "if": { "$in": [format!("$$this.{}", time_field), format!("$$value.{}", time_field)] },
+                    "then": "$$value",
+                    "else": { "$concatArrays": ["$$value", ["$$this"]] }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In this PR:
- we fix the update_timeseries_op() function, where a missing `$` in front the name of the array field to update broke that function
- the $sortArray operator used by update_timeseries_op() is only supported in aggregation pipelines, so we turn the update document passed to the `update_one()` method into a vec of doc, i.e. an aggregation pipeline used for update. *Note: the performance impact of that change is unknown and will be assessed using Pete's benchmarking suite in `boom-astro/boom-paper`*.
- we handle a potential edge-case where we try to update an array with new entries, but that array does not exist yet (in which case we want to avoid an error and proceed as usual). *Note: The logic there could be improved to use a simple insert of the new values when the field is missing but that isn't much of an issue nor a priority at the moment. That slight improvement only becomes useful if we have some schema change introducing new fields.*