### PR TITLE
PATs on Babamul user collection

### DIFF
--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -7,8 +7,7 @@ use mongodb::Database;
 
 /// Protected names for operational data collections, which should not be used
 /// for analytical data catalogs
-pub const PROTECTED_COLLECTION_NAMES: [&str; 4] =
-    ["filters", "babamul_users", "users", "babamul_user_tokens"];
+pub const PROTECTED_COLLECTION_NAMES: [&str; 3] = ["filters", "babamul_users", "users"];
 
 async fn init_api_admin_user(
     auth_config: &AuthConfig,
@@ -121,7 +120,7 @@ pub async fn build_db_api(conf: &AppConfig) -> Result<mongodb::Database, BoomCon
         .await
         .expect("failed to create username index on users collection");
 
-    // Only create babamul_users and babamul_user_tokens collections if Babamul is enabled
+    // Only create the babamul_users collection if Babamul is enabled
     if conf.babamul.enabled {
         // Create babamul_users collection with unique email index
         use crate::api::routes::babamul::BabamulUser;
@@ -139,39 +138,44 @@ pub async fn build_db_api(conf: &AppConfig) -> Result<mongodb::Database, BoomCon
             .create_index(email_index)
             .await
             .expect("failed to create email index on babamul_users collection");
-        // Create babamul_user_tokens collection with indexes
-        use crate::api::routes::babamul::tokens::BabamulUserToken;
-        let babamul_tokens_collection: mongodb::Collection<BabamulUserToken> =
-            db.collection("babamul_user_tokens");
-        // Unique index on token_hash for fast lookup during authentication
+
+        // Index on tokens.token_hash for efficient lookup
         let token_hash_index = mongodb::IndexModel::builder()
-            .keys(doc! { "token_hash": 1})
+            .keys(doc! { "tokens.token_hash": 1})
+            .options(
+                mongodb::options::IndexOptions::builder()
+                    .unique(false)
+                    .build(),
+            )
+            .build();
+        let _ = babamul_users_collection
+            .create_index(token_hash_index)
+            .await
+            .expect("failed to create token_hash index on babamul_users collection");
+
+        // Unique index on the user id + tokens.name to prevent duplicate token names per user
+        let token_name_index = mongodb::IndexModel::builder()
+            .keys(doc! { "_id": 1, "tokens.name": 1})
             .options(
                 mongodb::options::IndexOptions::builder()
                     .unique(true)
                     .build(),
             )
             .build();
-        let _ = babamul_tokens_collection
-            .create_index(token_hash_index)
+        let _ = babamul_users_collection
+            .create_index(token_name_index)
             .await
-            .expect("failed to create token_hash index on babamul_user_tokens collection");
-        // Index on user_id for efficient token listing and counting
-        let user_id_index = mongodb::IndexModel::builder()
-            .keys(doc! { "user_id": 1})
-            .build();
-        let _ = babamul_tokens_collection
-            .create_index(user_id_index)
-            .await
-            .expect("failed to create user_id index on babamul_user_tokens collection");
-        // Index on expires_at for efficient cleanup of expired tokens
+            .expect("failed to create tokens.name unique index on babamul_users collection");
+
+        // Index on tokens.expires_at for efficient cleanup of expired tokens
         let expires_at_index = mongodb::IndexModel::builder()
-            .keys(doc! { "expires_at": 1})
+            .keys(doc! { "tokens.expires_at": 1})
             .build();
-        let _ = babamul_tokens_collection
+        let _ = babamul_users_collection
             .create_index(expires_at_index)
             .await
-            .expect("failed to create expires_at index on babamul_user_tokens collection");
+            .expect("failed to create expires_at index on babamul_users collection");
+
         println!("Babamul database collections initialized");
     }
 

--- a/src/api/routes/babamul/mod.rs
+++ b/src/api/routes/babamul/mod.rs
@@ -94,6 +94,16 @@ impl KafkaCredentialEncrypted {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+pub struct BabamulUserToken {
+    pub id: String, // UUID for the token
+    pub name: String,
+    pub token_hash: String, // SHA256 hash of the token
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub last_used_at: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct BabamulUser {
     // Save in the database as _id, but we want to rename on the way out
     #[serde(rename = "_id")]
@@ -106,6 +116,7 @@ pub struct BabamulUser {
     pub created_at: i64, // Unix timestamp
     #[serde(default)]
     pub kafka_credentials: Vec<KafkaCredentialEncrypted>, // List of Kafka credentials (w/ encrypted passwords)
+    pub tokens: Vec<BabamulUserToken>, // List of API tokens
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -248,6 +259,7 @@ pub async fn post_babamul_signup(
                 is_activated,
                 created_at: flare::Time::now().to_utc().timestamp(),
                 kafka_credentials: Vec::new(), // Empty list, credentials created on demand
+                tokens: Vec::new(),            // Empty list of tokens
             };
 
             // Note: Kafka credentials will be created on demand via /babamul/kafka-credentials endpoint

--- a/src/api/routes/babamul/tokens.rs
+++ b/src/api/routes/babamul/tokens.rs
@@ -1,6 +1,7 @@
 /// Functionality for working with personal access tokens (PATs).
 use crate::api::models::response;
-use crate::api::routes::babamul::{generate_random_string, BabamulUser};
+use crate::api::routes::babamul::{generate_random_string, BabamulUser, BabamulUserToken};
+use crate::utils::db::mongify;
 use actix_web::{delete, get, post, web, HttpResponse};
 use flare::Time;
 use mongodb::bson::doc;
@@ -33,30 +34,6 @@ pub struct TokenPublic {
     pub last_used_at: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct BabamulUserToken {
-    pub _id: String,     // UUID for the token
-    pub user_id: String, // Reference to babamul_user
-    pub name: String,
-    pub token_hash: String, // SHA256 hash of the token
-    pub created_at: i64,
-    pub expires_at: i64,
-    pub last_used_at: Option<i64>,
-}
-
-impl BabamulUserToken {
-    /// Convert to a TokenPublic (without exposing the token_hash)
-    pub fn to_list_item(&self) -> TokenPublic {
-        TokenPublic {
-            id: self._id.clone(),
-            name: self.name.clone(),
-            created_at: self.created_at,
-            expires_at: self.expires_at,
-            last_used_at: self.last_used_at,
-        }
-    }
-}
-
 fn hash_token(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
@@ -75,10 +52,7 @@ fn hash_token(token: &str) -> String {
     tags=["Babamul"]
 )]
 #[get("/tokens")]
-pub async fn get_tokens(
-    db: web::Data<Database>,
-    current_user: Option<web::ReqData<BabamulUser>>,
-) -> HttpResponse {
+pub async fn get_tokens(current_user: Option<web::ReqData<BabamulUser>>) -> HttpResponse {
     let current_user = match current_user {
         Some(user) => user,
         None => {
@@ -86,32 +60,18 @@ pub async fn get_tokens(
         }
     };
 
-    let tokens_collection: mongodb::Collection<BabamulUserToken> =
-        db.collection("babamul_user_tokens");
-
-    match tokens_collection
-        .find(doc! { "user_id": &current_user.id })
-        .await
-    {
-        Ok(cursor) => {
-            use futures::TryStreamExt;
-            match cursor.try_collect::<Vec<_>>().await {
-                Ok(tokens) => {
-                    let token_list: Vec<TokenPublic> =
-                        tokens.iter().map(|t| t.to_list_item()).collect();
-                    HttpResponse::Ok().json(token_list)
-                }
-                Err(e) => {
-                    tracing::error!("Database error retrieving tokens: {}", e);
-                    response::internal_error("Failed to retrieve tokens")
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!("Database error querying tokens: {}", e);
-            response::internal_error("Failed to retrieve tokens")
-        }
-    }
+    let token_list: Vec<TokenPublic> = current_user
+        .tokens
+        .iter()
+        .map(|t| TokenPublic {
+            id: t.id.clone(),
+            name: t.name.clone(),
+            created_at: t.created_at,
+            expires_at: t.expires_at,
+            last_used_at: t.last_used_at,
+        })
+        .collect();
+    HttpResponse::Ok().json(token_list)
 }
 
 /// Create a new token for the authenticated user
@@ -157,22 +117,8 @@ pub async fn post_token(
     }
 
     // Check token limit (max 10 tokens per user)
-    let tokens_collection: mongodb::Collection<BabamulUserToken> =
-        db.collection("babamul_user_tokens");
-
-    match tokens_collection
-        .count_documents(doc! { "user_id": &current_user.id })
-        .await
-    {
-        Ok(count) => {
-            if count >= 10 {
-                return response::bad_request("Maximum number of tokens (10) reached. Please delete an existing token before creating a new one.");
-            }
-        }
-        Err(e) => {
-            tracing::error!("Database error counting tokens: {}", e);
-            return response::internal_error("Failed to check token limit");
-        }
+    if current_user.tokens.len() >= 10 {
+        return response::bad_request("Maximum number of tokens (10) reached. Please delete an existing token before creating a new one.");
     }
 
     // Generate token: bbml_{36_random_chars}
@@ -192,8 +138,7 @@ pub async fn post_token(
 
     let token_id = uuid::Uuid::new_v4().to_string();
     let token_doc = BabamulUserToken {
-        _id: token_id,
-        user_id: current_user.id.clone(),
+        id: token_id.clone(),
         name: name.to_string(),
         token_hash,
         created_at: now,
@@ -201,15 +146,28 @@ pub async fn post_token(
         last_used_at: None,
     };
 
-    // Store token in babamul_user_tokens collection
-    match tokens_collection.insert_one(&token_doc).await {
-        Ok(_) => HttpResponse::Ok().json(TokenResponse {
-            id: token_doc._id,
-            name: token_doc.name,
-            access_token: full_token,
-            created_at: token_doc.created_at,
-            expires_at: token_doc.expires_at,
-        }),
+    // Push it to the current_user's tokens array, making sure
+    // there are no duplicates (by id and name)
+    let users_collection: mongodb::Collection<BabamulUser> = db.collection("babamul_users");
+    match users_collection
+        .update_one(
+            doc! { "_id": &current_user.id, "tokens.name": { "$ne": name }, "tokens.id": { "$ne": &token_id } },
+            doc! { "$push": { "tokens": mongify(&token_doc) } },
+        )
+        .await
+    {
+        Ok(update_result) => {
+            if update_result.matched_count == 0 {
+                return response::bad_request("A token with this name already exists");
+            }
+            HttpResponse::Ok().json(TokenResponse {
+                id: token_doc.id,
+                name: token_doc.name,
+                access_token: full_token,
+                created_at: token_doc.created_at,
+                expires_at: token_doc.expires_at,
+            })
+        }
         Err(e) => {
             tracing::error!("Database error creating token: {}", e);
             response::internal_error("Failed to create token")
@@ -246,45 +204,28 @@ pub async fn delete_token(
     };
 
     let token_id = token_id.into_inner();
-    let tokens_collection: mongodb::Collection<BabamulUserToken> =
-        db.collection("babamul_user_tokens");
 
-    // Verify the token belongs to the current user before deleting
-    match tokens_collection
-        .find_one(doc! { "_id": &token_id, "user_id": &current_user.id })
+    // Remove the token from the user's tokens array
+    let users_collection: mongodb::Collection<BabamulUser> = db.collection("babamul_users");
+    match users_collection
+        .update_one(
+            doc! { "_id": &current_user.id },
+            doc! { "$pull": { "tokens": { "id": &token_id } } },
+        )
         .await
     {
-        Ok(Some(_)) => {
-            // Token belongs to the user, proceed with deletion
-            match tokens_collection
-                .delete_one(doc! { "_id": &token_id, "user_id": &current_user.id })
-                .await
-            {
-                Ok(result) => {
-                    if result.deleted_count > 0 {
-                        HttpResponse::Ok().json(serde_json::json!({
-                            "message": "Token deleted successfully"
-                        }))
-                    } else {
-                        HttpResponse::NotFound().json(serde_json::json!({
-                            "error": "Token not found"
-                        }))
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("Database error deleting token: {}", e);
-                    response::internal_error("Failed to delete token")
-                }
+        Ok(update_result) => {
+            if update_result.modified_count == 0 {
+                return HttpResponse::NotFound().json(serde_json::json!({
+                    "error": "Token not found",
+                }));
             }
-        }
-        Ok(None) => {
-            // Token doesn't exist or doesn't belong to the user
-            HttpResponse::NotFound().json(serde_json::json!({
-                "error": "Token not found"
+            HttpResponse::Ok().json(serde_json::json!({
+                "message": "Token deleted successfully"
             }))
         }
         Err(e) => {
-            tracing::error!("Database error querying token: {}", e);
+            tracing::error!("Database error deleting token: {}", e);
             response::internal_error("Failed to delete token")
         }
     }

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -43,6 +43,7 @@ mod tests {
                 is_activated: true,
                 created_at: 0,
                 kafka_credentials: vec![],
+                tokens: vec![],
             };
 
             let babamul_users_collection: mongodb::Collection<


### PR DESCRIPTION
This PR is an attempt at storing the PATs as an embedded array of the user collection, rather than as a separate one. It gives us these advantages:
- since we aren't in a relational DB, deleting a user in the current approach would leave the tokens in the other collection
- now when authenticating, instead of using 2 to 3 queries (reads/writes to the babamul_users and babamul_user_tokens collections) we only need one: a findOneAndUpdate that finds the user with that token hash if any , updates the last_used_at field and returns the user all in one DB round-trip
- Handlers like the get_tokens become very easy to implement, since we already get the `current_user` which contains the tokens.

BTW this is just my take on it! If the reviewer sees something wrong about that approach, happy to not take that road.