### PR TITLE
ZTF Forced Photometry: use fixed zp

### DIFF
--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::{
         db::{mongify, update_timeseries_op},
         enums::Survey,
-        lightcurves::{flux2mag, fluxerr2diffmaglim, Band, SNT, ZP_AB},
+        lightcurves::{flux2mag, fluxerr2diffmaglim, Band, LSST_ZP_AB_NJY, SNT},
         o11y::logging::as_error,
         spatial::{xmatch, Coordinates},
     },
@@ -42,8 +42,6 @@ pub const LSST_DECAM_XMATCH_RADIUS: f64 =
 pub const LSST_SCHEMA_REGISTRY_URL: &str = "https://usdf-alert-schemas-dev.slac.stanford.edu";
 pub const LSST_SCHEMA_REGISTRY_GITHUB_FALLBACK_URL: &str =
     "https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema";
-
-const LSST_ZP_AB_NJY: f32 = ZP_AB + 22.5; // ZP + nJy to Jy conversion factor, as 2.5 * log10(1e9) = 22.5
 
 #[serde_as]
 #[skip_serializing_none]

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -259,7 +259,7 @@ impl TryFrom<FpHist> for ZtfForcedPhot {
 
         let band = fid2band(fp_hist.fid)?;
         let magzpsci = fp_hist.magzpsci.ok_or(AlertError::MissingMagZPSci)?;
-        let factor = 10f32.powf((ZTF_ZP - magzpsci) / 2.5);
+        let zp_scaling_factor = 10f32.powf((ZTF_ZP - magzpsci) / 2.5);
 
         let (magpsf, sigmapsf, isdiffpos, snr, psf_flux) = match fp_hist.forcediffimflux {
             Some(psf_flux) => {
@@ -271,10 +271,16 @@ impl TryFrom<FpHist> for ZtfForcedPhot {
                         Some(sigmapsf),
                         Some(psf_flux > 0.0),
                         Some(psf_flux_abs / psf_flux_err),
-                        Some(psf_flux * 1e9_f32 * factor), // convert to nJy and a fixed ZTF_ZP
+                        Some(psf_flux * 1e9_f32 * zp_scaling_factor), // convert to nJy and a fixed ZTF_ZP
                     )
                 } else {
-                    (None, None, None, None, Some(psf_flux * 1e9_f32 * factor)) // convert to nJy and a fixed ZTF_ZP
+                    (
+                        None,
+                        None,
+                        None,
+                        None,
+                        Some(psf_flux * 1e9_f32 * zp_scaling_factor),
+                    ) // convert to nJy and a fixed ZTF_ZP
                 }
             }
             _ => (None, None, None, None, None),
@@ -285,7 +291,7 @@ impl TryFrom<FpHist> for ZtfForcedPhot {
             magpsf,
             sigmapsf,
             psf_flux,
-            psf_flux_err: Some(psf_flux_err * 1e9_f32 * factor), // convert to nJy and a fixed ZTF_ZP
+            psf_flux_err: Some(psf_flux_err * 1e9_f32 * zp_scaling_factor), // convert to nJy and a fixed ZTF_ZP
             isdiffpos,
             snr,
             band,
@@ -953,15 +959,16 @@ mod tests {
         assert!((magpsf - 15.949999).abs() < 1e-6);
         assert!((sigmapsf - 0.002316).abs() < 1e-6);
         // let's also verify that forcediffimflux(unc) converts to psfFlux(Err) correctly
-        let factor = 10f32.powf((ZTF_ZP - fp_negative_det.fp_hist.magzpsci.unwrap()) / 2.5);
+        let zp_scaling_factor =
+            10f32.powf((ZTF_ZP - fp_negative_det.fp_hist.magzpsci.unwrap()) / 2.5);
         assert!(
-            (fp_negative_det.fp_hist.forcediffimflux.unwrap() * 1e9_f32 * factor
+            (fp_negative_det.fp_hist.forcediffimflux.unwrap() * 1e9_f32 * zp_scaling_factor
                 - fp_negative_det.psf_flux.unwrap())
             .abs()
                 < 1e-6
         );
         assert!(
-            (fp_negative_det.fp_hist.forcediffimfluxunc.unwrap() * 1e9_f32 * factor
+            (fp_negative_det.fp_hist.forcediffimfluxunc.unwrap() * 1e9_f32 * zp_scaling_factor
                 - fp_negative_det.psf_flux_err.unwrap())
             .abs()
                 < 1e-6
@@ -984,15 +991,16 @@ mod tests {
         );
         assert!((magpsf - 20.801506).abs() < 1e-6);
         assert!((sigmapsf - 0.3616859).abs() < 1e-6);
-        let factor = 10f32.powf((ZTF_ZP - fp_positive_det.fp_hist.magzpsci.unwrap()) / 2.5);
+        let zp_scaling_factor =
+            10f32.powf((ZTF_ZP - fp_positive_det.fp_hist.magzpsci.unwrap()) / 2.5);
         assert!(
-            (fp_positive_det.fp_hist.forcediffimflux.unwrap() * 1e9_f32 * factor
+            (fp_positive_det.fp_hist.forcediffimflux.unwrap() * 1e9_f32 * zp_scaling_factor
                 - fp_positive_det.psf_flux.unwrap())
             .abs()
                 < 1e-6
         );
         assert!(
-            (fp_positive_det.fp_hist.forcediffimfluxunc.unwrap() * 1e9_f32 * factor
+            (fp_positive_det.fp_hist.forcediffimfluxunc.unwrap() * 1e9_f32 * zp_scaling_factor
                 - fp_positive_det.psf_flux_err.unwrap())
             .abs()
                 < 1e-6

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -259,7 +259,7 @@ impl TryFrom<FpHist> for ZtfForcedPhot {
 
         let band = fid2band(fp_hist.fid)?;
         let magzpsci = fp_hist.magzpsci.ok_or(AlertError::MissingMagZPSci)?;
-        let factor = 10f32.powf((magzpsci - ZTF_ZP) / 2.5);
+        let factor = 10f32.powf((ZTF_ZP - magzpsci) / 2.5);
 
         let (magpsf, sigmapsf, isdiffpos, snr, psf_flux) = match fp_hist.forcediffimflux {
             Some(psf_flux) => {

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -917,6 +917,15 @@ mod tests {
         assert_eq!(detection.prv_candidate.diffmaglim.is_some(), true);
         assert_eq!(detection.prv_candidate.isdiffpos.is_some(), true);
 
+        // let's also verify that we can recover the original magpsf and sigmapsf from the flux and flux_err for the detection
+        let (magpsf, sigmapsf) = flux2mag(
+            detection.psf_flux.unwrap() / 1e9_f32,     // convert back to Jy
+            detection.psf_flux_err.unwrap() / 1e9_f32, // convert back to Jy
+            ZTF_ZP,
+        );
+        assert!((magpsf - detection.prv_candidate.magpsf.unwrap()).abs() < 1e-6);
+        assert!((sigmapsf - detection.prv_candidate.sigmapsf.unwrap()).abs() < 1e-6);
+
         // validate the fp_hists
         let fp_hists = avro_alert.clone().fp_hists;
         assert!(fp_hists.is_some());

--- a/src/api/routes/babamul/surveys/schemas.rs
+++ b/src/api/routes/babamul/surveys/schemas.rs
@@ -10,8 +10,8 @@ pub struct BabamulAvroSchemas {
 impl BabamulAvroSchemas {
     pub fn new() -> Self {
         use apache_avro::AvroSchema;
-        let lsst_schema = crate::enrichment::babamul::EnrichedLsstAlert::get_schema();
-        let ztf_schema = crate::enrichment::babamul::EnrichedZtfAlert::get_schema();
+        let lsst_schema = crate::enrichment::babamul::BabamulEnrichedLsstAlert::get_schema();
+        let ztf_schema = crate::enrichment::babamul::BabamulEnrichedZtfAlert::get_schema();
         let lsst_schema = serde_json::to_value(&lsst_schema).unwrap();
         let ztf_schema = serde_json::to_value(&ztf_schema).unwrap();
         Self {

--- a/src/bin/migrate_fp_flux.rs
+++ b/src/bin/migrate_fp_flux.rs
@@ -1,0 +1,228 @@
+use boom::conf::{load_dotenv, AppConfig};
+use clap::Parser;
+use futures::TryStreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
+use mongodb::bson::{doc, Bson, Document};
+use tracing::{error, info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+/// Fixed zeropoint for ZTF forced photometry.
+const ZTF_ZP: f64 = 23.9;
+
+/// Migrate ZTF forced photometry flux values to a fixed zeropoint.
+///
+/// Recomputes `psfFlux` and `psfFluxErr` in `fp_hists` from the raw IPAC
+/// `forcediffimflux` and `forcediffimfluxunc` fields, converting to nJy at
+/// the fixed ZTF_ZP = 23.9 zeropoint.
+///
+/// Formula: value = raw_value * 1e9 * 10^((23.9 - magzpsci) / 2.5)
+///
+/// Idempotent: since it always recomputes from raw fields, running this
+/// multiple times produces the same result.
+#[derive(Parser)]
+struct Cli {
+    /// Number of document IDs to collect per update_many batch
+    #[arg(long, default_value = "5000")]
+    batch_size: usize,
+}
+
+/// Run batched updates by streaming IDs from a cursor and calling update_many
+/// with `{ _id: { $in: [...] } }` per batch.
+async fn run_batched_update(
+    collection: &mongodb::Collection<Document>,
+    filter: Document,
+    pipeline: Vec<Document>,
+    batch_size: usize,
+    estimated_total: u64,
+    label: &str,
+) -> i64 {
+    let pb = ProgressBar::new(estimated_total);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "{msg} {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
+        )
+        .unwrap(),
+    );
+    pb.set_message(label.to_string());
+
+    let mut cursor = match collection
+        .find(filter)
+        .projection(doc! { "_id": 1 })
+        .no_cursor_timeout(true)
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            error!("error querying documents: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let mut ids: Vec<Bson> = Vec::with_capacity(batch_size);
+    let mut total_modified: i64 = 0;
+
+    while let Some(d) = cursor.try_next().await.unwrap() {
+        ids.push(d.get("_id").unwrap().clone());
+
+        if ids.len() >= batch_size {
+            let n = ids.len() as u64;
+            let batch_filter = doc! { "_id": { "$in": &ids } };
+            match collection.update_many(batch_filter, pipeline.clone()).await {
+                Ok(result) => {
+                    total_modified += result.modified_count as i64;
+                }
+                Err(e) => {
+                    error!("error writing batch: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            pb.inc(n);
+            ids.clear();
+        }
+    }
+
+    if !ids.is_empty() {
+        let n = ids.len() as u64;
+        let batch_filter = doc! { "_id": { "$in": &ids } };
+        match collection.update_many(batch_filter, pipeline).await {
+            Ok(result) => {
+                total_modified += result.modified_count as i64;
+            }
+            Err(e) => {
+                error!("error writing final batch: {}", e);
+                std::process::exit(1);
+            }
+        }
+        pb.inc(n);
+    }
+
+    pb.finish();
+    total_modified
+}
+
+#[tokio::main]
+async fn main() {
+    load_dotenv();
+
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let args = Cli::parse();
+
+    let config = AppConfig::from_default_path().unwrap();
+    let db = match config.build_db().await {
+        Ok(db) => db,
+        Err(e) => {
+            error!("error building db: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let collection = db.collection::<Document>("ZTF_alerts_aux");
+
+    migrate(&collection, args.batch_size).await;
+}
+
+async fn migrate(collection: &mongodb::Collection<Document>, batch_size: usize) {
+    let estimated_count = match collection.estimated_document_count().await {
+        Ok(c) => c,
+        Err(e) => {
+            error!("error estimating document count: {}", e);
+            std::process::exit(1);
+        }
+    };
+    info!("Estimated ~{} documents in collection", estimated_count);
+
+    // Only process documents that have fp_hists
+    let filter = doc! {
+        "fp_hists.0": { "$exists": true },
+    };
+
+    // Converts raw flux to nJy at the fixed zeropoint:
+    //   psf_flux * 1e9 * 10^((ZTF_ZP - magzpsci) / 2.5)
+    let scale_factor = doc! {
+        "$multiply": [
+            1e9_f64,
+            { "$pow": [
+                10.0,
+                { "$divide": [
+                    { "$subtract": [ZTF_ZP, "$$fp.magzpsci"] },
+                    2.5
+                ]}
+            ]}
+        ]
+    };
+
+    // Filter out invalid raw flux values (-99999.0)
+    let valid_raw_flux = doc! {
+        "$and": [
+            { "$ne": ["$$fp.forcediffimflux", Bson::Null] },
+            { "$ne": ["$$fp.forcediffimflux", -99999.0] },
+        ]
+    };
+
+    let valid_raw_flux_err = doc! {
+        "$and": [
+            { "$ne": ["$$fp.forcediffimfluxunc", Bson::Null] },
+            { "$ne": ["$$fp.forcediffimfluxunc", -99999.0] },
+        ]
+    };
+
+    // psfFlux: computed from raw forcediffimflux when both it and magzpsci are valid
+    let new_flux = doc! {
+        "$cond": {
+            "if": { "$and": [
+                valid_raw_flux,
+                { "$ne": ["$$fp.magzpsci", Bson::Null] },
+            ]},
+            "then": { "$multiply": ["$$fp.forcediffimflux", scale_factor.clone()] },
+            "else": Bson::Null,
+        }
+    };
+
+    // psfFluxErr: computed from raw forcediffimfluxunc when both it and magzpsci are valid
+    let new_flux_err = doc! {
+        "$cond": {
+            "if": { "$and": [
+                valid_raw_flux_err.clone(),
+                { "$ne": ["$$fp.magzpsci", Bson::Null] },
+            ]},
+            "then": { "$multiply": ["$$fp.forcediffimfluxunc", scale_factor] },
+            "else": Bson::Null,
+        }
+    };
+
+    let pipeline = vec![doc! {
+        "$set": {
+            "fp_hists": {
+                "$map": {
+                    "input": "$fp_hists",
+                    "as": "fp",
+                    "in": {
+                        "$mergeObjects": [
+                            "$$fp",
+                            {
+                                "psfFlux": new_flux.clone(),
+                                "psfFluxErr": new_flux_err.clone(),
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+    }];
+
+    let total = run_batched_update(
+        collection,
+        filter,
+        pipeline,
+        batch_size,
+        estimated_count,
+        "migrate",
+    )
+    .await;
+
+    info!("Migration complete. Modified {} documents.", total);
+}

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -82,6 +82,10 @@ pub enum EnrichmentWorkerError {
     ConfigurationError(String),
     #[error("Bad processing status code: {0}")]
     BadProcstatus(String),
+    #[error("Missing magzpsci for forced photometry point, cannot apply ZP correction")]
+    MissingMagZPSci,
+    #[error("Missing PSF for forced photometry point, cannot apply ZP correction")]
+    MissingFluxPSF,
 }
 
 #[async_trait::async_trait]

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -1,6 +1,6 @@
 use crate::alert::LsstCandidate;
 use crate::conf::AppConfig;
-use crate::enrichment::babamul::{Babamul, EnrichedLsstAlert};
+use crate::enrichment::babamul::{Babamul, BabamulEnrichedLsstAlert};
 use crate::enrichment::{
     fetch_alert_cutouts, fetch_alerts, EnrichmentWorker, EnrichmentWorkerError, ZtfMatch,
 };
@@ -322,7 +322,7 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
         let mut updates = Vec::new();
         let mut processed_alerts = Vec::new();
         let mut enriched_alerts: Vec<(
-            EnrichedLsstAlert,
+            BabamulEnrichedLsstAlert,
             std::collections::HashMap<String, Vec<serde_json::Value>>,
         )> = Vec::new();
         for alert in alerts {
@@ -355,7 +355,7 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
                     .remove(&candid)
                     .ok_or_else(|| EnrichmentWorkerError::MissingCutouts(candid))?;
                 let (enriched_alert, cross_matches) =
-                    EnrichedLsstAlert::from_alert_properties_and_cutouts(
+                    BabamulEnrichedLsstAlert::from_alert_properties_and_cutouts(
                         alert,
                         Some(cutouts.cutout_science),
                         Some(cutouts.cutout_template),

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -63,10 +63,6 @@ pub fn is_in_footprint(ra_deg: f64, dec_deg: f64) -> bool {
     moc.contains_cell(MOC_DEPTH, cell)
 }
 
-fn default_lsst_zp() -> Option<f64> {
-    Some(8.9)
-}
-
 #[serdavro]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LsstPhotometry {
@@ -79,9 +75,6 @@ pub struct LsstPhotometry {
     #[serde(rename = "psfFluxErr")]
     pub flux_err: f64, // in nJy
     pub band: Band,
-    // Set a default if missing
-    #[serde(default = "default_lsst_zp")]
-    pub zp: Option<f64>,
     pub ra: Option<f64>,
     pub dec: Option<f64>,
     pub snr: Option<f64>,

--- a/src/enrichment/mod.rs
+++ b/src/enrichment/mod.rs
@@ -15,5 +15,5 @@ pub use lsst::{
 };
 pub use ztf::{
     ZtfAlertClassifications, ZtfAlertForEnrichment, ZtfAlertProperties, ZtfEnrichmentWorker,
-    ZtfMatch, ZtfPhotometry, ZtfSurveyMatches,
+    ZtfForcedPhotometry, ZtfMatch, ZtfPhotometry, ZtfSurveyMatches,
 };

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -1,5 +1,5 @@
 use crate::conf::AppConfig;
-use crate::enrichment::babamul::{Babamul, EnrichedZtfAlert};
+use crate::enrichment::babamul::{Babamul, BabamulEnrichedZtfAlert};
 use crate::enrichment::LsstMatch;
 use crate::utils::db::mongify;
 use crate::utils::lightcurves::{
@@ -461,7 +461,7 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
         // we will move to batch processing later
         let mut updates = Vec::new();
         let mut processed_alerts = Vec::new();
-        let mut enriched_alerts: Vec<EnrichedZtfAlert> = Vec::new();
+        let mut enriched_alerts: Vec<BabamulEnrichedZtfAlert> = Vec::new();
         for alert in alerts {
             let candid = alert.candid;
             let cutouts = candid_to_cutouts
@@ -531,7 +531,7 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
 
             // If Babamul is enabled, add the enriched alert to the batch
             if self.babamul.is_some() {
-                let enriched_alert = EnrichedZtfAlert::from_alert_properties_and_cutouts(
+                let enriched_alert = BabamulEnrichedZtfAlert::from_alert_properties_and_cutouts(
                     alert,
                     Some(cutouts.cutout_science),
                     Some(cutouts.cutout_template),

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -116,19 +116,19 @@ impl TryFrom<ZtfForcedPhotometry> for ZtfPhotometry {
         }
 
         // TODO: remove this conversion once we read flux and flux_err from the database with a fixed ZP
-        let factor = if let Some(magzpsci) = phot.magzpsci {
+        let zp_scaling_factor = if let Some(magzpsci) = phot.magzpsci {
             10f64.powf((ZTF_ZP as f64 - magzpsci) / 2.5)
         } else {
             return Err(EnrichmentWorkerError::MissingMagZPSci);
         };
 
         let flux = if phot.flux != Some(-99999.0) && phot.flux.map_or(false, |f| !f.is_nan()) {
-            phot.flux.map(|f| f * 1e9_f64 * factor) // convert to a fixed ZP and nJy
+            phot.flux.map(|f| f * 1e9_f64 * zp_scaling_factor) // convert to a fixed ZP and nJy
         } else {
             None
         };
         let flux_err = if phot.flux_err != -99999.0 && !phot.flux_err.is_nan() {
-            phot.flux_err * 1e9_f64 * factor // convert to a fixed ZP and nJy
+            phot.flux_err * 1e9_f64 * zp_scaling_factor // convert to a fixed ZP and nJy
         } else {
             return Err(EnrichmentWorkerError::MissingFluxPSF);
         };

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -4,7 +4,7 @@ use crate::enrichment::LsstMatch;
 use crate::utils::db::mongify;
 use crate::utils::lightcurves::{
     analyze_photometry, prepare_photometry, AllBandsProperties, Band, PerBandProperties,
-    PhotometryMag,
+    PhotometryMag, ZTF_ZP,
 };
 use crate::{
     alert::ZtfCandidate,
@@ -50,10 +50,12 @@ pub struct ZtfForcedPhotometry {
     pub magpsf: Option<f64>,
     pub sigmapsf: Option<f64>,
     pub diffmaglim: f64,
-    #[serde(rename = "psfFlux")]
-    pub flux: Option<f64>, // in nJy
-    #[serde(rename = "psfFluxErr")]
-    pub flux_err: f64, // in nJy
+    // TODO: read from psfFlux once that is moved to a fixed ZP in the database
+    #[serde(rename = "forcediffimflux")]
+    pub flux: Option<f64>,
+    // TODO: read from psfFlux once that is moved to a fixed ZP in the database
+    #[serde(rename = "forcediffimfluxunc")]
+    pub flux_err: f64,
     pub band: Band,
     pub magzpsci: Option<f64>,
     pub ra: Option<f64>,
@@ -77,7 +79,6 @@ pub struct ZtfPhotometry {
     #[serde(rename = "psfFluxErr")]
     pub flux_err: f64, // in nJy
     pub band: Band,
-    pub zp: Option<f64>,
     pub ra: Option<f64>,
     pub dec: Option<f64>,
     pub snr: Option<f64>,
@@ -99,7 +100,6 @@ impl TryFrom<ZtfAlertPhotometry> for ZtfPhotometry {
             band: phot.band,
             snr: phot.snr,
             programid: phot.programid,
-            zp: Some(23.9), // alert photometry uses a fixed zeropoint of 23.9
         })
     }
 }
@@ -115,19 +115,36 @@ impl TryFrom<ZtfForcedPhotometry> for ZtfPhotometry {
             return Err(EnrichmentWorkerError::BadProcstatus(procstatus));
         }
 
+        // TODO: remove this conversion once we read flux and flux_err from the database with a fixed ZP
+        let factor = if let Some(magzpsci) = phot.magzpsci {
+            10f64.powf((ZTF_ZP as f64 - magzpsci) / 2.5)
+        } else {
+            return Err(EnrichmentWorkerError::MissingMagZPSci);
+        };
+
+        let flux = if phot.flux != Some(-99999.0) && phot.flux.map_or(false, |f| !f.is_nan()) {
+            phot.flux.map(|f| f * 1e9_f64 * factor) // convert to a fixed ZP and nJy
+        } else {
+            None
+        };
+        let flux_err = if phot.flux_err != -99999.0 && !phot.flux_err.is_nan() {
+            phot.flux_err * 1e9_f64 * factor // convert to a fixed ZP and nJy
+        } else {
+            return Err(EnrichmentWorkerError::MissingFluxPSF);
+        };
+
         Ok(ZtfPhotometry {
             jd: phot.jd,
             magpsf: phot.magpsf,
             sigmapsf: phot.sigmapsf,
             diffmaglim: phot.diffmaglim,
-            flux: phot.flux,
-            flux_err: phot.flux_err,
+            flux,
+            flux_err,
             ra: phot.ra,
             dec: phot.dec,
             band: phot.band,
             snr: phot.snr,
             programid: phot.programid,
-            zp: phot.magzpsci, // forced photometry has a zeropoint per datapoint
         })
     }
 }

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -165,7 +165,7 @@ pub fn parse_programid_candid_tuple(tuple_str: &str) -> Option<(i32, i64)> {
     None
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum Origin {
     Alert,
     ForcedPhot,
@@ -177,7 +177,6 @@ pub struct Photometry {
     pub flux: Option<f64>, // in nJy
     pub flux_err: f64,     // in nJy
     pub band: String,
-    pub zero_point: f64,
     pub origin: Origin,
     pub programid: i32,
     pub survey: Survey,

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -105,7 +105,6 @@ const ALERT_SCHEMA: &str = r#"
                     {"name": "flux",  "type": ["null", "double"], "doc": "in nJy"},
                     {"name": "flux_err",  "type":"double", "doc": "in nJy"},
                     {"name":"band","type":"string"},
-                    {"name":"zero_point","type":"double"},
                     {"name":"origin","type":{"type":"enum","name":"Origin","symbols":["Alert","ForcedPhot"]}},
                     {"name":"programid","type":"int"},
                     {"name":"survey","type": "Survey"},

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -102,8 +102,8 @@ const ALERT_SCHEMA: &str = r#"
                 "name": "Photometry",
                 "fields": [
                     {"name": "jd", "type": "double"},
-                    {"name": "flux",  "type": ["null", "double"], "doc": "in nJy"},
-                    {"name": "flux_err",  "type":"double", "doc": "in nJy"},
+                    {"name": "flux",  "type": ["null", "double"], "doc": "in nJy; fixed zeropoints: 23.9 (ZTF), 31.4 (LSST = 8.9 AB + 22.5 nJy offset)"},
+                    {"name": "flux_err",  "type":"double", "doc": "in nJy; fixed zeropoints: 23.9 (ZTF), 31.4 (LSST = 8.9 AB + 22.5 nJy offset)"},
                     {"name":"band","type":"string"},
                     {"name":"origin","type":{"type":"enum","name":"Origin","symbols":["Alert","ForcedPhot"]}},
                     {"name":"programid","type":"int"},

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -830,6 +830,8 @@ pub enum FilterWorkerError {
     FilterNotFound,
     #[error("kafka config missing for survey: {0}")]
     KafkaConfigMissing(Survey),
+    #[error("Missing PSF for forced photometry point, cannot apply ZP correction")]
+    MissingFluxPSF,
 }
 
 #[async_trait::async_trait]

--- a/src/filter/lsst.rs
+++ b/src/filter/lsst.rs
@@ -200,7 +200,6 @@ pub async fn build_lsst_alerts(
                 flux: Some(flux),
                 flux_err,
                 band: format!("lsst{}", band),
-                zero_point: 8.9,
                 origin: Origin::Alert,
                 programid: 1, // only one public stream for LSST
                 survey: Survey::Lsst,
@@ -227,7 +226,6 @@ pub async fn build_lsst_alerts(
                 flux,
                 flux_err,
                 band: format!("lsst{}", band),
-                zero_point: 8.9,
                 origin: Origin::ForcedPhot,
                 programid: 1, // only one public stream for LSST
                 survey: Survey::Lsst,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -7,11 +7,9 @@ pub use base::{
     create_producer, load_alert_schema, load_schema, run_filter, run_filter_worker,
     send_alert_to_kafka, to_avro_bytes, uses_field_in_filter, validate_filter_pipeline, Alert,
     Filter, FilterError, FilterResults, FilterVersion, FilterWorker, FilterWorkerError,
-    LoadedFilter, SURVEYS_REQUIRING_PERMISSIONS,
+    LoadedFilter, Origin, Photometry, SURVEYS_REQUIRING_PERMISSIONS,
 };
-use base::{
-    parse_programid_candid_tuple, update_aliases_index_multiple, Classification, Origin, Photometry,
-};
+use base::{parse_programid_candid_tuple, update_aliases_index_multiple, Classification};
 pub use lsst::{build_lsst_alerts, build_lsst_filter_pipeline, LsstFilterWorker};
 use lsst::{build_lsst_aux_data, insert_lsst_aux_pipeline_if_needed};
 pub use ztf::{build_ztf_alerts, build_ztf_filter_pipeline, ZtfFilterWorker};

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -11,9 +11,7 @@ use crate::filter::{
     FilterWorkerError, LoadedFilter, Origin, Photometry,
 };
 use crate::utils::db::{fetch_timeseries_op, get_array_dict_element, get_array_element};
-use crate::utils::{enums::Survey, o11y::logging::as_error};
-
-const ZTF_ZP: f64 = 23.9;
+use crate::utils::{enums::Survey, lightcurves::ZTF_ZP, o11y::logging::as_error};
 
 /// For a filter running on another survey (e.g., LSST), determine if we need to
 /// fetch ZTF auxiliary data (prv_candidates, fp_hists) based on the fields
@@ -282,7 +280,7 @@ pub async fn build_ztf_alerts(
             let programid = doc.get_i32("programid")?;
 
             // TODO: remove this conversion once we read flux and flux_err from the database with a fixed ZP
-            let factor = 10f64.powf((ZTF_ZP - magzpsci) / 2.5);
+            let factor = 10f64.powf((ZTF_ZP as f64 - magzpsci) / 2.5);
             let flux = if flux != Some(-99999.0) && flux.map_or(false, |f| !f.is_nan()) {
                 flux.map(|f| f * 1e9_f64 * factor) // convert to a fixed ZP and nJy
             } else {

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -280,14 +280,14 @@ pub async fn build_ztf_alerts(
             let programid = doc.get_i32("programid")?;
 
             // TODO: remove this conversion once we read flux and flux_err from the database with a fixed ZP
-            let factor = 10f64.powf((ZTF_ZP as f64 - magzpsci) / 2.5);
+            let zp_scaling_factor = 10f64.powf((ZTF_ZP as f64 - magzpsci) / 2.5);
             let flux = if flux != Some(-99999.0) && flux.map_or(false, |f| !f.is_nan()) {
-                flux.map(|f| f * 1e9_f64 * factor) // convert to a fixed ZP and nJy
+                flux.map(|f| f * 1e9_f64 * zp_scaling_factor) // convert to a fixed ZP and nJy
             } else {
                 None
             };
             let flux_err = if flux_err != -99999.0 && !flux_err.is_nan() {
-                flux_err * 1e9_f64 * factor // convert to a fixed ZP and nJy
+                flux_err * 1e9_f64 * zp_scaling_factor // convert to a fixed ZP and nJy
             } else {
                 return Err(FilterWorkerError::MissingFluxPSF);
             };

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -229,7 +229,6 @@ pub async fn build_ztf_alerts(
                 flux: Some(flux),
                 flux_err,
                 band: format!("ztf{}", band),
-                zero_point: ZTF_ZP,
                 origin: Origin::Alert,
                 programid,
                 survey: Survey::Ztf,
@@ -254,7 +253,6 @@ pub async fn build_ztf_alerts(
                 flux: None, // for non-detections, flux is None
                 flux_err,
                 band: format!("ztf{}", band),
-                zero_point: ZTF_ZP,
                 origin: Origin::Alert,
                 programid,
                 survey: Survey::Ztf,
@@ -298,10 +296,9 @@ pub async fn build_ztf_alerts(
 
             photometry.push(Photometry {
                 jd,
-                flux: flux.map(|f| f * 1e9_f64 * factor), // convert to nJy and a fixed ZP
-                flux_err: flux_err * 1e9_f64 * factor,    // convert to nJy and a fixed ZP
+                flux,
+                flux_err,
                 band: format!("ztf{}", band),
-                zero_point: magzpsci,
                 origin: Origin::ForcedPhot,
                 programid,
                 survey: Survey::Ztf,

--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -5,9 +5,13 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 use utoipa::ToSchema;
 
-pub const ZP_AB: f32 = 8.90; // Zero point for AB magnitudes
+pub const ZP_AB: f32 = 8.90; // Zero point for AB magnitude
 pub const SNT: f32 = 3.0; // Signal-to-noise threshold for detection
 const FACTOR: f32 = 1.0857362047581294; // where 1.0857362047581294 = 2.5 / np.log(10)
+
+// now survey-specific values:
+pub const ZTF_ZP: f32 = 23.9;
+pub const LSST_ZP_AB_NJY: f32 = ZP_AB + 22.5; // ZP + nJy to Jy conversion factor, as 2.5 * log10(1e9) = 22.5
 
 pub fn flux2mag(flux: f32, flux_err: f32, zp: f32) -> (f32, f32) {
     let mag = -2.5 * (flux).log10() + zp;

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -197,7 +197,6 @@ async fn create_mock_enriched_lsst_alert_with_matches(
         flux_err: 10.0,
         snr: Some(100.0),
         band: Band::R,
-        zp: Some(8.9),
         ra: Some(ra_override.unwrap_or(150.0)),
         dec: Some(dec_override.unwrap_or(30.0)),
     };

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -92,13 +92,27 @@ fn create_mock_enriched_ztf_alert(
     inner_candidate.fid = 1; // g-band
     inner_candidate.programid = 1; // public
 
-    let candidate = ZtfCandidate {
-        candidate: inner_candidate,
-        psf_flux: 1000.0,
-        psf_flux_err: 10.0,
-        snr: 100.0,
-        band: Band::G,
-    };
+    let candidate = ZtfCandidate::try_from(inner_candidate.clone()).unwrap();
+
+    // let's make sure that the flux and flux_err generated when converting from Candidate to ZtfCandidate
+    // can be converted back to the original magpsf and sigmapsf using the same ZP, to verify that the conversion is consistent
+    let (new_magpsf, new_sigmapsf) = flux2mag(
+        candidate.psf_flux / 1e9_f32,     // convert back to Jy
+        candidate.psf_flux_err / 1e9_f32, // convert back to Jy
+        ZTF_ZP,
+    );
+    assert!(
+        (new_magpsf - candidate.candidate.magpsf).abs() < 1e-6,
+        "Magnitude conversion mismatch: expected {}, got {}",
+        candidate.candidate.magpsf,
+        new_magpsf
+    );
+    assert!(
+        (new_sigmapsf - candidate.candidate.sigmapsf).abs() < 1e-6,
+        "Magnitude error conversion mismatch: expected {}, got {}",
+        candidate.candidate.sigmapsf,
+        new_sigmapsf
+    );
 
     let magpsf = 15.949999;
     let sigmapsf = 0.002316;

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -3,12 +3,12 @@ use boom::{
     alert::{Candidate, DiaSource, LsstCandidate, LsstPrvCandidate, ZtfCandidate},
     conf::AppConfig,
     enrichment::{
-        babamul::{EnrichedLsstAlert, EnrichedZtfAlert},
+        babamul::{BabamulEnrichedLsstAlert, BabamulEnrichedZtfAlert},
         EnrichmentWorker, LsstAlertForEnrichment, LsstEnrichmentWorker, LsstPhotometry,
-        ZtfAlertProperties,
+        ZtfAlertProperties, ZtfForcedPhotometry, ZtfPhotometry,
     },
     utils::{
-        lightcurves::{Band, PerBandProperties},
+        lightcurves::{flux2mag, Band, PerBandProperties, ZTF_ZP},
         testing::TEST_CONFIG_FILE,
     },
 };
@@ -77,7 +77,11 @@ fn create_lspsc_cross_matches(
 }
 
 /// Create a mock enriched ZTF alert for testing
-fn create_mock_enriched_ztf_alert(candid: i64, object_id: &str, is_rock: bool) -> EnrichedZtfAlert {
+fn create_mock_enriched_ztf_alert(
+    candid: i64,
+    object_id: &str,
+    is_rock: bool,
+) -> BabamulEnrichedZtfAlert {
     // Create a minimal Candidate and ZtfCandidate using defaults
     let mut inner_candidate = Candidate::default();
     inner_candidate.candid = candid;
@@ -96,13 +100,59 @@ fn create_mock_enriched_ztf_alert(candid: i64, object_id: &str, is_rock: bool) -
         band: Band::G,
     };
 
-    EnrichedZtfAlert {
+    let magpsf = 15.949999;
+    let sigmapsf = 0.002316;
+    let flux = -11859.88;
+    let flux_err = 25.300741;
+    let magzpsci = 26.1352;
+    let ztf_forced_photometry = ZtfForcedPhotometry {
+        jd: 2460447.9202778,
+        magpsf: Some(magpsf),
+        sigmapsf: Some(sigmapsf),
+        diffmaglim: 20.5,
+        flux: Some(flux),
+        flux_err: flux_err,
+        snr: Some(100.0),
+        band: Band::G,
+        ra: Some(150.0),
+        dec: Some(30.0),
+        magzpsci: Some(magzpsci),
+        programid: 1,
+        procstatus: Some("0".to_string()),
+    };
+
+    let fp_as_photometry = ZtfPhotometry::try_from(ztf_forced_photometry).unwrap();
+
+    let new_flux = fp_as_photometry.flux.unwrap();
+    let new_flux_err = fp_as_photometry.flux_err;
+
+    // the new flux is on a fixed zeropoint (ZTF_ZP), verify
+    // that converting it back to magnitude gives the same magpsf and sigmapsf as the original data
+    let (new_magpsf, new_sigmapsf) = flux2mag(
+        -new_flux as f32 * 1e-9,    // from nJy to Jy
+        new_flux_err as f32 * 1e-9, // from nJy to Jy
+        ZTF_ZP,
+    );
+    assert!(
+        (new_magpsf - magpsf as f32).abs() < 1e-6,
+        "Magnitude conversion mismatch: expected {}, got {}",
+        magpsf,
+        new_magpsf
+    );
+    assert!(
+        (new_sigmapsf - sigmapsf as f32).abs() < 1e-6,
+        "Magnitude error conversion mismatch: expected {}, got {}",
+        sigmapsf,
+        new_sigmapsf
+    );
+
+    BabamulEnrichedZtfAlert {
         candid,
         object_id: object_id.to_string(),
         candidate,
         prv_candidates: vec![],
         prv_nondetections: vec![],
-        fp_hists: vec![],
+        fp_hists: vec![fp_as_photometry],
         properties: ZtfAlertProperties {
             rock: is_rock,
             star: false,
@@ -127,7 +177,10 @@ async fn create_mock_enriched_lsst_alert(
     is_rock: bool,
     ra_override: Option<f64>,
     dec_override: Option<f64>,
-) -> (EnrichedLsstAlert, HashMap<String, Vec<serde_json::Value>>) {
+) -> (
+    BabamulEnrichedLsstAlert,
+    HashMap<String, Vec<serde_json::Value>>,
+) {
     create_mock_enriched_lsst_alert_with_matches(
         candid,
         object_id,
@@ -152,7 +205,10 @@ async fn create_mock_enriched_lsst_alert_with_matches(
     survey_matches: Option<boom::enrichment::LsstSurveyMatches>,
     ra_override: Option<f64>,
     dec_override: Option<f64>,
-) -> (EnrichedLsstAlert, HashMap<String, Vec<serde_json::Value>>) {
+) -> (
+    BabamulEnrichedLsstAlert,
+    HashMap<String, Vec<serde_json::Value>>,
+) {
     // Create a minimal DiaSource with default values
     let mut dia_source = DiaSource::default();
     dia_source.candid = candid;
@@ -216,7 +272,7 @@ async fn create_mock_enriched_lsst_alert_with_matches(
         .await
         .unwrap();
 
-    EnrichedLsstAlert::from_alert_properties_and_cutouts(
+    BabamulEnrichedLsstAlert::from_alert_properties_and_cutouts(
         lsst_alert_for_enrichment,
         None,
         None,
@@ -667,7 +723,7 @@ async fn test_babamul_process_ztf_alerts() {
     let expected: std::collections::HashSet<String> =
         [ztf_obj1.clone(), ztf_obj2.clone()].into_iter().collect();
 
-    let schema = boom::enrichment::babamul::EnrichedZtfAlert::get_schema();
+    let schema = boom::enrichment::babamul::BabamulEnrichedZtfAlert::get_schema();
     let mut found: std::collections::HashSet<String> = std::collections::HashSet::new();
     for msg in &messages {
         if let Ok(reader) = apache_avro::Reader::with_schema(&schema, &msg[..]) {
@@ -726,7 +782,7 @@ async fn test_babamul_process_lsst_alerts() {
     let expected: std::collections::HashSet<String> =
         [lsst_obj1.clone(), lsst_obj2.clone()].into_iter().collect();
 
-    let schema = boom::enrichment::babamul::EnrichedLsstAlert::get_schema();
+    let schema = boom::enrichment::babamul::BabamulEnrichedLsstAlert::get_schema();
     let mut found: std::collections::HashSet<String> = std::collections::HashSet::new();
     for msg in &messages {
         if let Ok(reader) = apache_avro::Reader::with_schema(&schema, &msg[..]) {
@@ -1078,7 +1134,7 @@ async fn test_babamul_lsst_with_ztf_match() {
 
     // Try to decode and verify the ZTF match in the published messages
     // Skip messages that don't decode (e.g., due to schema mismatch with stale messages)
-    let schema = EnrichedLsstAlert::get_schema();
+    let schema = BabamulEnrichedLsstAlert::get_schema();
     let mut successful_decodes = 0;
     for msg in &messages {
         let reader = match apache_avro::Reader::with_schema(&schema, &msg[..]) {
@@ -1336,7 +1392,7 @@ async fn test_babamul_ztf_with_lsst_match() {
 
     // Try to decode and verify the LSST match in the published messages
     // Skip messages that don't decode (e.g., due to schema mismatch with stale messages)
-    let schema = EnrichedZtfAlert::get_schema();
+    let schema = BabamulEnrichedZtfAlert::get_schema();
     let mut successful_decodes = 0;
     for msg in &messages {
         let reader = match apache_avro::Reader::with_schema(&schema, &msg[..]) {

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -97,8 +97,8 @@ fn create_mock_enriched_ztf_alert(
     // let's make sure that the flux and flux_err generated when converting from Candidate to ZtfCandidate
     // can be converted back to the original magpsf and sigmapsf using the same ZP, to verify that the conversion is consistent
     let (new_magpsf, new_sigmapsf) = flux2mag(
-        candidate.psf_flux / 1e9_f32,     // convert back to Jy
-        candidate.psf_flux_err / 1e9_f32, // convert back to Jy
+        candidate.psf_flux.abs() / 1e9_f32, // convert back to Jy
+        candidate.psf_flux_err / 1e9_f32,   // convert back to Jy
         ZTF_ZP,
     );
     assert!(

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -5,9 +5,10 @@ use boom::{
     },
     conf::get_test_db,
     enrichment::{EnrichmentWorker, ZtfEnrichmentWorker},
-    filter::{alert_to_avro_bytes, load_alert_schema, FilterWorker, ZtfFilterWorker},
+    filter::{alert_to_avro_bytes, load_alert_schema, FilterWorker, Origin, ZtfFilterWorker},
     utils::{
         enums::Survey,
+        lightcurves::{flux2mag, ZTF_ZP},
         testing::{
             decam_alert_worker, drop_alert_from_collections, insert_test_filter, lsst_alert_worker,
             remove_test_filter, ztf_alert_worker, AlertRandomizer, TEST_CONFIG_FILE,
@@ -449,6 +450,35 @@ async fn test_filter_ztf_alert() {
     assert_eq!(alert.candid, candid);
     assert_eq!(alert.object_id, object_id);
     assert_eq!(alert.photometry.len(), 21); // prv_candidates + prv_nondetections + fp_hists
+
+    // let's validate that the photometry points were correctly parsed, and that the flux and flux_err values are consistent with the original values in the alert
+    let fp_point = alert
+        .photometry
+        .iter()
+        .find(|p| p.jd == 2460447.9202778 && p.origin == Origin::ForcedPhot)
+        .unwrap();
+    assert!(fp_point.flux.is_some());
+    let flux = fp_point.flux.unwrap();
+    assert!(flux < 0.0); // the first point is a negative detection, so the flux should be negative
+    let flux_err = fp_point.flux_err;
+    let band = &fp_point.band;
+    assert_eq!(band, "ztfg");
+
+    // we compute magpsf and magpsf_err from the flux values from the alert packet
+    let magzpsci = 26.1352;
+    let forcediffimflux = -11859.88;
+    let forcediffimfluxunc = 25.300741;
+    let (magpsf_forcediffimflux, magpsf_err) =
+        flux2mag(-forcediffimflux, forcediffimfluxunc, magzpsci);
+
+    // then we compute magpsf and magpsf_err from the flux and flux_err values
+    // we compute in the alert worker (at a fixed ZP)
+    let (magpsf, magpsf_err_from_flux) =
+        flux2mag(-flux as f32 * 1e-9, flux_err as f32 * 1e-9, ZTF_ZP);
+
+    // they should be consistent within a small tolerance
+    assert!((magpsf_forcediffimflux - magpsf).abs() < 1e-6);
+    assert!((magpsf_err - magpsf_err_from_flux).abs() < 1e-6);
 
     let filter_passed = alert
         .filters

--- a/tests/test_ztf.rs
+++ b/tests/test_ztf.rs
@@ -480,6 +480,29 @@ async fn test_filter_ztf_alert() {
     assert!((magpsf_forcediffimflux - magpsf).abs() < 1e-6);
     assert!((magpsf_err - magpsf_err_from_flux).abs() < 1e-6);
 
+    // let's do a similar validation for the first prv_candidates point, where the ZP is fixed at ZTF_ZP
+    let alert_points = alert
+        .photometry
+        .iter()
+        .filter(|p| p.origin == Origin::Alert && p.flux.is_some())
+        .collect::<Vec<_>>();
+    assert!(
+        !alert_points.is_empty(),
+        "No Alert photometry points with flux found"
+    );
+    let prv_candidate_point = alert
+        .photometry
+        .iter()
+        .find(|p| p.jd == 2460423.9562384 && p.origin == Origin::Alert && p.flux.is_some())
+        .unwrap();
+    assert!(prv_candidate_point.flux.is_some());
+    let flux = prv_candidate_point.flux.unwrap();
+    let flux_err = prv_candidate_point.flux_err;
+    let (magpsf_prv_candidate, magpsf_err_prv_candidate) =
+        flux2mag((flux.abs() * 1e-9) as f32, (flux_err * 1e-9) as f32, ZTF_ZP);
+    assert!((magpsf_prv_candidate - 16.8002).abs() < 1e-4);
+    assert!((magpsf_err_prv_candidate - 0.1788).abs() < 1e-4);
+
     let filter_passed = alert
         .filters
         .iter()


### PR DESCRIPTION
when computing psfFlux and psfFluxErr for ZTF fp_hists, move them to the same fixed zero points (23.9, what is already used by ZTF for its prv_candidates, candidate, and diffmaglim) rather than just scaling the original `forcediffimflux` and `forcediffimfluxunc` fields from Jy to nJy. Because if we just scale it like that, since the fluxes from `fp_hists` are at a different zeropoint for each timestamps, it means that for example: if a person wants to use fluxes from fp_hists and prv_candidates together, they NEED to know about that zeropoint and carry it everywhere they will make comparisons on conversions to mag. By computing `psfFlux` and `psfFluxErr` at a fixed zeropoint, we make them as easy to use as the other fluxes in the data model.

WARNINGS: 
- This is somewhat of a BREAKING CHANGE, as the data that is already in the database needs fixing. While said data gets fixed, however; the goal is to NOT prevent other operations that rely on that data (enrichment worker, babamul, and filter worker). For that, I ~will add a commit soon~ added a commit that makes these different services rely on the original FP data from IPAC (forcediffimflux, forcediffimfluxunc, and magzpsci) to compute the "fixed-zp fluxes" on-the-fly, rather than what is already in the DB. This means fixing what is in the DB can be done separately, and we can proceed w/ merging these changes.
- This changes the schema of the filter worker too. No more zeropoints in there either. So, systems that read from it need to use a fixed ZP of 23.9 for ZTF, and 8.9 for LSST (after converting from nJy to Jy). Long term, I'd like to make both babamul and filter worker schemas identical (minus the filter results, of course)

Note: I am also working on adding the script that once can run to migrate the DB. Once the DB is migrated for everybody in production (CIT & UMN), I'll re-open a PR that removes these temporary changes in these workers, so we can go back to using the data in the DB and avoid duplicating compute. It's not a huge performance hit to re-compute on the fly, so removing these temporary changes isn't something we need to rush.