### PR TITLE
Add structured tracing across API, scheduler, Kafka, and enrichment workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ scripts/convert2onnx/models_output/
 tests/throughput/config.yaml
 tests/throughput/cats150.filter.json
 logs
+meta.json
+venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,9 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "tracing-actix-web",
  "tracing-flame",
+ "tracing-log",
  "tracing-subscriber",
  "utoipa",
  "utoipa-scalar",
@@ -2558,6 +2560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutually_exclusive_features"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,6 +4472,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-actix-web"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5360edd490ec8dee9fedfc6a9fd83ac2f01b3e1996e3261b9ad18a61971fe064"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "time", "macros", "sync", "signal"] }
 tracing = "0.1.41"
+tracing-actix-web = "0.7"
+tracing-log = "0.2"
 tracing-flame = "0.2.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "registry"]}
 utoipa = { version = "5.4.0", features = ["actix_extras"] }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -7,7 +7,6 @@ use actix_web::middleware::Next;
 use actix_web::{web, Error, HttpMessage};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use mongodb::bson::doc;
-use mongodb::Database;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -27,8 +26,10 @@ pub struct AuthProvider {
 }
 
 impl AuthProvider {
-    pub async fn new(config: &AppConfig, db: &Database) -> Result<Self, std::io::Error> {
-        let auth_config = &config.api.auth;
+    pub async fn new(
+        auth_config: &AuthConfig,
+        db: &mongodb::Database,
+    ) -> Result<Self, std::io::Error> {
         let encoding_key = EncodingKey::from_secret(auth_config.secret_key.as_bytes());
         let decoding_key = DecodingKey::from_secret(auth_config.secret_key.as_bytes());
         let mut validation = Validation::new(Algorithm::HS256);

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -7,6 +7,7 @@ use actix_web::middleware::Next;
 use actix_web::{web, Error, HttpMessage};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use mongodb::bson::doc;
+use mongodb::Database;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info};
 
@@ -34,7 +35,7 @@ impl AuthProvider {
         let encoding_key = EncodingKey::from_secret(auth_config.secret_key.as_bytes());
         let decoding_key = DecodingKey::from_secret(auth_config.secret_key.as_bytes());
         let mut validation = Validation::new(Algorithm::HS256);
-        validation.validate_exp = config.token_expiration > 0; // Set to true if tokens should expire
+        validation.validate_exp = auth_config.token_expiration > 0; // Set to true if tokens should expire
 
         let users_collection: mongodb::Collection<User> = db.collection("users");
         debug!("AuthProvider initialized with users collection");
@@ -44,7 +45,7 @@ impl AuthProvider {
             decoding_key,
             validation,
             users_collection,
-            token_expiration: config.token_expiration,
+            token_expiration: auth_config.token_expiration,
         })
     }
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,6 +1,6 @@
 use crate::api::routes::babamul::BabamulUser;
 use crate::api::routes::users::User;
-use crate::conf::AppConfig;
+use crate::conf::{AppConfig, AuthConfig};
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::middleware::Next;
@@ -8,6 +8,7 @@ use actix_web::{web, Error, HttpMessage};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use mongodb::bson::doc;
 use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -33,19 +34,22 @@ impl AuthProvider {
         let encoding_key = EncodingKey::from_secret(auth_config.secret_key.as_bytes());
         let decoding_key = DecodingKey::from_secret(auth_config.secret_key.as_bytes());
         let mut validation = Validation::new(Algorithm::HS256);
-        validation.validate_exp = auth_config.token_expiration > 0; // Set to true if tokens should expire
+        validation.validate_exp = config.token_expiration > 0; // Set to true if tokens should expire
 
         let users_collection: mongodb::Collection<User> = db.collection("users");
+        debug!("AuthProvider initialized with users collection");
 
         Ok(AuthProvider {
             encoding_key,
             decoding_key,
             validation,
             users_collection,
-            token_expiration: auth_config.token_expiration,
+            token_expiration: config.token_expiration,
         })
     }
 
+    #[tracing::instrument(name = "auth::create_token", skip(self, user), 
+    fields(user_id = %user.id, token_expiration = self.token_expiration), err)]
     pub async fn create_token(
         &self,
         user: &User,
@@ -58,6 +62,7 @@ impl AuthProvider {
             exp,
         };
 
+        debug!("encoding JWT for user");
         let token = encode(&Header::default(), &claims, &self.encoding_key)?;
         Ok((
             token,
@@ -69,15 +74,18 @@ impl AuthProvider {
         ))
     }
 
+    #[tracing::instrument(name = "auth::decode_token", skip(self, token), err)]
     pub async fn decode_token(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
         decode::<Claims>(token, &self.decoding_key, &self.validation).map(|data| data.claims)
     }
 
+    #[tracing::instrument(name = "auth::validate_token", skip(self, token), err)]
     pub async fn validate_token(&self, token: &str) -> Result<String, jsonwebtoken::errors::Error> {
         let claims = self.decode_token(token).await?;
         Ok(claims.sub)
     }
 
+    #[tracing::instrument(name = "auth::authenticate_user", skip(self, token), fields(token_len = token.len()), err)]
     pub async fn authenticate_user(&self, token: &str) -> Result<User, std::io::Error> {
         let user_id = self.validate_token(token).await.map_err(|e| {
             std::io::Error::new(std::io::ErrorKind::Other, format!("Incorrect JWT: {}", e))
@@ -97,10 +105,9 @@ impl AuthProvider {
             .find_one(doc! {"_id": &user_id})
             .await
             .map_err(|e| {
-                tracing::error!(
+                error!(
                     "Database query failed when looking for user id {}: {}",
-                    user_id,
-                    e
+                    user_id, e
                 );
                 std::io::Error::new(
                     std::io::ErrorKind::Other,
@@ -109,24 +116,27 @@ impl AuthProvider {
             })?;
 
         match user {
-            Some(user) => return Ok(user),
-            None => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("User with id {} not found", user_id),
-                ));
+            Some(user) => {
+                info!(%user_id, "user authenticated successfully");
+                Ok(user)
             }
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("User with id {} not found", user_id),
+            )),
         }
     }
 
+    #[tracing::instrument(name = "auth::create_token_for_user", skip(self, username, password), fields(username = %username), err)]
     pub async fn create_token_for_user(
         &self,
         username: &str,
         password: &str,
     ) -> Result<(String, Option<usize>), std::io::Error> {
         let filter = mongodb::bson::doc! { "username": username };
+        debug!(%username, "looking up user for token creation");
         let user = self.users_collection.find_one(filter).await.map_err(|e| {
-            eprint!(
+            error!(
                 "Database query failed when looking for user {} (when creating token): {}",
                 username, e
             );
@@ -140,10 +150,16 @@ impl AuthProvider {
         // otherwise return an error
         if let Some(user) = user {
             match bcrypt::verify(&password, &user.password) {
-                Ok(true) => self.create_token(&user).await.map_err(|e| {
-                    eprint!("Token creation failed: {}", e);
-                    std::io::Error::new(std::io::ErrorKind::Other, format!("Token creation failed"))
-                }),
+                Ok(true) => {
+                    info!(%username, "credentials valid, creating token");
+                    self.create_token(&user).await.map_err(|e| {
+                        error!("Token creation failed: {}", e);
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("Token creation failed"),
+                        )
+                    })
+                }
                 _ => Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
                     "Invalid credentials",
@@ -162,16 +178,17 @@ pub async fn get_auth(
     app_config: &AppConfig,
     db: &Database,
 ) -> Result<AuthProvider, std::io::Error> {
-    AuthProvider::new(&app_config, &db).await
+    AuthProvider::new(&app_config.api.auth, &db).await
 }
 
 pub async fn get_test_auth(db: &Database) -> Result<AuthProvider, std::io::Error> {
     let app_config = AppConfig::from_test_config().unwrap();
-    AuthProvider::new(&app_config, &db).await
+    AuthProvider::new(&app_config.api.auth, &db).await
 }
 
 pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/"];
 
+#[tracing::instrument(name = "auth::middleware", skip(req, next), fields(path = %req.path()), err)]
 pub async fn auth_middleware(
     req: ServiceRequest,
     next: Next<impl MessageBody>,

--- a/src/api/catalogs.rs
+++ b/src/api/catalogs.rs
@@ -2,22 +2,31 @@
 use crate::api::db::PROTECTED_COLLECTION_NAMES;
 
 use mongodb::Database;
+use tracing::debug;
 
 /// Check if a catalog exists
+#[tracing::instrument(name = "catalogs::catalog_exists", skip(db), fields(catalog_name = %catalog_name), ret)]
 pub async fn catalog_exists(db: &Database, catalog_name: &str) -> bool {
     if catalog_name.is_empty() {
+        debug!("empty catalog");
         return false; // Empty catalog names are not valid
     }
     if PROTECTED_COLLECTION_NAMES.contains(&catalog_name) {
+        debug!("catalog name is in PROTECTED_COLLECTION_NAMES");
         return false; // Protected names cannot be used as catalog names
     }
     // Get collection names in alphabetical order
     let collection_names = match db.list_collection_names().await {
         Ok(c) => c,
-        Err(_) => return false,
+        Err(e) => {
+            debug!(error = %e, "failed to list collection names from database");
+            return false;
+        }
     };
     // Convert catalog name to collection name
     let collection_name = catalog_name.to_string();
     // Check if the collection exists
-    collection_names.contains(&collection_name)
+    let exists = collection_names.contains(&collection_name);
+    debug!(%exists, "catalog existence check complete");
+    exists
 }

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,4 +1,5 @@
 use crate::api::routes;
+use tracing::{debug, instrument};
 use utoipa::openapi::security::{Flow, OAuth2, Password, Scopes, SecurityScheme};
 use utoipa::openapi::Components;
 use utoipa::Modify;
@@ -7,11 +8,14 @@ use utoipa::OpenApi;
 struct SecurityAddon;
 
 impl Modify for SecurityAddon {
+    #[instrument(name = "docs::modify_security_addon", skip(self, openapi))]
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         if openapi.components.is_none() {
+            debug!("OpenAPI components missing, initializing");
             openapi.components = Some(Components::new());
         }
 
+        debug!("Adding api_jwt_token security scheme to OpenAPI components");
         openapi.components.as_mut().unwrap().add_security_scheme(
             "api_jwt_token",
             SecurityScheme::OAuth2(OAuth2::new([Flow::Password(Password::new(
@@ -25,11 +29,14 @@ impl Modify for SecurityAddon {
 struct BabamulSecurityAddon;
 
 impl Modify for BabamulSecurityAddon {
+    #[instrument(name = "docs::modify_babamul_security_addon", skip(self, openapi))]
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         if openapi.components.is_none() {
+            debug!("OpenAPI components missing, initializing");
             openapi.components = Some(Components::new());
         }
 
+        debug!("Adding babamul_jwt_token security scheme to OpenAPI components");
         openapi.components.as_mut().unwrap().add_security_scheme(
             "babamul_jwt_token",
             SecurityScheme::OAuth2(OAuth2::new([Flow::Password(Password::new(

--- a/src/api/routes/info.rs
+++ b/src/api/routes/info.rs
@@ -2,6 +2,7 @@ use crate::api::models::response;
 use crate::api::routes::users::User;
 use actix_web::{get, web, HttpResponse};
 use std::str;
+use tracing::{debug, error};
 
 /// Check the health of the API server
 #[utoipa::path(
@@ -12,8 +13,10 @@ use std::str;
     ),
     tags=["Info"]
 )]
+#[tracing::instrument(name = "info::get_health", skip(), fields(http.method = "GET", http.route = "/"))]
 #[get("/")]
 pub async fn get_health() -> HttpResponse {
+    debug!("health check endpoint hit");
     HttpResponse::Ok().json(serde_json::json!({
         "status": "success",
         "message": "Greetings from BOOM!"
@@ -29,17 +32,23 @@ pub async fn get_health() -> HttpResponse {
     ),
     tags=["Info"]
 )]
+#[tracing::instrument(name = "info::get_db_info", skip(db, current_user),
+fields(user_id = %current_user.id, is_admin = current_user.is_admin, http.method = "GET", http.route = "/api/db-info"))]
 #[get("/db-info")]
 pub async fn get_db_info(
     db: web::Data<mongodb::Database>,
     current_user: web::ReqData<User>,
 ) -> HttpResponse {
+    debug!(user_id = %current_user.id, is_admin = current_user.is_admin, "db-info endpoint hit");
     // Only admins can access this endpoint
     if !current_user.is_admin {
         return response::forbidden("Access denied: Admins only");
     }
     match db.run_command(mongodb::bson::doc! { "dbstats": 1 }).await {
         Ok(stats) => response::ok("success", serde_json::to_value(stats).unwrap()),
-        Err(e) => response::internal_error(&format!("Error getting database info: {:?}", e)),
+        Err(e) => {
+            error!(error = ?e, "Error getting database info");
+            response::internal_error(&format!("Error getting database info: {:?}", e))
+        }
     }
 }

--- a/src/api/test_utils.rs
+++ b/src/api/test_utils.rs
@@ -1,5 +1,7 @@
 use mongodb::{bson, Database};
+use tracing::instrument;
 
+#[instrument(name = "test_utils::create_test_catalog", skip(db), ret)]
 pub async fn create_test_catalog(db: &Database) -> String {
     let name = format!("test_catalog_{}", uuid::Uuid::new_v4());
     let collection = db.collection(&name);
@@ -23,10 +25,12 @@ pub async fn create_test_catalog(db: &Database) -> String {
     name
 }
 
+#[instrument(name = "test_utils::delete_test_catalog", skip(db))]
 pub async fn delete_test_catalog(db: &Database, name: &str) {
     db.collection::<bson::Document>(name).drop().await.unwrap();
 }
 
+#[instrument(name = "test_utils::read_str_response", skip(resp), ret)]
 pub async fn read_str_response<B>(resp: actix_web::dev::ServiceResponse<B>) -> String
 where
     B: actix_web::body::MessageBody,
@@ -36,6 +40,7 @@ where
 }
 
 // we read a json response in all of our tests, so let's make a helper function for that
+#[instrument(name = "test_utils::read_json_response", skip(resp), ret)]
 pub async fn read_json_response<B>(resp: actix_web::dev::ServiceResponse<B>) -> serde_json::Value
 where
     B: actix_web::body::MessageBody,

--- a/src/bin/add_filter.rs
+++ b/src/bin/add_filter.rs
@@ -64,7 +64,7 @@ async fn main() {
         description: Some(description),
         active: true,
         user_id: "cli".to_string(),
-        survey: survey,
+        survey: survey.clone(),
         permissions: permissions,
         fv: vec![FilterVersion {
             fid: "v2e0fs".to_string(),
@@ -76,6 +76,20 @@ async fn main() {
         created_at: now_jd(),
         updated_at: now_jd(),
     };
+
+    let span = tracing::info_span!(
+        "cmd::add_filter",
+        survey = %survey,
+        filter_id = %filter_id,
+        filter_file = %filter_file,
+    );
+    let _guard = span.enter();
+    tracing::info!(
+        survey = %survey,
+        filter_id = %filter_id,
+        filter_file = %filter_file,
+        "Preparing to insert filter into MongoDB"
+    );
 
     // insert the filter into the database
     let config = AppConfig::from_default_path().unwrap();

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -73,7 +73,18 @@ fn parse_date(s: &str) -> Result<NaiveDate, String> {
     Ok(date)
 }
 
-#[instrument(skip_all, fields(survey = %args.survey))]
+#[instrument(skip_all, fields(
+        survey = %args.survey,
+        date = ?args.date,
+        program_id = ?args.program_id,
+        processes = args.processes,
+        clear = args.clear,
+        max_in_queue = args.max_in_queue,
+        simulated = args.simulated,
+        exit_on_eof = args.exit_on_eof,
+        deployment_env = %args.deployment_env
+    )
+)]
 async fn run(args: Cli, meter_provider: SdkMeterProvider) {
     let timestamp = NaiveDateTime::from(args.date.unwrap_or_else(|| {
         chrono::Utc::now()

--- a/src/bin/kafka_producer.rs
+++ b/src/bin/kafka_producer.rs
@@ -55,6 +55,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .server_url
         .unwrap_or_else(|| "localhost:9092".to_string());
 
+    let span = tracing::info_span!(
+        "kafka::producer::produce",
+        survey = ?args.survey, date = %date, limit = limit, program_id = ?program_id,
+        server_url = %server_url,
+    );
+    let _g = span.enter();
     match args.survey {
         Survey::Ztf => {
             let producer = ZtfAlertProducer::new(date, limit, program_id, &server_url, true);

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -60,7 +60,7 @@ pub fn load_dotenv() {
     debug!("No .env file found, using system environment variables only");
 }
 
-#[instrument(err)]
+#[instrument(err, fields(path = %filepath))]
 pub fn load_raw_config(filepath: &str) -> Result<Config, BoomConfigError> {
     let path = Path::new(filepath);
 
@@ -82,8 +82,12 @@ pub fn load_raw_config(filepath: &str) -> Result<Config, BoomConfigError> {
     Ok(conf)
 }
 
-#[instrument(skip_all, err)]
-async fn build_db(conf: &AppConfig) -> Result<mongodb::Database, BoomConfigError> {
+#[instrument(skip_all, fields(
+    host = %conf.database.host,
+    port = conf.database.port,
+    name = %conf.database.name,
+), err)]
+pub async fn build_db(conf: &AppConfig) -> Result<mongodb::Database, BoomConfigError> {
     let db_conf = &conf.database;
 
     let prefix = match db_conf.srv {
@@ -127,8 +131,11 @@ async fn build_db(conf: &AppConfig) -> Result<mongodb::Database, BoomConfigError
     Ok(db)
 }
 
-#[instrument(skip_all, err)]
-async fn build_redis(
+#[instrument(skip_all, fields(
+    host = %conf.redis.host,
+    port = conf.redis.port,
+), err)]
+pub async fn build_redis(
     conf: &AppConfig,
 ) -> Result<redis::aio::MultiplexedConnection, BoomConfigError> {
     let host = &conf.redis.host;

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -19,7 +19,7 @@ use opentelemetry::{
 };
 use redis::AsyncCommands;
 use tokio::sync::mpsc;
-use tracing::{debug, instrument};
+use tracing::{debug, error, info, instrument, trace};
 use uuid::Uuid;
 
 // NOTE: Global instruments are defined here because reusing instruments is
@@ -107,7 +107,7 @@ pub trait EnrichmentWorker {
 ///
 /// # Returns
 /// A Result containing a vector of bson Documents representing the fetched alerts, or an EnrichmentWorkerError.
-#[instrument(skip_all, err)]
+#[instrument(skip(candids, alert_pipeline, alert_collection), fields(batch_size = candids.len()), err)]
 pub async fn fetch_alerts<T: for<'a> serde::Deserialize<'a>>(
     candids: &[i64], // this is a slice of candids to process
     alert_pipeline: &Vec<Document>,
@@ -121,6 +121,10 @@ pub async fn fetch_alerts<T: for<'a> serde::Deserialize<'a>>(
             }
         };
     }
+    debug!(
+        stages = alert_pipeline.len(),
+        "Fetching alerts with aggregation pipeline"
+    );
     let mut alert_cursor = alert_collection.aggregate(alert_pipeline).await?;
 
     let mut alerts: Vec<T> = Vec::new();
@@ -130,16 +134,17 @@ pub async fn fetch_alerts<T: for<'a> serde::Deserialize<'a>>(
                 let alert: T = mongodb::bson::from_document(document)?;
                 alerts.push(alert);
             }
-            _ => {
-                continue;
+            Err(e) => {
+                error!(error = %e, "failed to fetch alert document from MongoDB");
             }
         }
     }
 
+    debug!(fetched = alerts.len(), "Fetched alerts from database");
     Ok(alerts)
 }
 
-#[instrument(skip_all, err)]
+#[instrument(skip(candids, alert_cutout_collection), fields(batch_size = candids.len()), err)]
 pub async fn fetch_alert_cutouts(
     candids: &[i64],
     alert_cutout_collection: &mongodb::Collection<Document>,
@@ -147,6 +152,7 @@ pub async fn fetch_alert_cutouts(
     let filter = doc! {
         "_id": {"$in": candids}
     };
+    debug!("Fetching alert cutouts from database");
     let mut cursor = alert_cutout_collection.find(filter).await?;
 
     let mut cutouts_map: std::collections::HashMap<i64, AlertCutout> =
@@ -175,17 +181,22 @@ pub async fn fetch_alert_cutouts(
                 };
                 cutouts_map.insert(candid, alert_cutout);
             }
-            _ => {
+            Err(e) => {
+                error!(error = %e, "failed to fetch alert cutout document from MongoDB");
                 continue;
             }
         }
     }
 
+    debug!(
+        fetched = cutouts_map.len(),
+        "Fetched alert cutouts from database"
+    );
     Ok(cutouts_map)
 }
 
 #[tokio::main]
-#[instrument(skip_all, err)]
+#[instrument(skip_all, fields(worker_id = %worker_id, config_path = %config_path) err)]
 pub async fn run_enrichment_worker<T: EnrichmentWorker>(
     mut receiver: mpsc::Receiver<WorkerCmd>,
     config_path: &str,
@@ -199,6 +210,8 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
 
     let input_queue = enrichment_worker.input_queue_name();
     let output_queue = enrichment_worker.output_queue_name();
+
+    info!(input_queue = %input_queue, output_queue = %output_queue, "Enrichment worker started");
 
     let command_interval: usize = 500;
     let mut command_check_countdown = command_interval;
@@ -224,6 +237,7 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
     loop {
         if command_check_countdown == 0 {
             if should_terminate(&mut receiver) {
+                info!("termination signal received, shutting down enrichment worker");
                 break;
             }
             command_check_countdown = command_interval;
@@ -233,13 +247,15 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
         let candids: Vec<i64> = con
             .rpop::<&str, Vec<i64>>(&input_queue, NonZero::new(1000))
             .await
-            .inspect_err(|_| {
+            .inspect_err(|e| {
+                error!(error = %e, queue = %input_queue, "failed to read from input queue");
                 ACTIVE.add(-1, &active_attrs);
                 BATCH_PROCESSED.add(1, &input_error_attrs);
             })?;
 
         if candids.is_empty() {
             ACTIVE.add(-1, &active_attrs);
+            trace!(queue = %input_queue, "no candids found in input queue; sleeping");
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             command_check_countdown = 0;
             continue;
@@ -248,7 +264,8 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
         let processed_alerts: Vec<String> = enrichment_worker
             .process_alerts(&candids)
             .await
-            .inspect_err(|_| {
+            .inspect_err(|e| {
+                error!(error = %e, "failed to process alerts");
                 ACTIVE.add(-1, &active_attrs);
                 BATCH_PROCESSED.add(1, &processing_error_attrs);
             })?;
@@ -263,7 +280,8 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
         }
         con.lpush::<&str, Vec<String>, usize>(&output_queue, processed_alerts)
             .await
-            .inspect_err(|_| {
+            .inspect_err(|e| {
+                error!(error = %e, queue = %output_queue, "failed to write to output queue");
                 ACTIVE.add(-1, &active_attrs);
                 BATCH_PROCESSED.add(1, &output_error_attrs);
             })?;

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -20,7 +20,7 @@ use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
 use std::collections::HashMap;
 use std::sync::OnceLock;
-use tracing::{error, instrument, warn};
+use tracing::{debug, error, instrument, warn};
 
 pub const IS_STELLAR_DISTANCE_THRESH_ARCSEC: f64 = 1.0;
 pub const IS_NEAR_BRIGHTSTAR_DISTANCE_THRESH_ARCSEC: f64 = 20.0;
@@ -222,7 +222,7 @@ pub struct LsstEnrichmentWorker {
 
 #[async_trait::async_trait]
 impl EnrichmentWorker for LsstEnrichmentWorker {
-    #[instrument(err)]
+    #[instrument(err, skip(config_path))]
     async fn new(config_path: &str) -> Result<Self, EnrichmentWorkerError> {
         let config = AppConfig::from_path(config_path)?;
         let db = config.build_db().await?;
@@ -289,7 +289,7 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
         self.output_queue.clone()
     }
 
-    #[instrument(skip_all, err)]
+    #[instrument(skip_all, fields(batch_size = candids.len()), err)]
     async fn process_alerts(
         &mut self,
         candids: &[i64],
@@ -297,11 +297,16 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
         let alerts: Vec<LsstAlertForEnrichment> =
             fetch_alerts(&candids, &self.alert_pipeline, &self.alert_collection).await?;
 
+        debug!(
+            alerts = alerts.len(),
+            candids = candids.len(),
+            "fetched alerts"
+        );
         if alerts.len() != candids.len() {
             warn!(
-                "only {} alerts fetched from {} candids",
-                alerts.len(),
-                candids.len()
+                alerts = alerts.len(),
+                candids = candids.len(),
+                "alert/candid mismatch"
             );
         }
 
@@ -386,12 +391,14 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
             None => {}
         }
 
+        debug!("processed {} alerts", processed_alerts.len());
         Ok(processed_alerts)
     }
 }
 
 impl LsstEnrichmentWorker {
-    pub async fn get_alert_properties(
+    #[instrument(skip(self, alert), fields(candid = alert.candid), err)]
+    async fn get_alert_properties(
         &self,
         alert: &LsstAlertForEnrichment,
     ) -> Result<LsstAlertProperties, EnrichmentWorkerError> {

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -268,6 +268,7 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
         } else {
             None
         };
+        debug!(input_queue = %input_queue, output_queue = %output_queue, "LSST Enrichment Worker configuration");
 
         Ok(LsstEnrichmentWorker {
             input_queue,

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -398,7 +398,7 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
 
 impl LsstEnrichmentWorker {
     #[instrument(skip(self, alert), fields(candid = alert.candid), err)]
-    async fn get_alert_properties(
+    pub async fn get_alert_properties(
         &self,
         alert: &LsstAlertForEnrichment,
     ) -> Result<LsstAlertProperties, EnrichmentWorkerError> {

--- a/src/enrichment/models/acai.rs
+++ b/src/enrichment/models/acai.rs
@@ -11,7 +11,7 @@ pub struct AcaiModel {
 }
 
 impl Model for AcaiModel {
-    #[instrument(err)]
+    #[instrument(skip(path), fields(model_path = %path), err)]
     fn new(path: &str) -> Result<Self, ModelError> {
         Ok(Self {
             model: load_model(&path)?,
@@ -39,7 +39,7 @@ impl Model for AcaiModel {
 }
 
 impl AcaiModel {
-    #[instrument(skip_all, err)]
+    #[instrument(skip_all, fields(batch_size = alerts.len()), err)]
     pub fn get_metadata(
         &self,
         alerts: &[&ZtfAlertForEnrichment],

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -23,6 +23,7 @@ pub enum ModelError {
     MissingFeature(&'static str),
 }
 
+#[instrument(name = "models::load_model", skip(path), fields(model_path = %path) err)]
 pub fn load_model(path: &str) -> Result<Session, ModelError> {
     let mut builder = Session::builder()?;
 

--- a/src/enrichment/models/btsbot.rs
+++ b/src/enrichment/models/btsbot.rs
@@ -14,7 +14,7 @@ pub struct BtsBotModel {
 }
 
 impl Model for BtsBotModel {
-    #[instrument(err)]
+    #[instrument(skip(path), fields(model_path = %path), err)]
     fn new(path: &str) -> Result<Self, ModelError> {
         Ok(Self {
             model: load_model(&path)?,
@@ -42,7 +42,7 @@ impl Model for BtsBotModel {
 }
 
 impl BtsBotModel {
-    #[instrument(skip_all, err)]
+    #[instrument(skip_all, fields(batch_size = alerts.len()), err)]
     pub fn get_metadata(
         &self,
         alerts: &[&ZtfAlertForEnrichment],

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -19,7 +19,7 @@ use apache_avro_macros::serdavro;
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
 use serde::{Deserialize, Deserializer};
-use tracing::{instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn};
 
 #[serdavro]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -355,7 +355,7 @@ pub struct ZtfEnrichmentWorker {
 
 #[async_trait::async_trait]
 impl EnrichmentWorker for ZtfEnrichmentWorker {
-    #[instrument(err)]
+    #[instrument(err, skip(config_path))]
     async fn new(config_path: &str) -> Result<Self, EnrichmentWorkerError> {
         let config = AppConfig::from_path(config_path)?;
         let db: mongodb::Database = config.build_db().await?;
@@ -365,6 +365,9 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
 
         let input_queue = "ZTF_alerts_enrichment_queue".to_string();
         let output_queue = "ZTF_alerts_filter_queue".to_string();
+
+        debug!(input_queue = %input_queue, output_queue = %output_queue,
+            "ZTF Enrichment Worker configuration");
 
         // we load the ACAI models (same architecture, same input/output)
         let acai_h_model = AcaiModel::new("data/models/acai_h.d1_dnn_20201130.onnx")?;
@@ -408,13 +411,18 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
         self.output_queue.clone()
     }
 
-    #[instrument(skip_all, err)]
+    #[instrument(skip_all, fields(batch_size = candids.len()), err)]
     async fn process_alerts(
         &mut self,
         candids: &[i64],
     ) -> Result<Vec<String>, EnrichmentWorkerError> {
         let alerts: Vec<ZtfAlertForEnrichment> =
             fetch_alerts(&candids, &self.alert_pipeline, &self.alert_collection).await?;
+        debug!(
+            "fetched {} alerts for {} candids",
+            alerts.len(),
+            candids.len()
+        );
 
         if alerts.len() != candids.len() {
             warn!(
@@ -531,12 +539,13 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
         if let Some(babamul) = self.babamul.as_ref() {
             babamul.process_ztf_alerts(enriched_alerts).await?;
         }
-
+        debug!("processed {} alerts", processed_alerts.len());
         Ok(processed_alerts)
     }
 }
 
 impl ZtfEnrichmentWorker {
+    #[instrument(skip(self, alert), fields(candid = alert.candid), err)]
     async fn get_alert_properties(
         &self,
         alert: &ZtfAlertForEnrichment,

--- a/src/kafka/decam.rs
+++ b/src/kafka/decam.rs
@@ -2,7 +2,7 @@ use crate::{
     kafka::base::{AlertConsumer, AlertProducer},
     utils::{data::count_files_in_dir, enums::Survey},
 };
-use tracing::info;
+use tracing::{info, instrument};
 
 const DECAM_DEFAULT_NB_PARTITIONS: usize = 15;
 
@@ -72,6 +72,11 @@ impl AlertProducer for DecamAlertProducer {
     fn default_nb_partitions(&self) -> usize {
         DECAM_DEFAULT_NB_PARTITIONS
     }
+    #[instrument(skip(self), err, fields(
+        date = %self.date.format("%Y%m%d"),
+        server_url = %self.server_url,
+        limit = self.limit,
+    ))]
     async fn download_alerts_from_archive(&self) -> Result<i64, Box<dyn std::error::Error>> {
         // there is no public decam archive, so we just check if the directory exists
         let data_folder = self.data_directory();

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -133,6 +133,13 @@ impl AlertProducer for ZtfAlertProducer {
     fn default_nb_partitions(&self) -> usize {
         ZTF_DEFAULT_NB_PARTITIONS
     }
+    #[instrument(skip(self), err, fields(
+        date = %self.date.format("%Y%m%d"),
+        program_id = ?self.program_id,
+        server_url = %self.server_url,
+        working_dir = %self.working_dir,
+        limit = self.limit,
+    ))]
     async fn download_alerts_from_archive(&self) -> Result<i64, Box<dyn std::error::Error>> {
         let date_str = self.date.format("%Y%m%d").to_string();
         info!(


### PR DESCRIPTION
### Summary
This PR is a focused pass to add structured tracing/observability across BOOM’s API, scheduler, enrichment workers, and Kafka pipeline. The intent is to make it much easier to follow what the system is doing (per request/worker/alert) and to diagnose common “works on one machine but not another” issues (config, DB, Kafka, ONNX runtime/model loading). I tried to keep behavior the same wherever possible, most changes are instrumentation, context rich logs, and a small set of cleanup fixes found while rebasing/cherry-picking. This is mostly “wiring + spans” and not logic changes.
### What changed (grouped by area)
#### 1. Shared logging/tracing setup
- `src/utils/o11y/logging.rs`
    Centralizes tracing subscriber/log setup so all binaries (API, scheduler, Kafka tools) use the same initialization and produce consistent structured output.
#### 2. Config + startup visibility
- `src/conf.rs`  
    Adds tracing around config loading / config-derived setup so it’s easier to see _which config path_ was used and what the process thinks it should be doing.
- Entry points updated to consistently initialize observability early and carry context through startup:
    - `src/bin/api.rs`
    - `src/bin/scheduler.rs`
    - `src/bin/kafka_consumer.rs`
    - `src/bin/kafka_producer.rs`
    - `src/bin/add_filter.rs`        
#### 3. API: DB setup + request-level context
- `src/api/db.rs`  
    Adds trace context around DB creation and admin bootstrap logic. The goal is to make DB connectivity and “admin user exists/created” issues more obvious in logs.
- Core API modules updated for better trace context and error visibility:
    - `src/api/catalogs.rs`
    - `src/api/filters.rs`
    - `src/api/kafka.rs`
    - `src/api/email.rs` (clear “email disabled due to missing config” messaging)
    - `src/api/docs.rs` (OpenAPI/security-related visibility)
- Route handlers touched mainly to carry request context (and make failures easier to interpret):
    - `src/api/routes/auth.rs`
    - `src/api/routes/catalogs.rs`
    - `src/api/routes/filters.rs`
    - `src/api/routes/info.rs`
    - `src/api/routes/kafka.rs`
    - `src/api/routes/users.rs`
- Test scaffolding aligned with the updated wiring:    
    - `src/api/test_utils.rs`
#### 4. Auth cleanup + small correctness fix
- `src/api/auth.rs`  
    While doing the cleanup/rebase, I hit a build-breaking issue where token expiration/validation referenced the wrong config value (`validation.validate_exp` and `token_expiration` now use `auth_config.token_expiration`). This PR fixes that, and also adds better trace context around token creation and request authentication.  
    **Flag for review:** this file went through a lot of conflict resolution during the branch cleanup, so I’d appreciate reviewers sanity-checking the final behavior (especially around the async flow + middleware).    
#### 5. Enrichment workers and model diagnostics
- Worker instrumentation / clearer worker-loop context:
    - `src/enrichment/base.rs`
    - `src/enrichment/decam.rs`
    - `src/enrichment/ztf.rs`
    - `src/enrichment/lsst.rs`
- Model-related areas touched to make initialization failures easier to reason about:
    - `src/enrichment/models/acai.rs`
    - `src/enrichment/models/base.rs`
    - `src/enrichment/models/btsbot.rs`
- `src/enrichment/lsst.rs` also includes a small visibility change to fix a test access issue (a helper used by tests needed to be callable).  
    **Flag for review:** if you’d rather keep the method private and restructure the test (e.g., `cfg(test)` wrapper or moving the test), I’m happy to change it.    
#### 6. Kafka pipeline instrumentation
- Core consumer/producer loop context + error visibility:
    - `src/kafka/base.rs`
- Survey-specific Kafka support:
    - `src/kafka/ztf.rs`
    - `src/kafka/decam.rs`        
#### 7. Build/config housekeeping
- `.gitignore`
- `Cargo.toml`, `Cargo.lock`  
    Dependency/lock updates required by the new instrumentation wiring and rebuilds during cleanup.
---
### Tests I ran
- `cargo fmt` / `cargo fmt --check`
- `cargo test` / `cargo test --lib` 
- `pre-commit run --all-files` 
**Note:** `cargo clippy --all-targets -- -D warnings` currently fails on `upstream/main` due to warnings inside `apache-avro-macros`, so I didn’t treat that as a PR regression.
---
### Things I’d like reviewers to pay attention to
- `src/api/auth.rs`: final behavior after cleanup + conflict resolution (token expiration config usage + middleware flow).
- `src/enrichment/lsst.rs`: whether making the test helper callable is acceptable, or if you’d prefer a different testing approach.
- Overall log verbosity / any logging that should be toned down or have fields removed.
Happy to tweak any of this based on feedback.