### PR TITLE
Enrichment worker: fetch_alerts deduplication

### DIFF
--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -10,7 +10,8 @@ use crate::{
 
 use std::{num::NonZero, sync::LazyLock};
 
-use mongodb::bson::Document;
+use futures::StreamExt;
+use mongodb::bson::{doc, Document};
 use opentelemetry::{
     metrics::{Counter, UpDownCounter},
     KeyValue,
@@ -75,10 +76,74 @@ pub trait EnrichmentWorker {
         Self: Sized;
     fn input_queue_name(&self) -> String;
     fn output_queue_name(&self) -> String;
+    #[instrument(skip_all, err)]
     async fn fetch_alerts(
         &self,
         candids: &[i64], // this is a slice of candids to process
-    ) -> Result<Vec<Document>, EnrichmentWorkerError>;
+        alert_pipeline: &Vec<Document>,
+        alert_collection: &mongodb::Collection<Document>,
+        alert_cutout_collection: Option<&mongodb::Collection<Document>>,
+    ) -> Result<Vec<Document>, EnrichmentWorkerError> {
+        let mut alert_pipeline = alert_pipeline.clone();
+        if let Some(first_stage) = alert_pipeline.first_mut() {
+            *first_stage = doc! {
+                "$match": {
+                    "_id": {"$in": candids}
+                }
+            };
+        }
+        let mut alert_cursor = alert_collection.aggregate(alert_pipeline).await?;
+
+        let mut alerts: Vec<Document> = Vec::new();
+        let mut candid_to_idx = std::collections::HashMap::new();
+        let mut count = 0;
+        while let Some(result) = alert_cursor.next().await {
+            match result {
+                Ok(document) => {
+                    alerts.push(document);
+                    let candid = alerts[count].get_i64("_id")?;
+                    candid_to_idx.insert(candid, count);
+                    count += 1;
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+
+        // next we fetch cutouts from the cutout collection, if provided
+        if let Some(alert_cutout_collection) = alert_cutout_collection {
+            let mut cutout_cursor = alert_cutout_collection
+                .find(doc! {
+                    "_id": {"$in": candids}
+                })
+                .await?;
+            while let Some(result) = cutout_cursor.next().await {
+                match result {
+                    Ok(cutout_doc) => {
+                        let candid = cutout_doc.get_i64("_id")?;
+                        if let Some(idx) = candid_to_idx.get(&candid) {
+                            alerts[*idx]
+                                .insert("cutoutScience", cutout_doc.get("cutoutScience").unwrap());
+                            alerts[*idx].insert(
+                                "cutoutTemplate",
+                                cutout_doc.get("cutoutTemplate").unwrap(),
+                            );
+                            alerts[*idx].insert(
+                                "cutoutDifference",
+                                cutout_doc.get("cutoutDifference").unwrap(),
+                            );
+                        }
+                    }
+                    _ => {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Ok(alerts)
+    }
     async fn process_alerts(
         &mut self,
         alerts: &[i64],

--- a/src/enrichment/decam.rs
+++ b/src/enrichment/decam.rs
@@ -1,7 +1,6 @@
 use crate::enrichment::{EnrichmentWorker, EnrichmentWorkerError};
 use crate::utils::db::fetch_timeseries_op;
 use crate::utils::lightcurves::{analyze_photometry, parse_photometry};
-use futures::StreamExt;
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
 use tracing::{instrument, warn};
@@ -88,41 +87,13 @@ impl EnrichmentWorker for DecamEnrichmentWorker {
     }
 
     #[instrument(skip_all, err)]
-    async fn fetch_alerts(
-        &self,
-        candids: &[i64], // this is a slice of candids to process
-    ) -> Result<Vec<Document>, EnrichmentWorkerError> {
-        let mut alert_pipeline = self.alert_pipeline.clone();
-        if let Some(first_stage) = alert_pipeline.first_mut() {
-            *first_stage = doc! {
-                "$match": {
-                    "_id": {"$in": candids}
-                }
-            };
-        }
-        let mut alert_cursor = self.alert_collection.aggregate(alert_pipeline).await?;
-
-        let mut alerts: Vec<Document> = Vec::new();
-        while let Some(result) = alert_cursor.next().await {
-            match result {
-                Ok(document) => {
-                    alerts.push(document);
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-
-        Ok(alerts)
-    }
-
-    #[instrument(skip_all, err)]
     async fn process_alerts(
         &mut self,
         candids: &[i64],
     ) -> Result<Vec<String>, EnrichmentWorkerError> {
-        let alerts = self.fetch_alerts(&candids).await?;
+        let alerts = self
+            .fetch_alerts(&candids, &self.alert_pipeline, &self.alert_collection, None)
+            .await?;
 
         if alerts.len() != candids.len() {
             warn!(

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -1,7 +1,6 @@
 use crate::enrichment::{EnrichmentWorker, EnrichmentWorkerError};
 use crate::utils::db::{fetch_timeseries_op, get_array_element};
 use crate::utils::lightcurves::{analyze_photometry, parse_photometry};
-use futures::StreamExt;
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
 use tracing::{instrument, warn};
@@ -105,41 +104,13 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
     }
 
     #[instrument(skip_all, err)]
-    async fn fetch_alerts(
-        &self,
-        candids: &[i64], // this is a slice of candids to process
-    ) -> Result<Vec<Document>, EnrichmentWorkerError> {
-        let mut alert_pipeline = self.alert_pipeline.clone();
-        if let Some(first_stage) = alert_pipeline.first_mut() {
-            *first_stage = doc! {
-                "$match": {
-                    "_id": {"$in": candids}
-                }
-            };
-        }
-        let mut alert_cursor = self.alert_collection.aggregate(alert_pipeline).await?;
-
-        let mut alerts: Vec<Document> = Vec::new();
-        while let Some(result) = alert_cursor.next().await {
-            match result {
-                Ok(document) => {
-                    alerts.push(document);
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-
-        Ok(alerts)
-    }
-
-    #[instrument(skip_all, err)]
     async fn process_alerts(
         &mut self,
         candids: &[i64],
     ) -> Result<Vec<String>, EnrichmentWorkerError> {
-        let alerts = self.fetch_alerts(&candids).await?;
+        let alerts = self
+            .fetch_alerts(&candids, &self.alert_pipeline, &self.alert_collection, None)
+            .await?;
 
         if alerts.len() != candids.len() {
             warn!(

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -2,7 +2,6 @@ use crate::enrichment::models::{AcaiModel, BtsBotModel, Model};
 use crate::enrichment::{EnrichmentWorker, EnrichmentWorkerError};
 use crate::utils::db::{fetch_timeseries_op, get_array_element};
 use crate::utils::lightcurves::{analyze_photometry, parse_photometry};
-use futures::StreamExt;
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
 use tracing::{instrument, warn};
@@ -131,74 +130,18 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
     }
 
     #[instrument(skip_all, err)]
-    async fn fetch_alerts(
-        &self,
-        candids: &[i64], // this is a slice of candids to process
-    ) -> Result<Vec<Document>, EnrichmentWorkerError> {
-        let mut alert_pipeline = self.alert_pipeline.clone();
-        if let Some(first_stage) = alert_pipeline.first_mut() {
-            *first_stage = doc! {
-                "$match": {
-                    "_id": {"$in": candids}
-                }
-            };
-        }
-        let mut alert_cursor = self.alert_collection.aggregate(alert_pipeline).await?;
-
-        let mut alerts: Vec<Document> = Vec::new();
-        let mut candid_to_idx = std::collections::HashMap::new();
-        let mut count = 0;
-        while let Some(result) = alert_cursor.next().await {
-            match result {
-                Ok(document) => {
-                    alerts.push(document);
-                    let candid = alerts[count].get_i64("_id")?;
-                    candid_to_idx.insert(candid, count);
-                    count += 1;
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-
-        // next we fetch cutouts from the cutout collection
-        let mut cutout_cursor = self
-            .alert_cutout_collection
-            .find(doc! {
-                "_id": {"$in": candids}
-            })
-            .await?;
-        while let Some(result) = cutout_cursor.next().await {
-            match result {
-                Ok(cutout_doc) => {
-                    let candid = cutout_doc.get_i64("_id")?;
-                    if let Some(idx) = candid_to_idx.get(&candid) {
-                        alerts[*idx]
-                            .insert("cutoutScience", cutout_doc.get("cutoutScience").unwrap());
-                        alerts[*idx]
-                            .insert("cutoutTemplate", cutout_doc.get("cutoutTemplate").unwrap());
-                        alerts[*idx].insert(
-                            "cutoutDifference",
-                            cutout_doc.get("cutoutDifference").unwrap(),
-                        );
-                    }
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-
-        Ok(alerts)
-    }
-
-    #[instrument(skip_all, err)]
     async fn process_alerts(
         &mut self,
         candids: &[i64],
     ) -> Result<Vec<String>, EnrichmentWorkerError> {
-        let alerts = self.fetch_alerts(&candids).await?;
+        let alerts = self
+            .fetch_alerts(
+                &candids,
+                &self.alert_pipeline,
+                &self.alert_collection,
+                Some(&self.alert_cutout_collection),
+            )
+            .await?;
 
         if alerts.len() != candids.len() {
             warn!(


### PR DESCRIPTION
I couldn't help but notice that the `fetch_alerts` method implemented by each survey was mostly... identical.

This PR adds a generic `fetch_alerts` method to the `enrichment/base.rs` module that each survey can use. That method will optionally retrieve cutouts if an `alert_cutout_collection` is provided (for now we only need those for ZTF, so no need to add the overhead for LSST and Decam).