### PR TITLE
Throughput CI: post comment fix

### DIFF
--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -104,7 +104,7 @@ jobs:
           echo "current=$current" >> $GITHUB_OUTPUT
       - name: Post comment on PR (if applicable)
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Looks like the github action we use to post a comment isn't working anymore, due to some changes w/ node. This is an attempt at simply upgrading it to its last version