### PR TITLE
Add driver: bridge to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ networks:
   traefik-public:
     # Allow setting it to false for testing and local development
     external: true
+  default:
+    driver: bridge
 
 services:
   # Autoheal will monitor containers with autoheal=true label


### PR DESCRIPTION
This PR adds a required network to the docker-compose to get it running on the Harvard cluster.