### PR TITLE
Babamul LSST schema fix

### DIFF
--- a/src/enrichment/babamul.rs
+++ b/src/enrichment/babamul.rs
@@ -66,7 +66,6 @@ impl serde::Serialize for CutoutBytes {
 #[serdavro]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct EnrichedLsstAlert {
-    #[serde(rename = "_id")]
     pub candid: i64,
     #[serde(rename = "objectId")]
     pub object_id: String,


### PR DESCRIPTION
rename incorrect `candid` -> `_id` serde rename, when producing Babamul alerts