### PR TITLE
Mount apache-avro-macros for local dev

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -69,6 +69,7 @@ services:
     command: ["cargo", "watch", "-x", "run --bin api"]
     volumes:
       - ./src:/app/src
+      - ./apache-avro-macros:/app/apache-avro-macros
       - ./Cargo.toml:/app/Cargo.toml
       - ./Cargo.lock:/app/Cargo.lock
       - cargo-registry:/usr/local/cargo/registry


### PR DESCRIPTION
Was seeing an error when running the API in dev mode in Docker Compose.