### PR TITLE
ZTF Avro: fallback

### DIFF
--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -196,6 +196,8 @@ pub enum SchemaRegistryError {
 pub enum AlertError {
     #[error("error from avro")]
     Avro(#[from] apache_avro::Error),
+    #[error("no records in avro data")]
+    AvroNoRecords,
     #[error("value access error from bson")]
     BsonValueAccess(#[from] mongodb::bson::document::ValueAccessError),
     #[error("error from mongodb")]
@@ -580,12 +582,17 @@ impl SchemaCache {
                 let (schema, startidx) =
                     get_schema_and_startidx(avro_bytes).inspect_err(as_error!())?;
 
-                // if it's not an error this time, cache the new schema
-                // otherwise return the error
-                let value = from_avro_datum(&schema, &mut &avro_bytes[startidx..], None)
-                    .inspect_err(as_error!())?;
+                // try deserializing again with the schemaless approach
+                let reader = apache_avro::Reader::new(&avro_bytes[startidx..])?;
+
+                let value = reader
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| AlertError::AvroNoRecords)??;
+
                 self.cached_schema = Some(schema);
                 self.cached_start_idx = Some(startidx);
+
                 value
             }
         };

--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -496,10 +496,8 @@ impl SchemaRegistry {
         }
 
         // Finally, resolve all references to get the full - independent - canonical schema
-        let (schema, schemas) = apache_avro::schema::Schema::parse_str_with_list(
-            &schema_str,
-            schema_strs.iter().map(|s| s.as_str()),
-        )?;
+        let (schema, schemas) =
+            Schema::parse_str_with_list(&schema_str, schema_strs.iter().map(|s| s.as_str()))?;
         let canonical_schema_str = schema.independent_canonical_form(&schemas)?;
         let schema = Schema::parse_str(&canonical_schema_str).inspect_err(as_error!(
             "failed to parse resolved alert schema from github"
@@ -582,8 +580,8 @@ impl SchemaCache {
                 let (schema, startidx) =
                     get_schema_and_startidx(avro_bytes).inspect_err(as_error!())?;
 
-                // try deserializing again with the schemaless approach
-                let reader = apache_avro::Reader::new(&avro_bytes[startidx..])?;
+                // Retry deserializing by using apache_avro::Reader with the schemaless approach
+                let reader = Reader::new(&avro_bytes[..])?;
 
                 let value = reader
                     .into_iter()


### PR DESCRIPTION
One thing that @antoine-le-calloch and I noticed is that every now and then, our "fast" avro implementation in boom (where we attempt to use a cached schema rather than re-infer it everytime, which saves a lot of time) fails. Right now the fallbacj for this is to try to re-infer the schema, cache it, and try again with the same method. But clearly, some alerts are more stubborn than others and the cached schema approach we have simply fails (even with that retry).

In this PR, when we encounter a failure we do still update the cached schema (caus that could happen if there is a schema change for example, unlikely but of well...) but we use the built in avro reader to make sure we can read the alert (unless it's invalid of coiurse). We know from experience (that was the prior implementation, slow but secure) that this always works when it should.

PS: What made me go back to this was a user flagging an object we were missing in prod, and while I am not sure this is why, might as well fix this once and for all.