### PR TITLE
ZTF & LSST forced photometry: bugfixes

### DIFF
--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -529,15 +529,14 @@ impl TryFrom<DiaForcedSource> for ForcedPhot {
         // may revisit this later
         let (magpsf, sigmapsf, isdiffpos, snr) = match dia_forced_source.psf_flux {
             Some(psf_flux) => {
-                let psf_flux = psf_flux * 1e-9;
-                if (psf_flux / psf_flux_err) > SNT {
-                    let isdiffpos = psf_flux > 0.0;
-                    let (magpsf, sigmapsf) = flux2mag(psf_flux, psf_flux_err, ZP_AB);
+                let psf_flux_abs = psf_flux.abs() * 1e-9;
+                if (psf_flux_abs / psf_flux_err) > SNT {
+                    let (magpsf, sigmapsf) = flux2mag(psf_flux_abs, psf_flux_err, ZP_AB);
                     (
                         Some(magpsf),
                         Some(sigmapsf),
-                        Some(isdiffpos),
-                        Some(psf_flux / psf_flux_err),
+                        Some(psf_flux > 0.0),
+                        Some(psf_flux_abs / psf_flux_err),
                     )
                 } else {
                     (None, None, None, None)

--- a/src/filter/lsst.rs
+++ b/src/filter/lsst.rs
@@ -82,7 +82,8 @@ pub async fn build_lsst_alerts(
             .get_binary_generic("cutoutDifference")?
             .to_vec();
 
-        // let's create the array of photometry (non forced phot only for now)
+        // let's create the array of photometry
+
         let mut photometry = Vec::new();
         for doc in alert_document.get_array("prv_candidates")?.iter() {
             let doc = match doc.as_document() {
@@ -90,8 +91,8 @@ pub async fn build_lsst_alerts(
                 None => continue, // skip if not a document
             };
             let jd = doc.get_f64("jd")?;
-            let flux = doc.get_f64("psfFlux")?;
-            let flux_err = doc.get_f64("psfFluxErr")?;
+            let flux = doc.get_f64("psfFlux")? * 1e-9; // from nJy to Jy
+            let flux_err = doc.get_f64("psfFluxErr")? * 1e-9; // from nJy to Jy
             let band = doc.get_str("band")?.to_string();
             let ra = doc.get_f64("ra").ok(); // optional, might not be present
             let dec = doc.get_f64("dec").ok(); // optional, might not be present
@@ -116,15 +117,16 @@ pub async fn build_lsst_alerts(
                 None => continue, // skip if not a document
             };
             let jd = doc.get_f64("jd")?;
-            let flux = doc.get_f64("psfFlux")?;
-            let flux_err = doc.get_f64("psfFluxErr")?;
+            // flux may be None in forced photometry
+            let flux = doc.get_f64("psfFlux").map(|f| f * 1e-9).ok(); // from nJy to Jy
+            let flux_err = doc.get_f64("psfFluxErr")? * 1e-9; // from nJy to Jy
             let band = doc.get_str("band")?.to_string();
             let ra = doc.get_f64("ra").ok(); // optional, might not be present
             let dec = doc.get_f64("dec").ok(); // optional, might not be present
 
             photometry.push(Photometry {
                 jd,
-                flux: Some(flux),
+                flux,
                 flux_err,
                 band: format!("lsst{}", band),
                 zero_point: 8.9,

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -156,6 +156,7 @@ pub async fn build_ztf_alerts(
                 None => continue, // skip if not a document
             };
             let jd = doc.get_f64("jd")?;
+            let magzpsci = doc.get_f64("magzpsci")?;
             let flux = match doc.get_f64("forcediffimflux") {
                 Ok(flux) => Some(flux),
                 Err(_) => None,
@@ -164,19 +165,18 @@ pub async fn build_ztf_alerts(
                 Ok(flux_err) => flux_err,
                 Err(_) => {
                     let diffmaglim = doc.get_f64("diffmaglim")?;
-                    limmag_to_fluxerr(diffmaglim, 23.9, 5.0)
+                    limmag_to_fluxerr(diffmaglim, magzpsci, 5.0)
                 }
             };
             let band = doc.get_str("band")?.to_string();
             let programid = doc.get_i32("programid")?;
-            let zero_point = 23.9;
 
             photometry.push(Photometry {
                 jd,
                 flux,
                 flux_err,
                 band: format!("ztf{}", band),
-                zero_point,
+                zero_point: magzpsci,
                 origin: Origin::ForcedPhot,
                 programid,
                 survey: Survey::Ztf,

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -361,7 +361,7 @@ async fn test_enrich_ztf_alert() {
     let fading_rate = fading.get_f64("rate").unwrap();
     assert!((peak_mag - 15.6940).abs() < 1e-6);
     assert!((peak_jd - 2460441.971956).abs() < 1e-6);
-    assert!((rising_rate + 0.252037).abs() < 1e-6);
+    assert!((rising_rate + 0.20024).abs() < 1e-6);
     assert!((fading_rate - 0.037152).abs() < 1e-6);
 
     assert!(photstats.contains_key("r"));
@@ -374,7 +374,7 @@ async fn test_enrich_ztf_alert() {
     let fading_rate = fading.get_f64("rate").unwrap();
     assert!((peak_mag - 14.3987).abs() < 1e-6);
     assert!((peak_jd - 2460441.922303).abs() < 1e-6);
-    assert!((rising_rate + 0.133773).abs() < 1e-6);
+    assert!((rising_rate + 0.13846).abs() < 1e-6);
     assert!((fading_rate - 0.063829).abs() < 1e-6);
 }
 


### PR DESCRIPTION
In this PR, we:
- ztf and lsst alert workers: compute magnitude even for negative forced photometry fluxes
- ztf filter worker: fix fp zeropoint
- lsst filter worker: add missing flux unit conversion (so that `Alert` `Photometry` values from different surveys use the same flux units).

Note: This flux unit conversion does make me wonder: should we make sure at deserialization time that fluxes are converted to the same unit for ALL surveys? This way, in the DB itself units are matched and can be used in queries. I really doubt folks would use fluxes in queries but you never know, and folks using LSST data might assume the flux is in the unit of the original alert packet and some other folks might assume it's in another unit (like ZTF's flux for example). So... I honestly don't know what's best. In my opinion consistency is best in a data model, so we should convert things and simply document things properly OR rename the field names (just like we replace LSST's mjd values to jd to match ZTF, which is another debate in itself as perhaps we should do the opposite but whatever) so that the unit is clearly mentioned in them... Something to think about!