### PR TITLE
Xmatches: configurable max results

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,7 @@ workers:
     alert:
       n_workers: 1
     enrichment:
-      n_workers: 0
+      n_workers: 1
     filter:
       n_workers: 1
   DECAM:
@@ -47,58 +47,16 @@ workers:
     alert:
       n_workers: 1
     enrichment:
-      n_workers: 0
+      n_workers: 1
     filter:
       n_workers: 1
 crossmatch:
-  LSST: []
-  DECAM: []
-  ZTF:
-    - catalog: PS1_DR1
-      radius: 2.0 # 2 arcseconds
-      use_distance: false
-      projection:
-        _id: 1
-        gMeanPSFMag: 1
-        gMeanPSFMagErr: 1
-        rMeanPSFMag: 1
-        rMeanPSFMagErr: 1
-        iMeanPSFMag: 1
-        iMeanPSFMagErr: 1
-        zMeanPSFMag: 1
-        zMeanPSFMagErr: 1
-        yMeanPSFMag: 1
-        yMeanPSFMagErr: 1
-        ra: 1
-        dec: 1
-    - catalog: Gaia_DR3
-      radius: 2.0 # 2 arcseconds
-      use_distance: false
-      projection:
-        _id: 1
-        parallax: 1
-        parallax_error: 1
-        phot_g_mean_mag: 1
-        phot_bp_mean_mag: 1
-        phot_rp_mean_mag: 1
-        ra: 1
-        dec: 1
-    - catalog: milliquas_v6
-      radius: 2.0 # 2 arcseconds
-      use_distance: false
-      projection:
-        _id: 1
-        Name: 1
-        Descrip: 1
-        Qpct: 1
-        ra: 1
-        dec: 1
+  LSST:
     - catalog: NED
-      radius: 300.0 # 300 arcseconds
-      use_distance: true
+      radius_arcsec: 300.0 # 300 arcseconds
       distance_key: "z"
-      distance_max: 30.0
-      distance_max_near: 300.0
+      distance_max_kpc: 30.0
+      distance_max_near_arcsec: 300.0
       projection: 
         _id: 0
         ra: 1
@@ -117,3 +75,104 @@ crossmatch:
         tMASSphot: 1
         Mstar: 1
         Mstar_unc: 1
