### PR TITLE
Add missing docker compose config parameters

### DIFF
--- a/config/docker-compose.traefik.yml
+++ b/config/docker-compose.traefik.yml
@@ -54,6 +54,8 @@ services:
       - --entrypoints.http.address=:80
       # Create an entrypoint "https" listening on port 443
       - --entrypoints.https.address=:443
+      # Create an entrypoint "kafka" listening on port 9093
+      - --entrypoints.kafka.address=:9093
       # Create the certificate resolver "le" for Let's Encrypt, uses the environment variable EMAIL
       - --certificatesresolvers.le.acme.email=${EMAIL?Variable not set}
       # Store the Let's Encrypt certificates in the mounted volume

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -180,9 +180,11 @@ services:
     environment:
       # Required secrets - must be set in environment
       BOOM_DATABASE__PASSWORD: ${BOOM_DATABASE__PASSWORD:?BOOM_DATABASE__PASSWORD must be set}
+      BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID: ${BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID:?BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID must be set}
       # Optional overrides
       BOOM_DATABASE__HOST: mongo
       BOOM_DATABASE__USERNAME: ${BOOM_DATABASE__USERNAME:-mongoadmin}
+      BOOM_REDIS__HOST: valkey
     networks:
       - boom
     profiles:
@@ -202,9 +204,13 @@ services:
     environment:
       # Required secrets - must be set in environment
       BOOM_DATABASE__PASSWORD: ${BOOM_DATABASE__PASSWORD:?BOOM_DATABASE__PASSWORD must be set}
+      BOOM_KAFKA__CONSUMER__LSST__GROUP_ID: ${BOOM_KAFKA__CONSUMER__LSST__GROUP_ID:?BOOM_KAFKA__CONSUMER__LSST__GROUP_ID must be set}
+      BOOM_KAFKA__CONSUMER__LSST__USERNAME: ${BOOM_KAFKA__CONSUMER__LSST__USERNAME:?BOOM_KAFKA__CONSUMER__LSST__USERNAME must be set}
+      BOOM_KAFKA__CONSUMER__LSST__PASSWORD: ${BOOM_KAFKA__CONSUMER__LSST__PASSWORD:?BOOM_KAFKA__CONSUMER__LSST__PASSWORD must be set}
       # Optional overrides
       BOOM_DATABASE__HOST: mongo
       BOOM_DATABASE__USERNAME: ${BOOM_DATABASE__USERNAME:-mongoadmin}
+      BOOM_REDIS__HOST: valkey
     networks:
       - boom
     profiles:
@@ -227,6 +233,7 @@ services:
       BOOM_DATABASE__HOST: mongo
       BOOM_DATABASE__USERNAME: ${BOOM_DATABASE__USERNAME:-mongoadmin}
       BOOM_BABAMUL__ENABLED: ${BOOM_BABAMUL__ENABLED:-false}
+      BOOM_REDIS__HOST: valkey
     networks:
       - boom
     profiles:
@@ -250,6 +257,7 @@ services:
       BOOM_DATABASE__HOST: mongo
       BOOM_DATABASE__USERNAME: ${BOOM_DATABASE__USERNAME:-mongoadmin}
       BOOM_BABAMUL__ENABLED: ${BOOM_BABAMUL__ENABLED:-false}
+      BOOM_REDIS__HOST: valkey
     networks:
       - boom
     profiles:


### PR DESCRIPTION
* add a missing kafka entrypoint in the traefik config, which makes it invalid right now

* add missing env vars in the regular docker compose yaml, needed for parameters to be overwritten by environment variables