### PR TITLE
SMTP service: allow authless

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,6 +36,10 @@ jobs:
       PROMETHEUS_HASHED_PASSWORD: ${{ secrets.PROMETHEUS_HASHED_PASSWORD }}
       KAFKA_ADMIN_PASSWORD: ${{ secrets.KAFKA_ADMIN_PASSWORD }}
       KAFKA_READONLY_PASSWORD: ${{ secrets.KAFKA_READONLY_PASSWORD }}
+      SMTP_SERVER: ${{ vars.SMTP_SERVER }}
+      SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+      SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -150,6 +150,11 @@ services:
       BOOM_DATABASE__HOST: mongo
       BOOM_DATABASE__USERNAME: ${BOOM_DATABASE__USERNAME:-mongoadmin}
       BOOM_BABAMUL__ENABLED: ${BOOM_BABAMUL__ENABLED:-false}
+      # SMTP config for email notifications
+      SMTP_SERVER: ${SMTP_SERVER:-}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-}
     networks:
       - boom
       - traefik-public

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -64,16 +64,13 @@ impl EmailService {
 
         // Build SMTP transport
         let mailer = match SmtpTransport::relay(&smtp_server.unwrap()) {
-            Ok(transport) => {
-                // If both username and password are provided, use credentials. Otherwise, try to connect without auth.
-                match (smtp_username, smtp_password) {
-                    (Some(username), Some(password)) => {
-                        let creds = Credentials::new(username, password);
-                        Some(transport.credentials(creds).build())
-                    }
-                    _ => Some(transport.build()),
+            Ok(transport) => match (smtp_username, smtp_password) {
+                (Some(username), Some(password)) => {
+                    let creds = Credentials::new(username, password);
+                    Some(transport.credentials(creds).build())
                 }
-            }
+                _ => Some(transport.build()),
+            },
             Err(e) => {
                 eprintln!("Failed to create SMTP transport: {}", e);
                 println!("Email service is DISABLED (SMTP transport creation failed)");

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -47,10 +47,8 @@ impl EmailService {
             .unwrap_or_else(|_| "noreply@boom.example.com".to_string());
 
         // If any SMTP config is missing, disable email
-        if smtp_username.is_none() || smtp_password.is_none() || smtp_server.is_none() {
-            println!(
-                "Email service is DISABLED (missing SMTP configuration: SMTP_USERNAME, SMTP_PASSWORD, or SMTP_SERVER)"
-            );
+        if smtp_server.is_none() {
+            println!("Email service is DISABLED (missing SMTP configuration: SMTP_SERVER)");
             return Self {
                 mailer: None,
                 from_address,
@@ -58,11 +56,24 @@ impl EmailService {
             };
         }
 
-        // Build SMTP transport
-        let creds = Credentials::new(smtp_username.unwrap(), smtp_password.unwrap());
+        // If we have SMTP server but missing username/password, we will try to connect without auth (some servers allow this)
+        // But, let's log a warning if username/password are missing, as this is often a misconfiguration
+        if smtp_username.is_none() || smtp_password.is_none() {
+            println!("WARNING: SMTP_USERNAME or SMTP_PASSWORD is not set. Attempting to connect without authentication. This may fail if your SMTP server requires auth.");
+        }
 
+        // Build SMTP transport
         let mailer = match SmtpTransport::relay(&smtp_server.unwrap()) {
-            Ok(transport) => Some(transport.credentials(creds).build()),
+            Ok(transport) => {
+                // If both username and password are provided, use credentials. Otherwise, try to connect without auth.
+                match (smtp_username, smtp_password) {
+                    (Some(username), Some(password)) => {
+                        let creds = Credentials::new(username, password);
+                        Some(transport.credentials(creds).build())
+                    }
+                    _ => Some(transport.build()),
+                }
+            }
             Err(e) => {
                 eprintln!("Failed to create SMTP transport: {}", e);
                 println!("Email service is DISABLED (SMTP transport creation failed)");


### PR DESCRIPTION
As the title says :) It's not uncommon to use an authless smtp setup (for example our prod machine can send emails with the caltech astro smtp server, and that requires no auth since it only works for machines on the network).