### PR TITLE
Retention time per Survey

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,9 @@ babamul:
   enabled: false # Set via BOOM_BABAMUL__ENABLED environment variable
   webapp_url: # Set via BOOM_BABAMUL__WEBAPP_URL environment variable
   retention_days: 3
+  retention_days_by_survey: # Change these to override `retention_days`
+    ZTF: 3
+    LSST: 3
 redis:
   host: localhost
   port: 6379

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -380,6 +380,9 @@ pub struct BabamulConfig {
     /// Number of days to retain Kafka messages for Babamul topics
     #[serde(default = "default_babamul_retention_days")]
     pub retention_days: u32,
+    /// Optional per-survey retention settings (overrides retention_days)
+    #[serde(default)]
+    pub retention_days_by_survey: HashMap<Survey, u32>,
 }
 
 impl Default for BabamulConfig {
@@ -388,6 +391,7 @@ impl Default for BabamulConfig {
             enabled: false,
             webapp_url: None,
             retention_days: default_babamul_retention_days(),
+            retention_days_by_survey: HashMap::new(),
         }
     }
 }

--- a/src/enrichment/babamul.rs
+++ b/src/enrichment/babamul.rs
@@ -6,9 +6,10 @@ use crate::enrichment::lsst::{
     is_in_footprint, LsstAlertForEnrichment, LsstAlertProperties, IS_HOSTED_SCORE_THRESH,
 };
 use crate::enrichment::ztf::{ZtfAlertForEnrichment, ZtfAlertProperties};
-use crate::enrichment::EnrichmentWorkerError;
-use crate::utils::{derive_avro_schema::SerdavroWriter, lightcurves::Band};
-use apache_avro::{AvroSchema, DeflateSettings, Schema, Writer};
+use crate::enrichment::{EnrichmentWorkerError, LsstPhotometry, ZtfPhotometry};
+use crate::utils::derive_avro_schema::SerdavroWriter;
+use crate::utils::enums::Survey;
+use apache_avro::{AvroSchema, Schema, Writer};
 use apache_avro_macros::serdavro;
 use rdkafka::admin::{
     AdminClient, AdminOptions, AlterConfig, NewTopic, ResourceSpecifier, TopicReplication,
@@ -410,7 +411,8 @@ pub struct Babamul {
     lsst_avro_schema: Schema,
     ztf_avro_schema: Schema,
     kafka_admin_client: AdminClient<DefaultClientContext>,
-    topic_retention_ms: i64,
+    default_retention_ms: i64,
+    by_survey_retention_ms: HashMap<Survey, i64>,
     // A cache for Kafka topics we've checked exist and match retention policy
     checked_topics: Mutex<HashSet<String>>,
 }
@@ -449,15 +451,23 @@ impl Babamul {
             .expect("Failed to create Babamul Kafka admin client");
 
         // Compute retention in milliseconds from config (days)
-        let babamul_retention_ms: i64 =
+        let default_retention_ms: i64 =
             (config.babamul.retention_days as i64) * 24 * 60 * 60 * 1000;
+
+        // Build per-survey retention map
+        let mut by_survey_retention_ms = HashMap::new();
+        for (survey, days) in &config.babamul.retention_days_by_survey {
+            let retention_ms = (*days as i64) * 24 * 60 * 60 * 1000;
+            by_survey_retention_ms.insert(survey.clone(), retention_ms);
+        }
 
         Babamul {
             kafka_producer,
             lsst_avro_schema,
             ztf_avro_schema,
             kafka_admin_client: admin_client,
-            topic_retention_ms: babamul_retention_ms,
+            default_retention_ms,
+            by_survey_retention_ms,
             checked_topics: Mutex::new(HashSet::new()),
         }
     }
@@ -546,6 +556,31 @@ impl Babamul {
         }
     }
 
+    /// Extract the survey from a topic name
+    /// - "babamul.lsst.no-ztf-match.stellar" -> Some(Survey::Lsst)
+    /// - "other_topic" -> None
+    fn extract_survey_from_topic(topic_name: &str) -> Option<Survey> {
+        if topic_name.starts_with("babamul.lsst.") {
+            Some(Survey::Lsst)
+        } else if topic_name.starts_with("babamul.ztf.") {
+            Some(Survey::Ztf)
+        } else {
+            None
+        }
+    }
+
+    /// Get the retention period for a given topic based on its survey
+    fn get_retention_for_topic(&self, topic_name: &str) -> i64 {
+        if let Some(survey) = Self::extract_survey_from_topic(topic_name) {
+            self.by_survey_retention_ms
+                .get(&survey)
+                .copied()
+                .unwrap_or(self.default_retention_ms)
+        } else {
+            self.default_retention_ms
+        }
+    }
+
     /// Ensure the given topic exists with the desired retention policy
     #[instrument(skip_all, err)]
     async fn check_topic(&self, topic_name: &str) -> Result<(), EnrichmentWorkerError> {
@@ -558,7 +593,7 @@ impl Babamul {
         }
 
         // Create topic with retention if it does not exist; ignore "already exists" errors
-        let retention_ms_string = self.topic_retention_ms.to_string();
+        let retention_ms_string = self.get_retention_for_topic(topic_name).to_string();
         let new_topic = NewTopic::new(topic_name, 1, TopicReplication::Fixed(1))
             .set("retention.ms", &retention_ms_string)
             .set("cleanup.policy", "delete");

--- a/src/enrichment/babamul.rs
+++ b/src/enrichment/babamul.rs
@@ -6,10 +6,10 @@ use crate::enrichment::lsst::{
     is_in_footprint, LsstAlertForEnrichment, LsstAlertProperties, IS_HOSTED_SCORE_THRESH,
 };
 use crate::enrichment::ztf::{ZtfAlertForEnrichment, ZtfAlertProperties};
-use crate::enrichment::{EnrichmentWorkerError, LsstPhotometry, ZtfPhotometry};
-use crate::utils::derive_avro_schema::SerdavroWriter;
+use crate::enrichment::EnrichmentWorkerError;
 use crate::utils::enums::Survey;
-use apache_avro::{AvroSchema, Schema, Writer};
+use crate::utils::{derive_avro_schema::SerdavroWriter, lightcurves::Band};
+use apache_avro::{AvroSchema, DeflateSettings, Schema, Writer};
 use apache_avro_macros::serdavro;
 use rdkafka::admin::{
     AdminClient, AdminOptions, AlterConfig, NewTopic, ResourceSpecifier, TopicReplication,


### PR DESCRIPTION
This pull request introduces support for per-survey retention settings for Babamul Kafka topics, allowing different retention periods to be set for each survey (such as ZTF and LSST) in addition to the default retention period. 

Addresses #356