+    - catalog: LS_StarGalaxy
+      radius_arcsec: 30.0 # arcseconds
+      n_max_matches: 3
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+  DECAM:
+    - catalog: NED
+      radius_arcsec: 300.0 # 300 arcseconds
+      distance_key: "z"
+      distance_max_kpc: 30.0
+      distance_max_near_arcsec: 300.0
+      projection: 
+        _id: 0
+        ra: 1
+        dec: 1
+        objname: 1
+        objtype: 1
+        z: 1
+        z_unc: 1
+        z_tech: 1
+        z_qual: 1
+        DistMpc: 1
+        DistMpc_unc: 1
+        ebv: 1
+        m_Ks: 1
+        m_Ks_unc: 1
+        tMASSphot: 1
+        Mstar: 1
+        Mstar_unc: 1
+  ZTF:
+    - catalog: NED
+      radius_arcsec: 300.0 # 300 arcseconds
+      distance_key: "z"
+      distance_max_kpc: 30.0
+      distance_max_near_arcsec: 300.0
+      projection: 
+        _id: 0
+        ra: 1
+        dec: 1
+        objname: 1
+        objtype: 1
+        z: 1
+        z_unc: 1
+        z_tech: 1
+        z_qual: 1
+        DistMpc: 1
+        DistMpc_unc: 1
+        ebv: 1
+        m_Ks: 1
+        m_Ks_unc: 1
+        tMASSphot: 1
+        Mstar: 1
+        Mstar_unc: 1
+    - catalog: PS1_DR1
+      radius_arcsec: 2.0 # 2 arcseconds
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+    - catalog: Gaia_DR3
+      radius_arcsec: 2.0 # 2 arcseconds
+      projection:
+        _id: 1
+        parallax: 1
+        parallax_error: 1
+        phot_g_mean_mag: 1
+        phot_bp_mean_mag: 1
+        phot_rp_mean_mag: 1
+        ra: 1
+        dec: 1
+    - catalog: milliquas_v6
+      radius_arcsec: 2.0 # 2 arcseconds
+      projection:
+        _id: 1
+        Name: 1
+        Descrip: 1
+        Qpct: 1
+        ra: 1
+        dec: 1

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -529,15 +529,14 @@ impl TryFrom<DiaForcedSource> for ForcedPhot {
         // may revisit this later
         let (magpsf, sigmapsf, isdiffpos, snr) = match dia_forced_source.psf_flux {
             Some(psf_flux) => {
-                let psf_flux = psf_flux * 1e-9;
-                if (psf_flux / psf_flux_err) > SNT {
-                    let isdiffpos = psf_flux > 0.0;
-                    let (magpsf, sigmapsf) = flux2mag(psf_flux, psf_flux_err, ZP_AB);
+                let psf_flux_abs = psf_flux.abs() * 1e-9;
+                if (psf_flux_abs / psf_flux_err) > SNT {
+                    let (magpsf, sigmapsf) = flux2mag(psf_flux_abs, psf_flux_err, ZP_AB);
                     (
                         Some(magpsf),
                         Some(sigmapsf),
-                        Some(isdiffpos),
-                        Some(psf_flux / psf_flux_err),
+                        Some(psf_flux > 0.0),
+                        Some(psf_flux_abs / psf_flux_err),
                     )
                 } else {
                     (None, None, None, None)

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -187,6 +187,7 @@ pub struct CatalogXmatchConfig {
     pub distance_key: Option<String>,        // name of the field to use for distance
     pub distance_max: Option<f64>,           // maximum distance in kpc
     pub distance_max_near: Option<f64>,      // maximum distance in arcsec for nearby objects
+    pub n_max: Option<i64>,                  // maximum number of objects to return
 }
 
 impl CatalogXmatchConfig {
@@ -194,11 +195,20 @@ impl CatalogXmatchConfig {
         catalog: &str,
         radius: f64,
         projection: mongodb::bson::Document,
-        use_distance: bool,
         distance_key: Option<String>,
         distance_max: Option<f64>,
         distance_max_near: Option<f64>,
+        n_max: Option<i64>,
     ) -> CatalogXmatchConfig {
+        let use_distance =
+            distance_key.is_some() && distance_max.is_some() && distance_max_near.is_some();
+
+        if distance_key.is_some() || distance_max.is_some() || distance_max_near.is_some() {
+            if !use_distance {
+                panic!("If any of distance_key, distance_max, or distance_max_near is set, all must be set (or none at all).");
+            }
+        }
+
         CatalogXmatchConfig {
             catalog: catalog.to_string(),
             radius: radius * std::f64::consts::PI / 180.0 / 3600.0, // convert arcsec to radians
@@ -207,6 +217,7 @@ impl CatalogXmatchConfig {
             distance_key,
             distance_max,
             distance_max_near,
+            n_max,
         }
     }
 
@@ -233,23 +244,23 @@ impl CatalogXmatchConfig {
             .clone()
             .into_table()?;
 
-        let use_distance = match hashmap_xmatch.get("use_distance") {
-            Some(use_distance) => use_distance.clone().into_bool()?,
-            None => false,
-        };
-
         let distance_key = match hashmap_xmatch.get("distance_key") {
             Some(distance_key) => Some(distance_key.clone().into_string()?),
             None => None,
         };
 
-        let distance_max = match hashmap_xmatch.get("distance_max") {
+        let distance_max = match hashmap_xmatch.get("distance_max_kpc") {
             Some(distance_max) => Some(distance_max.clone().into_float()?),
             None => None,
         };
 
-        let distance_max_near = match hashmap_xmatch.get("distance_max_near") {
+        let distance_max_near = match hashmap_xmatch.get("distance_max_near_arcsec") {
             Some(distance_max_near) => Some(distance_max_near.clone().into_float()?),
+            None => None,
+        };
+
+        let n_max = match hashmap_xmatch.get("n_max_matches") {
+            Some(n_max) => Some(n_max.clone().into_int()?),
             None => None,
         };
 
@@ -261,28 +272,14 @@ impl CatalogXmatchConfig {
             projection_doc.insert(key, value);
         }
 
-        if use_distance {
-            if distance_key.is_none() {
-                panic!("must provide a distance_key if use_distance is true");
-            }
-
-            if distance_max.is_none() {
-                panic!("must provide a distance_max if use_distance is true");
-            }
-
-            if distance_max_near.is_none() {
-                panic!("must provide a distance_max_near if use_distance is true");
-            }
-        }
-
         Ok(CatalogXmatchConfig::new(
             &catalog,
             radius,
             projection_doc,
-            use_distance,
             distance_key,
             distance_max,
             distance_max_near,
+            n_max,
         ))
     }
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -233,7 +233,7 @@ impl CatalogXmatchConfig {
             .into_string()?;
 
         let radius = hashmap_xmatch
-            .get("radius")
+            .get("radius_arcsec")
             .ok_or(BoomConfigError::MissingKeyError)?
             .clone()
             .into_float()?;

--- a/src/filter/lsst.rs
+++ b/src/filter/lsst.rs
@@ -82,7 +82,8 @@ pub async fn build_lsst_alerts(
             .get_binary_generic("cutoutDifference")?
             .to_vec();
 
-        // let's create the array of photometry (non forced phot only for now)
+        // let's create the array of photometry
+
         let mut photometry = Vec::new();
         for doc in alert_document.get_array("prv_candidates")?.iter() {
             let doc = match doc.as_document() {
@@ -90,8 +91,8 @@ pub async fn build_lsst_alerts(
                 None => continue, // skip if not a document
             };
             let jd = doc.get_f64("jd")?;
-            let flux = doc.get_f64("psfFlux")?;
-            let flux_err = doc.get_f64("psfFluxErr")?;
+            let flux = doc.get_f64("psfFlux")? * 1e-9; // from nJy to Jy
+            let flux_err = doc.get_f64("psfFluxErr")? * 1e-9; // from nJy to Jy
             let band = doc.get_str("band")?.to_string();
             let ra = doc.get_f64("ra").ok(); // optional, might not be present
             let dec = doc.get_f64("dec").ok(); // optional, might not be present
@@ -116,15 +117,16 @@ pub async fn build_lsst_alerts(
                 None => continue, // skip if not a document
             };
             let jd = doc.get_f64("jd")?;
-            let flux = doc.get_f64("psfFlux")?;
-            let flux_err = doc.get_f64("psfFluxErr")?;
+            // flux may be None in forced photometry
+            let flux = doc.get_f64("psfFlux").map(|f| f * 1e-9).ok(); // from nJy to Jy
+            let flux_err = doc.get_f64("psfFluxErr")? * 1e-9; // from nJy to Jy
             let band = doc.get_str("band")?.to_string();
             let ra = doc.get_f64("ra").ok(); // optional, might not be present
             let dec = doc.get_f64("dec").ok(); // optional, might not be present
 
             photometry.push(Photometry {
                 jd,
-                flux: Some(flux),
+                flux,
                 flux_err,
                 band: format!("lsst{}", band),
                 zero_point: 8.9,

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -156,6 +156,7 @@ pub async fn build_ztf_alerts(
                 None => continue, // skip if not a document
             };
             let jd = doc.get_f64("jd")?;
+            let magzpsci = doc.get_f64("magzpsci")?;
             let flux = match doc.get_f64("forcediffimflux") {
                 Ok(flux) => Some(flux),
                 Err(_) => None,
@@ -164,19 +165,18 @@ pub async fn build_ztf_alerts(
                 Ok(flux_err) => flux_err,
                 Err(_) => {
                     let diffmaglim = doc.get_f64("diffmaglim")?;
-                    limmag_to_fluxerr(diffmaglim, 23.9, 5.0)
+                    limmag_to_fluxerr(diffmaglim, magzpsci, 5.0)
                 }
             };
             let band = doc.get_str("band")?.to_string();
             let programid = doc.get_i32("programid")?;
-            let zero_point = 23.9;
 
             photometry.push(Photometry {
                 jd,
                 flux,
                 flux_err,
                 band: format!("ztf{}", band),
-                zero_point,
+                zero_point: magzpsci,
                 origin: Origin::ForcedPhot,
                 programid,
                 survey: Survey::Ztf,

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -33,7 +33,7 @@ workers:
     alert:
       n_workers: 1
     enrichment:
-      n_workers: 0
+      n_workers: 1
     filter:
       n_workers: 1
   DECAM:
@@ -41,58 +41,16 @@ workers:
     alert:
       n_workers: 1
     enrichment:
-      n_workers: 0
+      n_workers: 1
     filter:
       n_workers: 1
 crossmatch:
-  LSST: []
-  DECAM: []
-  ZTF:
-    - catalog: PS1_DR1
-      radius: 2.0 # 2 arcseconds
-      use_distance: false
-      projection:
-        _id: 1
-        gMeanPSFMag: 1
-        gMeanPSFMagErr: 1
-        rMeanPSFMag: 1
-        rMeanPSFMagErr: 1
-        iMeanPSFMag: 1
-        iMeanPSFMagErr: 1
-        zMeanPSFMag: 1
-        zMeanPSFMagErr: 1
-        yMeanPSFMag: 1
-        yMeanPSFMagErr: 1
-        ra: 1
-        dec: 1
-    - catalog: Gaia_DR3
-      radius: 2.0 # 2 arcseconds
-      use_distance: false
-      projection:
-        _id: 1
-        parallax: 1
-        parallax_error: 1
-        phot_g_mean_mag: 1
-        phot_bp_mean_mag: 1
-        phot_rp_mean_mag: 1
-        ra: 1
-        dec: 1
-    - catalog: milliquas_v6
-      radius: 2.0 # 2 arcseconds
-      use_distance: false
-      projection:
-        _id: 1
-        Name: 1
-        Descrip: 1
-        Qpct: 1
-        ra: 1
-        dec: 1
+  LSST:
     - catalog: NED
-      radius: 300.0 # 300 arcseconds
-      use_distance: true
+      radius_arcsec: 300.0 # 300 arcseconds
       distance_key: "z"
-      distance_max: 30.0
-      distance_max_near: 300.0
+      distance_max_kpc: 30.0
+      distance_max_near_arcsec: 300.0
       projection: 
         _id: 0
         ra: 1
@@ -111,3 +69,104 @@ crossmatch:
         tMASSphot: 1
         Mstar: 1
         Mstar_unc: 1
+    - catalog: LS_StarGalaxy
+      radius_arcsec: 30.0 # arcseconds
+      n_max_matches: 3
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+  DECAM:
+    - catalog: NED
+      radius_arcsec: 300.0 # 300 arcseconds
+      distance_key: "z"
+      distance_max_kpc: 30.0
+      distance_max_near_arcsec: 300.0
+      projection: 
+        _id: 0
+        ra: 1
+        dec: 1
+        objname: 1
+        objtype: 1
+        z: 1
+        z_unc: 1
+        z_tech: 1
+        z_qual: 1
+        DistMpc: 1
+        DistMpc_unc: 1
+        ebv: 1
+        m_Ks: 1
+        m_Ks_unc: 1
+        tMASSphot: 1
+        Mstar: 1
+        Mstar_unc: 1
+  ZTF:
+    - catalog: NED
+      radius_arcsec: 300.0 # 300 arcseconds
+      distance_key: "z"
+      distance_max_kpc: 30.0
+      distance_max_near_arcsec: 300.0
+      projection: 
+        _id: 0
+        ra: 1
+        dec: 1
+        objname: 1
+        objtype: 1
+        z: 1
+        z_unc: 1
+        z_tech: 1
+        z_qual: 1
+        DistMpc: 1
+        DistMpc_unc: 1
+        ebv: 1
+        m_Ks: 1
+        m_Ks_unc: 1
+        tMASSphot: 1
+        Mstar: 1
+        Mstar_unc: 1
+    - catalog: PS1_DR1
+      radius_arcsec: 2.0 # 2 arcseconds
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+    - catalog: Gaia_DR3
+      radius_arcsec: 2.0 # 2 arcseconds
+      projection:
+        _id: 1
+        parallax: 1
+        parallax_error: 1
+        phot_g_mean_mag: 1
+        phot_bp_mean_mag: 1
+        phot_rp_mean_mag: 1
+        ra: 1
+        dec: 1
+    - catalog: milliquas_v6
+      radius_arcsec: 2.0 # 2 arcseconds
+      projection:
+        _id: 1
+        Name: 1
+        Descrip: 1
+        Qpct: 1
+        ra: 1
+        dec: 1

--- a/tests/test_conf.rs
+++ b/tests/test_conf.rs
@@ -80,6 +80,7 @@ fn test_catalogxmatchconfig() {
         distance_max: None,
         distance_max_near: None,
         projection: ps1_projection.clone(),
+        n_max: None,
     };
 
     assert_eq!(xmatch_config.catalog, "PS1_DR1");
@@ -91,6 +92,7 @@ fn test_catalogxmatchconfig() {
     assert_eq!(xmatch_config.distance_key, None);
     assert_eq!(xmatch_config.distance_max, None);
     assert_eq!(xmatch_config.distance_max_near, None);
+    assert_eq!(xmatch_config.n_max, None);
 
     let projection = xmatch_config.projection;
     assert_eq!(projection, ps1_projection);

--- a/tests/test_conf.rs
+++ b/tests/test_conf.rs
@@ -50,7 +50,7 @@ fn test_build_xmatch_configs() {
     let projection = &first.projection;
     // test reading a few of the expected fields
     assert_eq!(projection.get("_id").unwrap().as_i64().unwrap(), 0);
-    assert_eq!(projection.get("objname").unwrap().as_i64().unwrap(), 0);
+    assert_eq!(projection.get("objname").unwrap().as_i64().unwrap(), 1);
     assert_eq!(projection.get("DistMpc").unwrap().as_i64().unwrap(), 1);
 }
 

--- a/tests/test_conf.rs
+++ b/tests/test_conf.rs
@@ -39,21 +39,19 @@ fn test_build_xmatch_configs() {
 
     let first = &catalog_xmatch_configs[0];
     // verify that its a CatalogXmatchConfig
-    assert_eq!(first.catalog, "PS1_DR1");
-    assert_eq!(first.radius, 2.0 * std::f64::consts::PI / 180.0 / 3600.0);
-    assert_eq!(first.use_distance, false);
-    assert_eq!(first.distance_key, None);
-    assert_eq!(first.distance_max, None);
-    assert_eq!(first.distance_max_near, None);
+    assert_eq!(first.catalog, "NED");
+    assert_eq!(first.radius, 300.0 * std::f64::consts::PI / 180.0 / 3600.0);
+    assert_eq!(first.use_distance, true);
+    assert_eq!(first.distance_key, Some("z".to_string()));
+    assert_eq!(first.distance_max, Some(30.0));
+    assert_eq!(first.distance_max_near, Some(300.0));
+    assert_eq!(first.n_max, None);
 
     let projection = &first.projection;
     // test reading a few of the expected fields
-    assert_eq!(projection.get("_id").unwrap().as_i64().unwrap(), 1);
-    assert_eq!(projection.get("gMeanPSFMag").unwrap().as_i64().unwrap(), 1);
-    assert_eq!(
-        projection.get("gMeanPSFMagErr").unwrap().as_i64().unwrap(),
-        1
-    );
+    assert_eq!(projection.get("_id").unwrap().as_i64().unwrap(), 0);
+    assert_eq!(projection.get("objname").unwrap().as_i64().unwrap(), 0);
+    assert_eq!(projection.get("DistMpc").unwrap().as_i64().unwrap(), 1);
 }
 
 #[tokio::test]

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -361,7 +361,7 @@ async fn test_enrich_ztf_alert() {
     let fading_rate = fading.get_f64("rate").unwrap();
     assert!((peak_mag - 15.6940).abs() < 1e-6);
     assert!((peak_jd - 2460441.971956).abs() < 1e-6);
-    assert!((rising_rate + 0.252037).abs() < 1e-6);
+    assert!((rising_rate + 0.20024).abs() < 1e-6);
     assert!((fading_rate - 0.037152).abs() < 1e-6);
 
     assert!(photstats.contains_key("r"));
@@ -374,7 +374,7 @@ async fn test_enrich_ztf_alert() {
     let fading_rate = fading.get_f64("rate").unwrap();
     assert!((peak_mag - 14.3987).abs() < 1e-6);
     assert!((peak_jd - 2460441.922303).abs() < 1e-6);
-    assert!((rising_rate + 0.133773).abs() < 1e-6);
+    assert!((rising_rate + 0.13846).abs() < 1e-6);
     assert!((fading_rate - 0.063829).abs() < 1e-6);
 }
 


### PR DESCRIPTION
This PR adds the following:
- [x] config + spatial: allow setting a maximum number of results on xmatch results coming back from MongoDB
- [x] config: remove some useless fields and rename field names to include unit information
- [x] config: have all surveys xmatch with NED LVS (catalog of galaxies, useful for most applications)
- [x] config: add `LSSG` to LSST xmatch config (a catalog of star galaxy score based on Legacy Survey, goes a lot deeper than PS1 and super useful given that LSST does NOT include star vs galaxy information in their alerts!), at 30 arcsec radius and 3 matches max (ala ZTF with its PS1 catalog-based SG scores).

TODOs:
- [x] update the test config with the same changes as the regular config