### PR TITLE
Quantities: first batch of changes

### DIFF
--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -88,7 +88,7 @@ async fn run(args: Cli, meter_provider: SdkMeterProvider) {
         config_path.clone(),
     );
     let ml_pool = ThreadPool::new(
-        WorkerType::ML,
+        WorkerType::Enrichment,
         n_ml as usize,
         args.survey.clone(),
         config_path.clone(),

--- a/src/enrichment/decam.rs
+++ b/src/enrichment/decam.rs
@@ -126,7 +126,7 @@ impl EnrichmentWorker for DecamEnrichmentWorker {
 
         if alerts.len() != candids.len() {
             warn!(
-                "FEATURE WORKER: only {} alerts fetched from {} candids",
+                "only {} alerts fetched from {} candids",
                 alerts.len(),
                 candids.len()
             );

--- a/src/scheduler/base.rs
+++ b/src/scheduler/base.rs
@@ -216,23 +216,24 @@ impl Worker {
                         .unwrap_or_else(as_error!("filter worker failed"));
                 })
             }),
-            WorkerType::ML => thread::spawn(move || {
+            WorkerType::Enrichment => thread::spawn(move || {
                 let tid = std::thread::current().id();
-                span!(INFO, "feature worker", ?tid, ?survey_name).in_scope(|| {
-                    info!("starting feature worker");
+                span!(INFO, "enrichment worker", ?tid, ?survey_name).in_scope(|| {
+                    info!("starting enrichment worker");
                     debug!(?config_path);
                     let run = match survey_name {
                         Survey::Ztf => run_enrichment_worker::<ZtfEnrichmentWorker>,
                         Survey::Lsst => run_enrichment_worker::<LsstEnrichmentWorker>,
                         _ => {
                             error!(
-                                "Feature worker not implemented for survey: {:?}",
+                                "Enrichment worker not implemented for survey: {:?}",
                                 survey_name
                             );
                             return;
                         }
                     };
-                    run(receiver, &config_path).unwrap_or_else(as_error!("feature worker failed"));
+                    run(receiver, &config_path)
+                        .unwrap_or_else(as_error!("enrichment     worker failed"));
                 })
             }),
         };

--- a/src/utils/worker.rs
+++ b/src/utils/worker.rs
@@ -40,8 +40,8 @@ pub fn get_check_command_interval(conf: Config, stream_name: &str) -> i64 {
 #[derive(Clone, Debug)]
 pub enum WorkerType {
     Alert,
+    Enrichment,
     Filter,
-    ML,
 }
 
 impl Copy for WorkerType {}
@@ -54,7 +54,7 @@ impl fmt::Display for WorkerType {
                 enum_str = "Alert";
             }
             WorkerType::Filter => enum_str = "Filter",
-            WorkerType::ML => enum_str = "ML",
+            WorkerType::Enrichment => enum_str = "Enrichment",
         }
         write!(f, "{}", enum_str)
     }

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -361,7 +361,7 @@ async fn test_enrich_ztf_alert() {
     let fading_rate = fading.get_f64("rate").unwrap();
     assert!((peak_mag - 15.6940).abs() < 1e-6);
     assert!((peak_jd - 2460441.971956).abs() < 1e-6);
-    assert!((rising_rate + 0.019685).abs() < 1e-6);
+    assert!((rising_rate + 0.252037).abs() < 1e-6);
     assert!((fading_rate - 0.037152).abs() < 1e-6);
 
     assert!(photstats.contains_key("r"));


### PR DESCRIPTION
This addresses Jake's comments on the existing PR (#234):
- [x] rename all `ml worker` and `feature worker` occurrences to the new naming schema `enrichment worker`
- [ ] add some unit tests to `lightcurves.rs`
- [ ] extract the feature computation logic in each ML workers as it's own function, to make the main processing loop shorter and easier to read.