### PR TITLE
Kafka consumer: default date (and time) bugfix 

### DIFF
--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -79,7 +79,10 @@ fn parse_date(s: &str) -> Result<NaiveDateTime, String> {
 
 #[instrument(skip_all, fields(survey = %args.survey))]
 async fn run(args: Cli, meter_provider: SdkMeterProvider) {
-    let date = args.date.unwrap_or_else(|| chrono::Utc::now().naive_utc());
+    let date = args.date.unwrap_or_else(|| {
+        let today = chrono::Utc::now().naive_utc().date();
+        today.and_hms_opt(0, 0, 0).unwrap()
+    });
     let timestamp = date.and_utc().timestamp();
 
     let exit_on_eof = if args.deployment_env == "dev" {


### PR DESCRIPTION
fix the date's default value, which time component was not set at 00:00:00 (but current time).