### PR TITLE
Throughput reports bugfix

### DIFF
--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   test:
     name: Run throughput test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions: write-all
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -89,8 +89,8 @@ jobs:
         run: |
           current=$(cat logs/boom-*/wall_time.txt)
           echo "Current wall time: $current seconds"
-          if [ -f ./baseline/logs/boom-*/wall_time.txt ]; then
-            baseline=$(cat ./baseline/logs/boom-*/wall_time.txt)
+          if [ -f ./baseline/boom-*/wall_time.txt ]; then
+            baseline=$(cat ./baseline/boom-*/wall_time.txt)
             echo "Baseline wall time: $baseline seconds"
             percentage_diff=$(echo "scale=2; (($current - $baseline) / $baseline) * 100" | bc)
           else

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   test:
     name: Run throughput test
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions: write-all
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  TOLERANCE: 0.05 # 5% tolerance for wall time increase
+  TOLERANCE_PERCENTAGE: 5.0 # 5% tolerance for wall time increase
 
 jobs:
   test:
@@ -100,8 +100,6 @@ jobs:
 
           echo "Percentage difference: $percentage_diff%"
 
-          TOLERANCE_PERCENT=$((TOLERANCE*100))
-
           echo "percentage_diff=$percentage_diff" >> $GITHUB_OUTPUT
           echo "baseline=$baseline" >> $GITHUB_OUTPUT
           echo "current=$current" >> $GITHUB_OUTPUT
@@ -119,3 +117,12 @@ jobs:
           comment-type: edit
           reuse-existing-comment: true
           edit-mode: replace
+      - name: Fail if wall time increased too much (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          percentage_diff=${{ steps.compare-with-baseline.outputs.percentage_diff }}
+          if (( $(echo "$percentage_diff > $TOLERANCE_PERCENTAGE" | bc -l) )); then
+            echo "Wall time increased by $percentage_diff%, which is more than the allowed $TOLERANCE_PERCENTAGE%."
+            exit 1
+          fi
+          

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -74,7 +74,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dawidd6/action-download-artifact@v11
         with:
-          workflow: ${{ github.workflow }}
+          workflow: test-throughput.yaml
           branch: main
           name: throughput-logs
           path: ./baseline

--- a/tests/throughput/compose.yaml
+++ b/tests/throughput/compose.yaml
@@ -64,6 +64,7 @@ services:
     image: apache/kafka:latest
     hostname: broker
     expose:
+      - "9092"
       - "29092"
     networks:
       - boom

--- a/tests/throughput/compose.yaml
+++ b/tests/throughput/compose.yaml
@@ -13,8 +13,6 @@ services:
     hostname: mongo
     expose:
       - "27017"
-    ports:
-      - "27017:27017"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=mongoadmin
       - MONGO_INITDB_ROOT_PASSWORD=mongoadminsecret
@@ -50,8 +48,8 @@ services:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
       - VALKEY_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"
     restart: always
     networks:
       - boom
@@ -65,8 +63,8 @@ services:
   broker:
     image: apache/kafka:latest
     hostname: broker
-    ports:
-      - 9092:9092
+    expose:
+      - "29092"
     networks:
       - boom
     environment:


### PR DESCRIPTION
Looks like we weren't able to read the baseline wall time number from main, this PR fixes this.

Also, we make the CI fail if the time we take with the PRs code is more than `TOLERANCE_PERCENTAGE` % slower, where for now `TOLERANCE_PERCENTAGE=5.0%` (should be tuned based on the standard deviation we observe in the next few PRs).

Last but not least, we stop mapping container ports to the host. It's useless, and can create conflicts if you have other services running on the same machine.