### PR TITLE
ZTF Enrichment Worker: skip MLing if features are missing

### DIFF
--- a/src/enrichment/decam.rs
+++ b/src/enrichment/decam.rs
@@ -149,6 +149,8 @@ impl EnrichmentWorker for DecamEnrichmentWorker {
             return Ok(vec![]);
         }
 
+        let now = flare::Time::now().to_jd();
+
         // we keep it very simple for now, let's run on 1 alert at a time
         // we will move to batch processing later
         let mut updates = Vec::new();
@@ -161,6 +163,7 @@ impl EnrichmentWorker for DecamEnrichmentWorker {
             let update_alert_document = doc! {
                 "$set": {
                     "properties": mongify(&properties),
+                    "updated_at": now,
                 }
             };
 

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -322,6 +322,8 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
             );
         }
 
+        let now = flare::Time::now().to_jd();
+
         // we keep it very simple for now, let's run on 1 alert at a time
         // we will move to batch processing later
         let mut updates = Vec::new();
@@ -339,6 +341,7 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
             let update_alert_document = doc! {
                 "$set": {
                     "properties": mongify(&properties),
+                    "updated_at": now,
                 }
             };
 

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -19,7 +19,7 @@ pub enum ModelError {
     PrepareCutoutError(#[from] CutoutError),
     #[error("error converting predictions to vec")]
     ModelOutputToVecError,
-    #[error("missing feature in alert")]
+    #[error("missing feature in alert: {0}")]
     MissingFeature(&'static str),
 }
 

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -454,36 +454,47 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
                 self.get_alert_properties(&alert).await?;
 
             // Now, prepare inputs for ML models and run inference
-            let metadata = self.acai_h_model.get_metadata(&[&alert])?;
+            // (we skip ML inference if features cannot be computed, e.g. missing required features)
             let triplet = self.acai_h_model.get_triplet(&[&cutouts])?;
-
-            let acai_h_scores = self.acai_h_model.predict(&metadata, &triplet)?;
-            let acai_n_scores = self.acai_n_model.predict(&metadata, &triplet)?;
-            let acai_v_scores = self.acai_v_model.predict(&metadata, &triplet)?;
-            let acai_o_scores = self.acai_o_model.predict(&metadata, &triplet)?;
-            let acai_b_scores = self.acai_b_model.predict(&metadata, &triplet)?;
-
-            let metadata_btsbot = self
+            let metadata_result = self.acai_h_model.get_metadata(&[&alert]);
+            let btsbot_metadata_result = self
                 .btsbot_model
-                .get_metadata(&[&alert], &[all_bands_properties])?;
-            let btsbot_scores = self.btsbot_model.predict(&metadata_btsbot, &triplet)?;
+                .get_metadata(&[&alert], &[all_bands_properties.clone()]);
 
-            let classifications = ZtfAlertClassifications {
-                acai_h: acai_h_scores[0],
-                acai_n: acai_n_scores[0],
-                acai_v: acai_v_scores[0],
-                acai_o: acai_o_scores[0],
-                acai_b: acai_b_scores[0],
-                btsbot: btsbot_scores[0],
+            let classifications = if let (Ok(metadata), Ok(btsbot_metadata)) =
+                (metadata_result, btsbot_metadata_result)
+            {
+                let acai_h_scores = self.acai_h_model.predict(&metadata, &triplet)?;
+                let acai_n_scores = self.acai_n_model.predict(&metadata, &triplet)?;
+                let acai_v_scores = self.acai_v_model.predict(&metadata, &triplet)?;
+                let acai_o_scores = self.acai_o_model.predict(&metadata, &triplet)?;
+                let acai_b_scores = self.acai_b_model.predict(&metadata, &triplet)?;
+                let btsbot_scores = self.btsbot_model.predict(&btsbot_metadata, &triplet)?;
+                Some(ZtfAlertClassifications {
+                    acai_h: acai_h_scores[0],
+                    acai_n: acai_n_scores[0],
+                    acai_v: acai_v_scores[0],
+                    acai_o: acai_o_scores[0],
+                    acai_b: acai_b_scores[0],
+                    btsbot: btsbot_scores[0],
+                })
+            } else {
+                warn!(
+                    "Skipping ML inference for candid {} due to missing features",
+                    candid
+                );
+                None
             };
 
-            let update_alert_document = doc! {
-                "$set": {
-                    // ML scores
+            let update_alert_document = if let Some(classifications) = classifications {
+                doc! { "$set": {
                     "classifications": mongify(&classifications),
-                    // properties
                     "properties": mongify(&properties),
-                }
+                }}
+            } else {
+                doc! { "$set": {
+                    "properties": mongify(&properties),
+                }}
             };
 
             let update = WriteModel::UpdateOne(

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -438,6 +438,8 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
             );
         }
 
+        let now = flare::Time::now().to_jd();
+
         // we keep it very simple for now, let's run on 1 alert at a time
         // we will move to batch processing later
         let mut updates = Vec::new();
@@ -490,10 +492,12 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
                 doc! { "$set": {
                     "classifications": mongify(&classifications),
                     "properties": mongify(&properties),
+                    "updated_at": now,
                 }}
             } else {
                 doc! { "$set": {
                     "properties": mongify(&properties),
+                    "updated_at": now,
                 }}
             };
 


### PR DESCRIPTION
If some ML features can't be computed, skip MLing ZTF alerts in the enrichment worker (and only add properties), instead of panicking which right now kills the worker. Besides, it's actually normal for these features to be missing for old alerts (say pre 2020), when a bunch of fields weren't in the schema yet.

For context: this created issues when I imported a bunch of old alerts from Kowalski, for which these models simply cannot run on by design, and that's ok.

EDIT: looks like we aren't updating the `updated_at` field of the alert when we enrich it, which I think we should be. This PR also adds that.