### PR TITLE
ZtfAliases: use serdavro macro

### DIFF
--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -636,7 +636,8 @@ where
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, AvroSchema, ToSchema, Default)]
+#[serdavro]
+#[derive(Debug, Deserialize, Serialize, ToSchema, Default)]
 pub struct ZtfAliases {
     #[serde(rename = "LSST")]
     pub lsst: Vec<String>,


### PR DESCRIPTION
use serdavro macro on ZtfAliases, for the renames to take effect in t…he schema sent out from the API. Currently, the `lsst` and `ztf` fields are not renamed to their capitalized version as instructed by the serde decorator (since the basic AvroSchema trait doesn't do that and we need our custom macro).