### PR TITLE
Babamul API: password reset flow

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -220,6 +220,8 @@ const BABAMUL_PUBLIC_ROUTES: &[&str] = &[
     "/babamul/signup",
     "/babamul/activate",
     "/babamul/auth",
+    "/babamul/forgot-password",
+    "/babamul/reset-password",
     "/babamul/surveys/lsst/schemas",
     "/babamul/surveys/ztf/schemas",
     "/babamul/docs",

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -9,6 +9,7 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use mongodb::bson::doc;
 use mongodb::Database;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -272,7 +273,6 @@ pub async fn babamul_auth_middleware(
             // Check if this is a personal access token (PAT)
             if token.starts_with("bbml_") {
                 // Handle PAT authentication
-                use sha2::{Digest, Sha256};
 
                 // Validate token length to prevent slicing panics.
                 // Expected format: "bbml_" (5 chars) + 36-char secret = 41 chars total.

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -92,6 +92,8 @@ pub struct ApiDoc;
         routes::babamul::post_babamul_signup,
         routes::babamul::post_babamul_activate,
         routes::babamul::post_babamul_auth,
+        routes::babamul::post_babamul_forgot_password,
+        routes::babamul::post_babamul_reset_password,
         routes::babamul::get_babamul_profile,
         routes::babamul::post_kafka_credentials,
         routes::babamul::get_kafka_credentials,

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -32,7 +32,7 @@ impl EmailService {
             .unwrap_or(true);
 
         if !enabled {
-            println!("Email service is DISABLED (EMAIL_ENABLED=false)");
+            tracing::info!("Email service is DISABLED (EMAIL_ENABLED=false)");
             return Self {
                 mailer: None,
                 from_address: String::new(),
@@ -49,7 +49,7 @@ impl EmailService {
 
         // If any SMTP config is missing, disable email
         if smtp_server.is_none() {
-            println!("Email service is DISABLED (missing SMTP configuration: SMTP_SERVER)");
+            tracing::info!("Email service is DISABLED (missing SMTP configuration: SMTP_SERVER)");
             return Self {
                 mailer: None,
                 from_address,
@@ -73,8 +73,10 @@ impl EmailService {
                         Some(transport.port(port).credentials(creds).build())
                     }
                     Err(e) => {
-                        eprintln!("Failed to create SMTP transport: {}", e);
-                        println!("Email service is DISABLED (SMTP transport creation failed)");
+                        tracing::error!("Failed to create SMTP transport: {}", e);
+                        tracing::info!(
+                            "Email service is DISABLED (SMTP transport creation failed)"
+                        );
                         return Self {
                             mailer: None,
                             from_address,
@@ -86,7 +88,7 @@ impl EmailService {
             _ => {
                 // No credentials: use plain unauthenticated SMTP (port 25 by default)
                 let port = smtp_port.unwrap_or(25);
-                println!(
+                tracing::info!(
                     "SMTP_USERNAME/SMTP_PASSWORD not set — using unauthenticated plain SMTP on port {}.",
                     port
                 );
@@ -98,7 +100,7 @@ impl EmailService {
             }
         };
 
-        println!("Email service is ENABLED (SMTP configured)");
+        tracing::info!("Email service is ENABLED (SMTP configured)");
         Self {
             mailer,
             from_address,

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -311,7 +311,8 @@ impl EmailService {
                             border-radius:8px;font-size:13px;line-height:1.6;
                             overflow-x:auto;white-space:pre-wrap;word-break:break-all;margin:0 0 8px;">curl -X POST https://{domain}/babamul/reset-password \
      -H 'Content-Type: application/json' \
-     -d '{{"token":"{token}","new_password":"YOUR_NEW_PASSWORD"}}'</pre>"#,
+     -d '{{"email":"{email}","token":"{token}","new_password":"YOUR_NEW_PASSWORD"}}'</pre>"#,
+                email = to_email,
                 domain = domain,
                 token = raw_token,
             )

--- a/src/api/filters.rs
+++ b/src/api/filters.rs
@@ -130,7 +130,7 @@ pub fn doc2json(docs: Vec<Document>) -> Vec<serde_json::Value> {
         .filter_map(|doc| match serde_json::to_value(doc) {
             Ok(value) => Some(value),
             Err(e) => {
-                println!("Serialization error: {}", e); // TODO: replace with tracing once integrated
+                tracing::error!("Serialization error: {}", e); // TODO: replace with tracing once integrated
                 None
             }
         })

--- a/src/api/kafka.rs
+++ b/src/api/kafka.rs
@@ -294,9 +294,10 @@ pub async fn delete_acls_for_username(
 
     if !errors.is_empty() {
         let combined = errors.join("; ");
-        eprintln!(
+        tracing::error!(
             "Error deleting ACLs for user {}: {}",
-            kafka_username, combined
+            kafka_username,
+            combined
         );
         return Err(format!(
             "Failed to delete ACLs for user {}: {}",
@@ -346,7 +347,7 @@ pub async fn delete_kafka_credentials_and_acls(
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             // Log the error but don't fail if the user doesn't exist
-            eprintln!(
+            tracing::error!(
                 "Note: SCRAM user deletion may have failed (user may not exist): {}",
                 stderr
             );

--- a/src/api/models/response.rs
+++ b/src/api/models/response.rs
@@ -55,7 +55,7 @@ pub fn ok_ser<T: serde::Serialize>(message: &str, data: T) -> HttpResponse {
     match serde_json::to_value(data) {
         Ok(data_value) => HttpResponse::Ok().json(ApiResponseBody::ok(message, data_value)),
         Err(e) => {
-            println!("Serialization error: {}", e); // TODO: replace with tracing once integrated
+            tracing::info!("Serialization error: {}", e); // TODO: replace with tracing once integrated
             HttpResponse::InternalServerError()
                 .json(ApiResponseBody::error("Failed to serialize response data"))
         }

--- a/src/api/routes/babamul/mod.rs
+++ b/src/api/routes/babamul/mod.rs
@@ -9,6 +9,7 @@ use mongodb::bson::doc;
 use mongodb::Database;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
+use sha2::{Digest, Sha256};
 use std::process::Command;
 use utoipa::ToSchema;
 
@@ -819,7 +820,6 @@ pub async fn post_babamul_forgot_password(
     };
 
     // Generate a secure random raw token and store its SHA-256 hash.
-    use sha2::{Digest, Sha256};
     let raw_token = generate_random_string(48);
     let mut hasher = Sha256::new();
     hasher.update(raw_token.as_bytes());
@@ -915,7 +915,6 @@ pub async fn post_babamul_reset_password(
     }
 
     // Hash the incoming token to look it up in the database.
-    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(raw_token.as_bytes());
     let token_hash = format!("{:x}", hasher.finalize());

--- a/src/api/routes/queries/find.rs
+++ b/src/api/routes/queries/find.rs
@@ -93,7 +93,7 @@ pub async fn post_find_query(db: web::Data<Database>, body: web::Json<FindQuery>
         match result {
             Ok(doc) => docs.push(doc),
             Err(e) => {
-                eprintln!("Error retrieving document from the database: {}", e);
+                tracing::error!("Error retrieving document from the database: {}", e);
                 return response::internal_error("Error retrieving document from the database");
             }
         }

--- a/src/api/routes/queries/pipeline.rs
+++ b/src/api/routes/queries/pipeline.rs
@@ -68,7 +68,7 @@ pub async fn post_pipeline_query(
         match result {
             Ok(doc) => docs.push(doc),
             Err(e) => {
-                eprintln!("Error retrieving document from the database: {}", e);
+                tracing::error!("Error retrieving document from the database: {}", e);
                 return response::internal_error("Error retrieving document from the database");
             }
         }

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -26,9 +26,9 @@ async fn main() -> std::io::Result<()> {
 
     let babamul_is_enabled = config.babamul.enabled;
     if babamul_is_enabled {
-        println!("Babamul API endpoints are ENABLED");
+        tracing::info!("Babamul API endpoints are ENABLED");
     } else {
-        println!("Babamul API endpoints are DISABLED");
+        tracing::info!("Babamul API endpoints are DISABLED");
     }
 
     // Create API docs from OpenAPI spec

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -55,6 +55,8 @@ async fn main() -> std::io::Result<()> {
                     .service(routes::babamul::post_babamul_signup)
                     .service(routes::babamul::post_babamul_activate)
                     .service(routes::babamul::post_babamul_auth)
+                    .service(routes::babamul::post_babamul_forgot_password)
+                    .service(routes::babamul::post_babamul_reset_password)
                     // Protected routes
                     .service(routes::babamul::get_babamul_profile)
                     .service(routes::babamul::post_kafka_credentials)

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -380,6 +380,9 @@ pub struct BabamulConfig {
     /// Number of days to retain Kafka messages for Babamul topics
     #[serde(default = "default_babamul_retention_days")]
     pub retention_days: u32,
+    /// Minimum number of minutes that must elapse between successive password resets (default: 15)
+    #[serde(default = "default_password_reset_cooldown_minutes")]
+    pub password_reset_cooldown_minutes: u32,
 }
 
 impl Default for BabamulConfig {
@@ -388,12 +391,17 @@ impl Default for BabamulConfig {
             enabled: false,
             webapp_url: None,
             retention_days: default_babamul_retention_days(),
+            password_reset_cooldown_minutes: default_password_reset_cooldown_minutes(),
         }
     }
 }
 
 fn default_babamul_retention_days() -> u32 {
     3
+}
+
+fn default_password_reset_cooldown_minutes() -> u32 {
+    15
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
solves #395 

* add /reset-password and /forgot-password endpoints to babamul's API, to enable passwort reset workflows (with an email being sent)
* add unit tests to cover all paths

The password reset email looks like this:

<img width="628" height="680" alt="image" src="https://github.com/user-attachments/assets/fa3cb6ba-0b80-4105-b9d4-17bf04017751" />

Note:
- I only require the password to be at least 8 characters long. We could be more clever about this (best would be to have a list of common passwords we don't allow folks to use, there are a couple of these online)
