### PR TITLE
Enrichment: Legacy SNR fallback fix

### DIFF
--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -37,8 +37,11 @@ pub struct ZtfAlertPhotometry {
     pub band: Band,
     pub ra: Option<f64>,
     pub dec: Option<f64>,
-    #[serde(alias = "snr")]
     pub snr_psf: Option<f64>,
+    /// Legacy fallback: populated from the `snr` field for un-migrated documents that pre-date the snr migration.
+    #[allow(dead_code)]
+    #[serde(rename = "snr", default, skip_serializing)]
+    pub snr_legacy: Option<f64>,
     pub programid: i32,
 }
 
@@ -61,8 +64,11 @@ pub struct ZtfForcedPhotometry {
     pub magzpsci: Option<f64>,
     pub ra: Option<f64>,
     pub dec: Option<f64>,
-    #[serde(alias = "snr")]
     pub snr_psf: Option<f64>,
+    /// Legacy fallback: populated from the `snr` field for un-migrated documents that pre-date the snr migration.
+    #[allow(dead_code)]
+    #[serde(rename = "snr", default, skip_serializing)]
+    pub snr_legacy: Option<f64>,
     pub programid: i32,
     pub procstatus: Option<String>,
 }
@@ -83,7 +89,6 @@ pub struct ZtfPhotometry {
     pub band: Band,
     pub ra: Option<f64>,
     pub dec: Option<f64>,
-    #[serde(alias = "snr")]
     pub snr_psf: Option<f64>,
     pub programid: i32,
 }
@@ -101,7 +106,7 @@ impl TryFrom<ZtfAlertPhotometry> for ZtfPhotometry {
             ra: phot.ra,
             dec: phot.dec,
             band: phot.band,
-            snr_psf: phot.snr_psf,
+            snr_psf: phot.snr_psf.or(phot.snr_legacy),
             programid: phot.programid,
         })
     }
@@ -146,7 +151,7 @@ impl TryFrom<ZtfForcedPhotometry> for ZtfPhotometry {
             ra: phot.ra,
             dec: phot.dec,
             band: phot.band,
-            snr_psf: phot.snr_psf,
+            snr_psf: phot.snr_psf.or(phot.snr_legacy),
             programid: phot.programid,
         })
     }

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -127,6 +127,7 @@ fn create_mock_enriched_ztf_alert(candid: i64, object_id: &str, is_rock: bool) -
         flux: Some(flux),
         flux_err: flux_err,
         snr_psf: Some(100.0),
+        snr_legacy: None,
         band: Band::G,
         ra: Some(150.0),
         dec: Some(30.0),


### PR DESCRIPTION
We used to have an `snr` field on ZTF photometry arrays (prv candidates and fp_hists), that is now called `snr_psf`. The migration adds the new field but does not remove the old one, and we had this serde alias macro set on top of `snr_psf`, so that we could read in `snr` to populate `snr_psf` if that was missing from the DB (e.g. on a DB that has not been migrated yet).

Issue is, for migrated documents  that now have snr and snr_psf, this created this serde+mongo error: "duplicated field: snr_psf".

This PR removes the serde alias and use a secondary field for the fallback to the old snr (if the new field hasn't been added to old data yet - e.g. if the migration did not finish - in code we use that old field rather than the new one that may be missing).

BTW, all this is useless once the migration is ran, so we may just remove this later if we'd like (if we know all prod systems have been updated).