### PR TITLE
Babamul multi-survey support (bugfixes and improvements)

### DIFF
--- a/apache-avro-macros/src/lib.rs
+++ b/apache-avro-macros/src/lib.rs
@@ -122,7 +122,14 @@ fn serdavro_impl(item: &ItemStruct) -> syn::Result<TokenStream> {
 
                             Schema::Record(record)
                         }
-                        _ => panic!("Only record schemas are supported")
+                        // Support Schema::Ref by cleaning up the name.
+                        Schema::Ref { name } => {
+                            let name_str = name.to_string();
+                            let clean_name_str = name_str.trim_start_matches("__SERDAVRO__").trim_end_matches("__");
+                            let clean_name = Name::new(clean_name_str).expect("Unable to parse schema name");
+                            Schema::Ref { name: clean_name }
+                        }
+                        _ => panic!("Only record and ref schemas are supported")
                     }
                 }
             }

--- a/src/enrichment/babamul.rs
+++ b/src/enrichment/babamul.rs
@@ -4,8 +4,8 @@ use crate::alert::{LsstCandidate, ZtfCandidate};
 use crate::conf::AppConfig;
 use crate::enrichment::lsst::{LsstAlertForEnrichment, LsstAlertProperties};
 use crate::enrichment::ztf::{ZtfAlertForEnrichment, ZtfAlertProperties};
-use crate::enrichment::EnrichmentWorkerError;
-use crate::utils::{derive_avro_schema::SerdavroWriter, lightcurves::PhotometryMag};
+use crate::enrichment::{EnrichmentWorkerError, LsstPhotometry, ZtfPhotometry};
+use crate::utils::derive_avro_schema::SerdavroWriter;
 use apache_avro::{AvroSchema, Schema, Writer};
 use apache_avro_macros::serdavro;
 use std::collections::HashMap;
