### PR TITLE
Babamul LSST alerts: remove ZTF associations if no public prv_candidates

### DIFF
--- a/src/enrichment/babamul.rs
+++ b/src/enrichment/babamul.rs
@@ -168,10 +168,17 @@ impl From<crate::enrichment::lsst::LsstMatch> for BabamulSurveyMatch {
 impl From<Option<crate::enrichment::lsst::LsstSurveyMatches>> for BabamulSurveyMatches {
     fn from(opt: Option<crate::enrichment::lsst::LsstSurveyMatches>) -> Self {
         match opt {
-            Some(lsst_matches) => BabamulSurveyMatches {
-                ztf: lsst_matches.ztf.map(|m| m.into()),
-                lsst: None, // Naturally, no LSST match for an LSST alert
-            },
+            Some(lsst_matches) => {
+                // for ztf matches, if we are left with an empty prv_candidates after filtering,
+                // then it means we have no public alert to share for that match and we should not include it in Babamul
+                BabamulSurveyMatches {
+                    ztf: lsst_matches
+                        .ztf
+                        .map(|m| m.into())
+                        .filter(|m: &BabamulSurveyMatch| !m.prv_candidates.is_empty()),
+                    lsst: None, // Naturally, no LSST match for an LSST alert
+                }
+            }
             None => BabamulSurveyMatches::default(),
         }
     }


### PR DESCRIPTION
In this PR:
* we don't include a ztf match in babamul - to an LSST alert - if there is no public alerts for it (prv_candidates is empty, after filtering by programid)
* add test case to test_compute_babamul_category_lsst that validates this logic

This is based on a recurring issue I ran into when using the babamul client, where an LSST object would end up in the `ztf-match` topic but the matching ZTF object has no public alerts, so we shouldn't tell folks about it (because its very confusing, you see theres a match but you have no detections)