### PR TITLE
Missing ML docker volumes for the scheduler(s)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -214,6 +214,7 @@ services:
       - prod
     volumes:
       - ${PWD}/config.yaml:/app/config.yaml
+      - ${PWD}/data/models:/app/data/models
     command:
       - /app/scheduler
       - ztf
@@ -235,6 +236,7 @@ services:
       - prod
     volumes:
       - ${PWD}/config.yaml:/app/config.yaml
+      - ${PWD}/data/models:/app/data/models
     command:
       - /app/scheduler
       - lsst


### PR DESCRIPTION
The models are not added in the Docker image nor made available through volumes. We weill have multiple - and larger - models in the future and want to use features to run them conditionally, so bringing them into the container via volumes (rather than bloating the image with more stuff) makes sense to me. If that becomes too inconvenient, we could just put those in the image, at the cost of disk space usage.

Currently, this prevents the scheduler from working whatsoever in Docker.