### PR TITLE
Add back `classtar` to the ZTF candidate schema

### DIFF
--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -452,19 +452,19 @@ pub struct DiaObject {
     pub ndethist: i32,
 }
 
-#[serde_as]
-#[skip_serializing_none]
-#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct DiaNondetectionLimit {
-    #[serde(rename = "ccdVisitId")]
-    pub ccd_visit_id: i64,
-    #[serde(rename(deserialize = "midpointMjdTai", serialize = "jd"))]
-    #[serde(deserialize_with = "deserialize_mjd")]
-    pub jd: f64,
-    pub band: String,
-    #[serde(rename = "diaNoise")]
-    pub dia_noise: f32,
-}
+// #[serde_as]
+// #[skip_serializing_none]
+// #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+// pub struct DiaNondetectionLimit {
+//     #[serde(rename = "ccdVisitId")]
+//     pub ccd_visit_id: i64,
+//     #[serde(rename(deserialize = "midpointMjdTai", serialize = "jd"))]
+//     #[serde(deserialize_with = "deserialize_mjd")]
+//     pub jd: f64,
+//     pub band: String,
+//     #[serde(rename = "diaNoise")]
+//     pub dia_noise: f32,
+// }
 
 #[serde_as]
 #[skip_serializing_none]

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -181,6 +181,7 @@ pub struct DiaSource {
     /// Filter band this source was observed with.
     pub band: Option<String>,
     /// Source well fit by a dipole.
+    #[serde(rename = "isDipole")]
     pub is_dipole: Option<bool>,
     /// General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.
     #[serde(rename = "pixelFlags")]

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -212,6 +212,7 @@ pub struct Candidate {
     pub sharpnr: Option<f32>,
     pub sky: Option<f32>,
     pub fwhm: Option<f32>,
+    pub classtar: Option<f32>,
     pub mindtoedge: Option<f32>,
     pub seeratio: Option<f32>,
     pub aimage: Option<f32>,


### PR DESCRIPTION
This PR adds the `classtar` field back to the ZTF candidate schema, also adds a missing `serde rename` macro on the `is_dipole` field (which is named `isDipole` in the schema).