@@ -43,8 +43,8 @@ pub struct EnrichedLsstAlert {
     #[serde(rename = "objectId")]
     pub object_id: String,
     pub candidate: LsstCandidate,
-    pub prv_candidates: Vec<PhotometryMag>,
-    pub fp_hists: Vec<PhotometryMag>,
+    pub prv_candidates: Vec<LsstPhotometry>,
+    pub fp_hists: Vec<LsstPhotometry>,
     pub properties: LsstAlertProperties,
     #[serde(rename = "cutoutScience")]
     pub cutout_science: Option<CutoutBytes>,
@@ -86,8 +86,9 @@ pub struct EnrichedZtfAlert {
     #[serde(rename = "objectId")]
     pub object_id: String,
     pub candidate: ZtfCandidate,
-    pub prv_candidates: Vec<PhotometryMag>,
-    pub fp_hists: Vec<PhotometryMag>,
+    pub prv_candidates: Vec<ZtfPhotometry>,
+    pub prv_nondetections: Vec<ZtfPhotometry>,
+    pub fp_hists: Vec<ZtfPhotometry>,
     pub properties: ZtfAlertProperties,
     pub survey_matches: Option<crate::enrichment::ztf::ZtfSurveyMatches>,
     #[serde(rename = "cutoutScience")]
@@ -112,6 +113,7 @@ impl EnrichedZtfAlert {
             object_id: alert.object_id,
             candidate: alert.candidate,
             prv_candidates: alert.prv_candidates,
+            prv_nondetections: alert.prv_nondetections,
             fp_hists: alert.fp_hists,
             properties,
             cutout_science: cutout_science.map(CutoutBytes),

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -126,6 +126,7 @@ pub async fn fetch_alerts<T: for<'a> serde::Deserialize<'a>>(
     while let Some(result) = alert_cursor.next().await {
         match result {
             Ok(document) => {
+                println!("Fetched alert document: {:?}", document);
                 let alert: T = mongodb::bson::from_document(document)?;
                 alerts.push(alert);
             }
@@ -273,6 +274,8 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, AvroSchema, JsonSchema)]
 pub struct SurveyMatch {
     pub object_id: String,
+    pub ra: f64,
+    pub dec: f64,
     pub prv_candidates: Vec<PhotometryMag>,
     pub fp_hists: Vec<PhotometryMag>,
 }

--- a/src/enrichment/mod.rs
+++ b/src/enrichment/mod.rs
@@ -9,5 +9,9 @@ pub use base::{
     EnrichmentWorkerError, SurveyMatch,
 };
 pub use decam::DecamEnrichmentWorker;
-pub use lsst::{LsstAlertForEnrichment, LsstAlertProperties, LsstEnrichmentWorker};
-pub use ztf::{ZtfAlertForEnrichment, ZtfAlertProperties, ZtfEnrichmentWorker};
+pub use lsst::{
+    LsstAlertForEnrichment, LsstAlertProperties, LsstEnrichmentWorker, LsstMatch, LsstPhotometry,
+};
+pub use ztf::{
+    ZtfAlertForEnrichment, ZtfAlertProperties, ZtfEnrichmentWorker, ZtfMatch, ZtfPhotometry,
+};

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -1,9 +1,10 @@
 use crate::conf::AppConfig;
 use crate::enrichment::babamul::{Babamul, EnrichedZtfAlert};
-use crate::enrichment::base::SurveyMatch;
-use crate::utils::db::{fetch_timeseries_op, mongify};
+use crate::enrichment::LsstMatch;
+use crate::utils::db::{get_array_dict_element, get_array_element, mongify};
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, AllBandsProperties, PerBandProperties, PhotometryMag,
+    analyze_photometry, prepare_photometry, AllBandsProperties, Band, PerBandProperties,
+    PhotometryMag,
 };
 use crate::{
     alert::ZtfCandidate,
@@ -14,10 +15,56 @@ use crate::{
     },
 };
 use apache_avro_derive::AvroSchema;
+use apache_avro_macros::serdavro;
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
 use schemars::JsonSchema;
 use tracing::{instrument, warn};
+
+fn default_ztf_zp() -> Option<f64> {
+    Some(23.9)
+}
+
+#[serdavro]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ZtfPhotometry {
+    pub jd: f64,
+    pub magpsf: Option<f64>,
+    pub sigmapsf: Option<f64>,
+    pub diffmaglim: f64,
+    #[serde(rename = "psfFlux")]
+    pub flux: Option<f64>, // in nJy
+    #[serde(rename = "psfFluxErr")]
+    pub flux_err: f64, // in nJy
+    pub band: Band,
+    // set a default of 23.9 for zp if missing
+    #[serde(default = "default_ztf_zp")]
+    pub zp: Option<f64>,
+    pub ra: Option<f64>,
+    pub dec: Option<f64>,
+    pub snr: Option<f64>,
+    pub programid: i32,
+}
+
+// it should return an optional PhotometryMag
+impl ZtfPhotometry {
+    pub fn to_photometry_mag(&self) -> Option<PhotometryMag> {
+        // if the abs value of the snr > 3 and magpsf is Some, we return Some(PhotometryMag)
+        println!(
+            "ZtfPhotometry to_photometry_mag: jd={}, magpsf={:?}, sigmapsf={:?}, snr={:?}",
+            self.jd, self.magpsf, self.sigmapsf, self.snr
+        );
+        match (self.snr, self.magpsf, self.sigmapsf) {
+            (Some(snr), Some(mag), Some(sig)) if snr.abs() > 3.0 => Some(PhotometryMag {
+                time: self.jd,
+                mag: mag as f32,
+                mag_err: sig as f32,
+                band: self.band.clone(),
+            }),
+            _ => None,
+        }
+    }
+}
 
 pub fn create_ztf_alert_pipeline() -> Vec<Document> {
     vec![
@@ -35,111 +82,156 @@ pub fn create_ztf_alert_pipeline() -> Vec<Document> {
         doc! {
             "$lookup": {
                 "from": "ZTF_alerts_aux",
-                "localField": "objectId",
-                "foreignField": "_id",
+                "let": { "obj_id": "$objectId" },
+                "pipeline": [
+                    doc! {
+                        "$match": {
+                            "$expr": {
+                                "$eq": [ "$_id", "$$obj_id" ]
+                            }
+                        }
+                    },
+                    doc! {
+                        "$project": {
+                            // prv_candidates
+                            "prv_candidates.jd": 1,
+                            "prv_candidates.magpsf": 1,
+                            "prv_candidates.sigmapsf": 1,
+                            "prv_candidates.diffmaglim": 1,
+                            "prv_candidates.band": 1,
+                            "prv_candidates.psfFlux": 1,
+                            "prv_candidates.psfFluxErr": 1,
+                            "prv_candidates.ra": 1,
+                            "prv_candidates.dec": 1,
+                            "prv_candidates.programid": 1,
+                            "prv_candidates.snr": 1,
+                            // prv_nondetections
+                            "prv_nondetections.jd": 1,
+                            "prv_nondetections.diffmaglim": 1,
+                            "prv_nondetections.band": 1,
+                            "prv_nondetections.psfFluxErr": 1,
+                            "prv_nondetections.programid": 1,
+                            // fp_hists
+                            "fp_hists.jd": 1,
+                            "fp_hists.magpsf": 1,
+                            "fp_hists.sigmapsf": 1,
+                            "fp_hists.diffmaglim": 1,
+                            "fp_hists.band": 1,
+                            "fp_hists.psfFlux": 1,
+                            "fp_hists.psfFluxErr": 1,
+                            "fp_hists.zp": 1,
+                            "fp_hists.programid": 1,
+                            "fp_hists.snr": 1,
+                            // aliases
+                            "aliases": 1,
+                        }
+                    }
+                ],
                 "as": "aux"
             }
         },
         doc! {
             "$addFields": {
-                "aux": { "$arrayElemAt": ["$aux", 0] }
+                "prv_candidates": get_array_element("aux.prv_candidates"),
+                "prv_nondetections": get_array_element("aux.prv_nondetections"),
+                "fp_hists": get_array_element("aux.fp_hists"),
+                "aliases": get_array_dict_element("aux.aliases"),
+                "aux": mongodb::bson::Bson::Null,
             }
         },
-        // Lookup LSST cross-matches
         doc! {
+            // same here, we do a pipeline to be more efficient
             "$lookup": {
                 "from": "LSST_alerts_aux",
-                "let": {
-                    "lsst_ids": {
-                        "$cond": [
-                            { "$and": [{ "$isArray": "$aux.aliases.LSST" }, { "$gt": [{ "$size": "$aux.aliases.LSST" }, 0] }] },
-                            "$aux.aliases.LSST",
-                            []
-                        ]
-                    }
-                },
+                "let": { "lsst_obj_id": { "$arrayElemAt": [ "$aliases.LSST", 0 ] } },
                 "pipeline": [
-                    doc! { "$match": { "$expr": { "$in": ["$_id", "$$lsst_ids"] } } },
+                    doc! {
+                        "$match": {
+                            "$expr": {
+                                "$eq": [ "$_id", "$$lsst_obj_id" ]
+                            }
+                        }
+                    },
                     doc! {
                         "$project": {
-                            "_id": 1,
-                            "prv_candidates": 1,
-                            "fp_hists": 1,
+                            // prv_candidates up to 365 days
+                            "prv_candidates.jd": 1,
+                            "prv_candidates.magpsf": 1,
+                            "prv_candidates.sigmapsf": 1,
+                            "prv_candidates.diffmaglim": 1,
+                            "prv_candidates.band": 1,
+                            "prv_candidates.psfFlux": 1,
+                            "prv_candidates.psfFluxErr": 1,
+                            "prv_candidates.ra": 1,
+                            "prv_candidates.dec": 1,
+                            "prv_candidates.snr": 1,
+                            // fp_hists up to 365 days
+                            "fp_hists.jd": 1,
+                            "fp_hists.magpsf": 1,
+                            "fp_hists.sigmapsf": 1,
+                            "fp_hists.diffmaglim": 1,
+                            "fp_hists.band": 1,
+                            "fp_hists.psfFlux": 1,
+                            "fp_hists.psfFluxErr": 1,
+                            "fp_hists.snr": 1,
+                            // grab the ra from coordinates.radec_geojson
+                            "ra": { "$add": [
+                                { "$arrayElemAt": [ "$coordinates.radec_geojson.coordinates", 0 ] },
+                                180
+                            ] },
+                            "dec": { "$arrayElemAt": [ "$coordinates.radec_geojson.coordinates", 1 ] },
                         }
                     }
                 ],
-                "as": "lsst_xmatches"
+                "as": "lsst_aux"
             }
         },
         doc! {
-            "$project": doc! {
-                "objectId": 1,
-                "candidate": 1,
-                "prv_candidates": fetch_timeseries_op(
-                    "aux.prv_candidates",
-                    "candidate.jd",
-                    365,
-                    None
-                ),
-                "fp_hists": fetch_timeseries_op(
-                    "aux.fp_hists",
-                    "candidate.jd",
-                    365,
-                    Some(vec![doc! {
-                        "$gte": [
-                            "$$x.snr",
-                            3.0
-                        ]
-                    }]),
-                ),
-                "aliases": {
-                    "$ifNull": [
-                        "$aux.aliases",
-                        doc! {}
-                    ]
-                },
-                "survey_matches": {
-                    "lsst": {
-                        "$map": {
-                            "input": {
-                                "$ifNull": [
-                                    "$lsst_xmatches",
-                                    {"$ifNull": ["$aux.aliases.LSST", []]}
-                                ]
-                            },
-                            "as": "obj",
-                            "in": {
-                                "survey": "LSST",
-                                "object_id": {"$ifNull": ["$$obj._id", "$$obj"]},
-                                "prv_candidates": {"$ifNull": ["$$obj.prv_candidates", []]},
-                                "fp_hists": {"$ifNull": ["$$obj.fp_hists", []]}
-                            }
-                        }
+            "$addFields": {
+                "survey_matches.lsst": {
+                    "$cond": {
+                        "if": { "$gt": [ { "$size": "$lsst_aux" }, 0 ] },
+                        "then": {
+                            "object_id": { "$arrayElemAt": [ "$lsst_aux._id", 0 ] },
+                            "prv_candidates": get_array_element("lsst_aux.prv_candidates"),
+                            "prv_nondetections": get_array_element("lsst_aux.prv_nondetections"),
+                            "fp_hists": get_array_element("lsst_aux.fp_hists"),
+                            "ra": { "$arrayElemAt": [ "$lsst_aux.ra", 0 ] },
+                            "dec": { "$arrayElemAt": [ "$lsst_aux.dec", 0 ] },
+                        },
+                        "else": null
                     }
-                }
+                },
+                "lsst_aux": mongodb::bson::Bson::Null,
             }
         },
         doc! {
             "$project": doc! {
                 "objectId": 1,
                 "candidate": 1,
-                "prv_candidates.jd": 1,
-                "prv_candidates.magpsf": 1,
-                "prv_candidates.sigmapsf": 1,
-                "prv_candidates.band": 1,
-                "fp_hists.jd": 1,
-                "fp_hists.magpsf": 1,
-                "fp_hists.sigmapsf": 1,
-                "fp_hists.band": 1,
+                "prv_candidates":  1,
+                "prv_nondetections": 1,
+                "fp_hists": 1,
                 "survey_matches": 1,
             }
         },
     ]
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, AvroSchema, JsonSchema)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, AvroSchema)]
 pub struct ZtfSurveyMatches {
-    pub lsst: Vec<SurveyMatch>,
+    pub lsst: Option<LsstMatch>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, AvroSchema)]
+pub struct ZtfMatch {
+    // #[serde(rename = "_id")]
+    pub object_id: String,
+    pub ra: f64,
+    pub dec: f64,
+    pub prv_candidates: Vec<ZtfPhotometry>,
+    pub prv_nondetections: Vec<ZtfPhotometry>,
+    pub fp_hists: Vec<ZtfPhotometry>,
 }
 
 /// ZTF alert structure used to deserialize alerts
@@ -152,8 +244,9 @@ pub struct ZtfAlertForEnrichment {
     #[serde(rename = "objectId")]
     pub object_id: String,
     pub candidate: ZtfCandidate,
-    pub prv_candidates: Vec<PhotometryMag>,
-    pub fp_hists: Vec<PhotometryMag>,
+    pub prv_candidates: Vec<ZtfPhotometry>,
+    pub prv_nondetections: Vec<ZtfPhotometry>,
+    pub fp_hists: Vec<ZtfPhotometry>,
     pub survey_matches: Option<ZtfSurveyMatches>,
 }
 
@@ -165,6 +258,7 @@ pub struct ZtfAlertProperties {
     pub near_brightstar: bool,
     pub stationary: bool,
     pub photstats: PerBandProperties,
+    pub multisurvey_photstats: PerBandProperties,
 }
 
 pub struct ZtfEnrichmentWorker {
@@ -402,14 +496,44 @@ impl ZtfEnrichmentWorker {
                 && distpsnr1 < 0.5
                 && (sgmag1 < 17.0 || srmag1 < 17.0 || simag1 < 17.0));
 
-        let prv_candidates = alert.prv_candidates.clone();
-        let fp_hists = alert.fp_hists.clone();
+        let prv_candidates: Vec<PhotometryMag> = alert
+            .prv_candidates
+            .iter()
+            .filter_map(|p| p.to_photometry_mag())
+            .collect();
+        let fp_hists: Vec<PhotometryMag> = alert
+            .fp_hists
+            .iter()
+            .filter_map(|p| p.to_photometry_mag())
+            .collect();
 
         // lightcurve is prv_candidates + fp_hists, no need for parse_photometry here
         let mut lightcurve = [prv_candidates, fp_hists].concat();
 
         prepare_photometry(&mut lightcurve);
         let (photstats, all_bands_properties, stationary) = analyze_photometry(&lightcurve);
+
+        // make a multisurvey lightcurve if we have LSST matches
+        let multisurvey_photstats = if let Some(survey_matches) = &alert.survey_matches {
+            if let Some(lsst_match) = &survey_matches.lsst {
+                let lsst_prv_candidates: Vec<PhotometryMag> = lsst_match
+                    .prv_candidates
+                    .iter()
+                    .filter_map(|p| p.to_photometry_mag())
+                    .collect();
+                let lsst_fp_hists: Vec<PhotometryMag> = lsst_match
+                    .fp_hists
+                    .iter()
+                    .filter_map(|p| p.to_photometry_mag())
+                    .collect();
+                let mut lsst_lightcurve = [lsst_prv_candidates, lsst_fp_hists].concat();
+                prepare_photometry(&mut lsst_lightcurve);
+                lightcurve.extend(lsst_lightcurve);
+            }
+            analyze_photometry(&lightcurve).0
+        } else {
+            PerBandProperties::default()
+        };
 
         Ok((
             ZtfAlertProperties {
@@ -418,6 +542,7 @@ impl ZtfEnrichmentWorker {
                 near_brightstar: is_near_brightstar,
                 stationary,
                 photstats,
+                multisurvey_photstats,
             },
             all_bands_properties,
             programid,

--- a/src/filter/lsst.rs
+++ b/src/filter/lsst.rs
@@ -10,7 +10,7 @@ use crate::filter::{
     Classification, FilterError, FilterResults, FilterWorker, FilterWorkerError, LoadedFilter,
     Origin, Photometry,
 };
-use crate::utils::db::{fetch_timeseries_op, get_array_element};
+use crate::utils::db::{fetch_timeseries_op, get_array_dict_element, get_array_element};
 use crate::utils::enums::Survey;
 
 /// For a filter running on another survey (e.g., ZTF), determine if we need to
@@ -322,11 +322,11 @@ pub async fn build_lsst_filter_pipeline(
     if use_cross_matches_index.is_some() {
         aux_add_fields.insert(
             "cross_matches".to_string(),
-            get_array_element("aux.cross_matches"),
+            get_array_dict_element("aux.cross_matches"),
         );
     }
     if use_aliases_index.is_some() {
-        aux_add_fields.insert("aliases".to_string(), get_array_element("aux.aliases"));
+        aux_add_fields.insert("aliases".to_string(), get_array_dict_element("aux.aliases"));
     }
 
     let mut insert_aux_pipeline = use_prv_candidates_index.is_some()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "512"] // for large bson documents in pipelines (default was 256)
 pub mod alert;
 pub mod api;
 pub mod conf;

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -109,9 +109,28 @@ pub fn update_timeseries_op(
 
 pub fn get_array_element(field: &str) -> Document {
     doc! {
-        "$arrayElemAt": [
-            format!("${}", field),
-            0
+        "$ifNull": [
+            {
+                "$arrayElemAt": [
+                    format!("${}", field),
+                    0
+                ]
+            },
+            []
+        ]
+    }
+}
+
+pub fn get_array_dict_element(field: &str) -> Document {
+    doc! {
+        "$ifNull": [
+            {
+                "$arrayElemAt": [
+                    format!("${}", field),
+                    0
+                ]
+            },
+            {}
         ]
     }
 }
@@ -119,6 +138,8 @@ pub fn get_array_element(field: &str) -> Document {
 /// This function generates a MongoDB aggregation operation
 /// that filters an array field based on a time window relative to a candidate's jd field.
 /// It can also include optional conditions for filtering.
+/// The array_field is expected to come from an auxiliary collection
+/// (i.e. "ztf_aux.prv_candidates", where "ztf_aux" is an array of documents itself).
 pub fn fetch_timeseries_op(
     array_field: &str,
     candidate_jd_field: &str,
@@ -149,12 +170,7 @@ pub fn fetch_timeseries_op(
     }
     doc! {
         "$filter": doc! {
-            "input": {
-                "$ifNull": [
-                    format!("${}", array_field),
-                    []
-                ]
-            },
+            "input": get_array_element(array_field),
             "as": "x",
             "cond": doc! {
                 "$and": conditions

--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -1,4 +1,5 @@
 use apache_avro_derive::AvroSchema;
+use apache_avro_macros::serdavro;
 use mongodb::bson::doc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -66,9 +67,9 @@ pub struct BandRateProperties {
     pub nb_data: i32,
 }
 
-// TODO: for some reason, avro serialization
-// seems to fail when we use skip_serializing_none (and rising and/or fading are None)
-// which is odd since we don't get this issue in other structs...
+// TODO: avro serialization fail when we use skip_serializing_none,
+// since the optional fields are not just None but simply missing
+// (this needs to be fixed in the apache_avro-related crates)
 // #[serde_as]
 // #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, AvroSchema, JsonSchema)]
@@ -80,9 +81,13 @@ pub struct BandProperties {
     pub fading: Option<BandRateProperties>,
 }
 
-#[serde_as]
-#[skip_serializing_none]
-#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, AvroSchema, JsonSchema, Default)]
+// TODO: avro serialization fail when we use skip_serializing_none,
+// since the optional fields are not just None but simply missing
+// (this needs to be fixed in the apache_avro-related crates)
+// #[serde_as]
+// #[skip_serializing_none]
+#[serdavro]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, JsonSchema, Default)]
 pub struct PerBandProperties {
     pub g: Option<BandProperties>,
     pub r: Option<BandProperties>,
@@ -92,8 +97,6 @@ pub struct PerBandProperties {
     pub u: Option<BandProperties>,
 }
 
-#[serde_as]
-#[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, AvroSchema)]
 pub struct AllBandsProperties {
     pub peak_jd: f64,

--- a/tests/test_filter.rs
+++ b/tests/test_filter.rs
@@ -22,12 +22,12 @@ async fn test_build_filter() {
         doc! { "$match": { "_id": { "$in": [] } } },
         doc! { "$project": { "objectId": 1, "candidate": 1, "classifications": 1, "properties": 1, "coordinates": 1 } },
         doc! { "$lookup": { "from": "ZTF_alerts_aux", "localField": "objectId", "foreignField": "_id", "as": "aux" } },
-        doc! { "$addFields": { "aux": { "$arrayElemAt": ["$aux", 0] } } },
         doc! {
             "$addFields": {
+                "aux": mongodb::bson::Bson::Null,
                 "prv_candidates": {
                     "$filter": {
-                        "input": { "$ifNull": ["$aux.prv_candidates", []] },
+                        "input": { "$ifNull": [ {"$arrayElemAt": ["$aux.prv_candidates", 0] }, [] ] },
                         "as": "x",
                         "cond": {
                             "$and": [
@@ -96,14 +96,10 @@ async fn test_build_multisurvey_filter() {
         doc! { "$lookup": { "from": "ZTF_alerts_aux", "localField": "objectId", "foreignField": "_id", "as": "aux" } },
         doc! {
             "$addFields": {
-                "aux": { "$arrayElemAt": ["$aux", 0] }
-            }
-        },
-        doc! {
-            "$addFields": {
+                "aux": mongodb::bson::Bson::Null,
                 "prv_candidates": {
                     "$filter": {
-                        "input": { "$ifNull": ["$aux.prv_candidates", []] },
+                        "input": { "$ifNull": [ {"$arrayElemAt": ["$aux.prv_candidates", 0] }, [] ] },
                         "as": "x",
                         "cond": {
                             "$and": [
@@ -115,7 +111,7 @@ async fn test_build_multisurvey_filter() {
                     }
                 },
                 "aliases": {
-                    "$ifNull": ["$aux.aliases", doc!{}]
+                    "$ifNull": [ {"$arrayElemAt": ["$aux.aliases", 0] }, doc!{}]
                 }
             }
         },
@@ -125,7 +121,7 @@ async fn test_build_multisurvey_filter() {
                 "lsst_aux": mongodb::bson::Bson::Null,
                 "LSST.prv_candidates": {
                     "$filter": {
-                        "input": { "$ifNull": ["$lsst_aux.prv_candidates", []] },
+                        "input": { "$ifNull": [ {"$arrayElemAt": ["$lsst_aux.prv_candidates", 0] }, [] ] },
                         "as": "x",
                         "cond": {
                             "$and": [


### PR DESCRIPTION
- [x] revert some changes to avoid adding an extra addFields pipeline to make aux array fields into single docs
- [x] add get_array_dict_element where we use {} as the missing value placeholder for
- [x] revert change to fetch_timeseries_op since all its inputs are back to being array like (and therefore need a get_array_element fn call)
- [x] add ZtfMatch and LsstMatch structs, and edit the create_<survey>_alert_pipeline methods to format the survey matches fit with these new structs
- [x] newly added <Survey>Match structs include more information right lightcurves as well as position
- [x] since we now get multisurvey data in the enrichment worker processing we add a multisurvey_photstats field
- [x] updated babamul unit tests
- [ ] when creating the babamul output of LSST alerts, remove non-public ZTF data from the ZTF match lightcurves
- [ ] the babamul unit tests create aux table entries by writing documents manually. It's very prone to errors (for example here, the documents were a clear mismatch with the data model!!!). I know we have a document DB but we also have the data model clearly modeled as structs now, so we should use that and never create documents from scratch unless it's really a lot easier. Structs for everything is the way to go. Here the unit tests kept failing as I changed or fixed the code, not because of the changesd were incorrect but because the documents created in the tests were incorrect or not in sync.