### PR TITLE
Throughput CI: rust build caching (in docker)

### DIFF
--- a/Dockerfile-benchmark
+++ b/Dockerfile-benchmark
@@ -1,19 +1,23 @@
 FROM rust:1.87-slim-bookworm AS builder
 
-WORKDIR /app
-
-# Copy the Cargo.toml and Cargo.lock files
-COPY Cargo.toml Cargo.lock ./
-
 RUN apt-get update && \
     apt-get install -y curl gcc g++ libhdf5-dev perl make libsasl2-dev pkg-config && \
     apt-get autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Copy the source code
+# First we build an empty rust project to cache dependencies
+# this way we skip dependencies build when only the source code changes
+RUN cargo init app && cd app && cargo init api
+COPY Cargo.toml Cargo.lock /app/
+COPY api/Cargo.toml /app/api/
+RUN cd app && cargo build --release --workspace && \
+    rm -rf app/src && rm -rf app/api/src
+
+# Now we copy the source code and build the actual application
+WORKDIR /app
 COPY ./src ./src
-COPY ./api ./api
+COPY ./api/src ./api/src
 
 # Build the application (all of the binaries)
 RUN cargo build --release --workspace


### PR DESCRIPTION
In this PR, we edit the `Dockerfile-benchmark` docker file to:
- first create an empty application with the same layout as booms, and copy our Cargo.toml files to it
- then we build this empty project. This will download and build dependencies. This way, this step only runs when there are Cargo.toml changes, and otherwise is cached along with the build dependencies
- then we copy the source code of boom and build that. Since dependencies are already built, this will only require build time for the app itself. So, now that is the only build time that needs to happen when there are source code changes, and we don't need to rerun the whole dependencies update.

This is in an effort to cut down the docker build time for the throughput test. Similar changes could be made to the proper Dockerfile we use to run the app, to make builds a lot faster when we change the code, which would be a big big help.