### PR TITLE
Make sure NED catalog is populated in throughput test

### DIFF
--- a/tests/throughput/_run.sh
+++ b/tests/throughput/_run.sh
@@ -186,6 +186,50 @@ echo "$(current_datetime) - All alerts ingested, classified, and filtered"
 echo "$(current_datetime) - Reading from Kafka output topic"
 python $BOOM_REPO_ROOT/tests/throughput/read-kafka-output.py
 
+# Export collection stats to JSON for analysis
+echo "$(current_datetime) - Collecting MongoDB collection stats"
+MONGO_RESULT="$({
+	docker compose "${COMPOSE_CONFIG[@]}" exec -T mongo \
+		mongosh "mongodb://mongoadmin:mongoadminsecret@localhost:27017/admin?authSource=admin" \
+		--quiet \
+		--eval '
+const dbName = "boom-benchmarking";
+const d = db.getSiblingDB(dbName);
+function collectionStats(name) {
+	const c = d.getCollection(name);
+	const s = c.stats();
+  return {
+	collection: name,
+	count: c.countDocuments(),
+	data_size_bytes: s.size,
+	storage_size_bytes: s.storageSize,
+	total_index_size_bytes: s.totalIndexSize,
+	total_size_bytes: s.totalSize
+  };
+}
+const collectionNames = d
+	.getCollectionInfos({ type: "collection" })
+	.map((info) => info.name)
+	.sort();
+const out = {
+  generated_at_utc: new Date().toISOString(),
+  database: dbName,
+  collections: collectionNames.map(collectionStats)
+};
+print(JSON.stringify(out));
+'
+} | tail -n 1)"
+
+if [ -n "$MONGO_RESULT" ]; then
+	mkdir -p "$LOGS_DIR"
+	if command -v jq >/dev/null 2>&1; then
+		printf '%s\n' "$MONGO_RESULT" | jq . > "$LOGS_DIR/collection_stats.json"
+	else
+		printf '%s\n' "$MONGO_RESULT" > "$LOGS_DIR/collection_stats.json"
+	fi
+	echo "$(current_datetime) - Wrote collection stats to $LOGS_DIR/collection_stats.json"
+fi
+
 # Check to see if any of our containers have exited with a non-zero status,
 # which would indicate an error
 EXIT_CODE=$(docker compose "${COMPOSE_CONFIG[@]}" ps -aq | xargs docker inspect -f '{{.State.ExitCode}}' | grep -v '^0$' || true)

--- a/tests/throughput/mongo-init.sh
+++ b/tests/throughput/mongo-init.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Only import NED alerts if the collection does not exist
+NED_EXPECTED_COUNT=1872544
+
+# Only import NED alerts if the collection does not exist or has the wrong count
 NED_COLLECTION_NAME="NED"
 NED_COLLECTION_EXISTS=$(mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" --quiet --eval "db.getCollectionNames().includes('$NED_COLLECTION_NAME')")
 NED_COLLECTION_COUNT=0
@@ -8,11 +10,11 @@ if [ "$NED_COLLECTION_EXISTS" = "true" ]; then
     NED_COLLECTION_COUNT=$(mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" --quiet --eval "db.getCollection('$NED_COLLECTION_NAME').countDocuments()")
 fi
 echo "NED collection exists: $NED_COLLECTION_EXISTS"
-echo "NED collection count: $NED_COLLECTION_COUNT"
+echo "NED collection count: $NED_COLLECTION_COUNT (expected $NED_EXPECTED_COUNT)"
 
-if [ "$NED_COLLECTION_EXISTS" = "false" ] || [ "${NED_COLLECTION_COUNT:-0}" -eq 0 ]; then
+if [ "$NED_COLLECTION_EXISTS" = "false" ] || [ "${NED_COLLECTION_COUNT:-0}" -ne "$NED_EXPECTED_COUNT" ]; then
     if [ "$NED_COLLECTION_EXISTS" = "true" ]; then
-        echo "NED collection exists but is empty; dropping and reimporting"
+        echo "NED collection exists but has wrong count ($NED_COLLECTION_COUNT != $NED_EXPECTED_COUNT); dropping and reimporting"
         mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" \
             --quiet --eval "db.$NED_COLLECTION_NAME.drop()"
     fi
@@ -33,12 +35,12 @@ if [ "$NED_COLLECTION_EXISTS" = "false" ] || [ "${NED_COLLECTION_COUNT:-0}" -eq 
         --jsonArray
 
     NED_COLLECTION_COUNT=$(mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" --quiet --eval "db.getCollection('$NED_COLLECTION_NAME').countDocuments()")
-    if [ "${NED_COLLECTION_COUNT:-0}" -le 0 ]; then
-        echo "Failed to import NED alerts into $DB_NAME; collection is empty"
+    if [ "${NED_COLLECTION_COUNT:-0}" -ne "$NED_EXPECTED_COUNT" ]; then
+        echo "Failed to import NED alerts: expected $NED_EXPECTED_COUNT documents but got $NED_COLLECTION_COUNT"
         exit 1
     fi
 else
-    echo "NED alerts already imported; skipping import"
+    echo "NED alerts already imported with correct count ($NED_COLLECTION_COUNT); skipping import"
 fi
 
 # Always drop ZTF_alerts, ZTF_alerts_aux, ZTF_alerts_cutouts, and filters collections

--- a/tests/throughput/mongo-init.sh
+++ b/tests/throughput/mongo-init.sh
@@ -3,9 +3,20 @@
 # Only import NED alerts if the collection does not exist
 NED_COLLECTION_NAME="NED"
 NED_COLLECTION_EXISTS=$(mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" --quiet --eval "db.getCollectionNames().includes('$NED_COLLECTION_NAME')")
+NED_COLLECTION_COUNT=0
+if [ "$NED_COLLECTION_EXISTS" = "true" ]; then
+    NED_COLLECTION_COUNT=$(mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" --quiet --eval "db.getCollection('$NED_COLLECTION_NAME').countDocuments()")
+fi
 echo "NED collection exists: $NED_COLLECTION_EXISTS"
+echo "NED collection count: $NED_COLLECTION_COUNT"
 
-if [ "$NED_COLLECTION_EXISTS" = "false" ]; then
+if [ "$NED_COLLECTION_EXISTS" = "false" ] || [ "${NED_COLLECTION_COUNT:-0}" -eq 0 ]; then
+    if [ "$NED_COLLECTION_EXISTS" = "true" ]; then
+        echo "NED collection exists but is empty; dropping and reimporting"
+        mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" \
+            --quiet --eval "db.$NED_COLLECTION_NAME.drop()"
+    fi
+
     echo "Creating collection $NED_COLLECTION_NAME"
     mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" \
         --eval "db.createCollection('$NED_COLLECTION_NAME')"
@@ -20,6 +31,12 @@ if [ "$NED_COLLECTION_EXISTS" = "false" ]; then
         "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin$DB_ADD_URI" \
         --collection $NED_COLLECTION_NAME \
         --jsonArray
+
+    NED_COLLECTION_COUNT=$(mongosh "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin" --quiet --eval "db.getCollection('$NED_COLLECTION_NAME').countDocuments()")
+    if [ "${NED_COLLECTION_COUNT:-0}" -le 0 ]; then
+        echo "Failed to import NED alerts into $DB_NAME; collection is empty"
+        exit 1
+    fi
 else
     echo "NED alerts already imported; skipping import"
 fi


### PR DESCRIPTION
Just to be safe, following the aux import logic. We also export collection stats to JSON at the end of the run per the paper reviewer's request.