### PR TITLE
Babamul API: fix link to docs

### DIFF
--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -50,7 +50,7 @@ async fn main() -> std::io::Result<()> {
                     .app_data(web::Data::new(babamul_avro_schemas))
                     .wrap(from_fn(babamul_auth_middleware))
                     // Public routes
-                    .service(Scalar::with_url("/babamul/docs", babamul_doc.clone()))
+                    .service(Scalar::with_url("/docs", babamul_doc.clone()))
                     .service(routes::babamul::surveys::get_babamul_schema)
                     .service(routes::babamul::post_babamul_signup)
                     .service(routes::babamul::post_babamul_activate)


### PR DESCRIPTION
It's all in the title :). A recent PR of mine that fixed all the other routes omitted an update that was required to the routing to the docs. This PR fixes this