### PR TITLE
Filter worker(s): periodic active filters refresh

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,6 +43,7 @@ kafka:
 workers:
   ztf:
     command_interval: 500
+    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 3
     enrichment:
@@ -51,6 +52,7 @@ workers:
       n_workers: 3
   lsst:
     command_interval: 500
+    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 4
     enrichment:
@@ -59,6 +61,7 @@ workers:
       n_workers: 1
   decam:
     command_interval: 500
+    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:

--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -1069,6 +1069,8 @@ pub enum AlertWorkerError {
     Redis(#[from] redis::RedisError),
     #[error("failed to get avro bytes from the alert queue")]
     GetAvroBytesError,
+    #[error("worker config missing for survey: {0}")]
+    WorkerConfigMissing(Survey),
 }
 
 #[async_trait::async_trait]
@@ -1076,7 +1078,7 @@ pub trait AlertWorker {
     async fn new(config_path: &str) -> Result<Self, AlertWorkerError>
     where
         Self: Sized;
-    fn stream_name(&self) -> String;
+    fn survey() -> Survey;
     fn input_queue_name(&self) -> String;
     fn output_queue_name(&self) -> String;
     #[instrument(skip(self, alert, collection), err)]
@@ -1333,10 +1335,10 @@ pub trait AlertWorker {
 }
 
 #[instrument(skip_all)]
-fn report_progress(start: &Instant, stream: &str, count: u64, message: &str) {
+fn report_progress(start: &Instant, stream: &Survey, count: u64, message: &str) {
     let elapsed = start.elapsed().as_secs();
     info!(
-        stream,
+        ?stream,
         count,
         elapsed,
         average_rate = count as f64 / elapsed as f64,
@@ -1405,9 +1407,13 @@ pub async fn run_alert_worker<T: AlertWorker>(
 ) -> Result<(), AlertWorkerError> {
     debug!(?config_path);
     let config = AppConfig::from_path(config_path)?;
+    let survey = T::survey();
+    let worker_config = config
+        .workers
+        .get(&survey)
+        .ok_or(AlertWorkerError::WorkerConfigMissing(survey.clone()))?;
 
     let mut alert_processor = T::new(config_path).await?;
-    let stream_name = alert_processor.stream_name();
 
     let input_queue_name = alert_processor.input_queue_name();
     let temp_queue_name = format!("{}_temp", input_queue_name);
@@ -1418,7 +1424,7 @@ pub async fn run_alert_worker<T: AlertWorker>(
         .await
         .inspect_err(as_error!("failed to create redis client"))?;
 
-    let command_interval: usize = 500;
+    let command_interval: usize = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
     let mut count = 0;
 
@@ -1507,10 +1513,10 @@ pub async fn run_alert_worker<T: AlertWorker>(
 
         handle_result?;
         if count > 0 && count % 1000 == 0 {
-            report_progress(&start, &stream_name, count, "progress");
+            report_progress(&start, &survey, count, "progress");
         }
         count += 1;
     }
-    report_progress(&start, &stream_name, count, "summary");
+    report_progress(&start, &survey, count, "summary");
     Ok(())
 }

--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -1461,13 +1461,13 @@ pub async fn run_alert_worker<T: AlertWorker>(
         if command_check_countdown == 0 {
             if should_terminate(&mut receiver) {
                 break;
-            } else {
-                command_check_countdown = command_interval + 1;
             }
+            command_check_countdown = command_interval;
         }
-        command_check_countdown -= 1;
 
         ACTIVE.add(1, &active_attrs);
+
+        command_check_countdown -= 1;
         let result = retrieve_avro_bytes(&mut con, &input_queue_name, &temp_queue_name).await;
 
         let avro_bytes = match result {

--- a/src/alert/decam.rs
+++ b/src/alert/decam.rs
@@ -205,7 +205,6 @@ struct AlertAuxForUpdate {
 }
 
 pub struct DecamAlertWorker {
-    stream_name: String,
     xmatch_configs: Vec<conf::CatalogXmatchConfig>,
     db: mongodb::Database,
     alert_collection: mongodb::Collection<DecamAlert>,
@@ -381,7 +380,6 @@ impl AlertWorker for DecamAlertWorker {
             db.collection(&lsst::ALERT_AUX_COLLECTION);
 
         let worker = DecamAlertWorker {
-            stream_name: STREAM_NAME.to_string(),
             xmatch_configs,
             db,
             alert_collection,
@@ -395,16 +393,16 @@ impl AlertWorker for DecamAlertWorker {
         Ok(worker)
     }
 
-    fn stream_name(&self) -> String {
-        self.stream_name.clone()
+    fn survey() -> Survey {
+        Survey::Decam
     }
 
     fn input_queue_name(&self) -> String {
-        format!("{}_alerts_packets_queue", self.stream_name)
+        format!("{}_alerts_packets_queue", DecamAlertWorker::survey())
     }
 
     fn output_queue_name(&self) -> String {
-        format!("{}_alerts_enrichment_queue", self.stream_name)
+        format!("{}_alerts_enrichment_queue", DecamAlertWorker::survey())
     }
 
     async fn process_alert(&mut self, avro_bytes: &[u8]) -> Result<ProcessAlertStatus, AlertError> {

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -889,7 +889,6 @@ struct AlertAuxForUpdate {
 }
 
 pub struct LsstAlertWorker {
-    stream_name: String,
     schema_registry: SchemaRegistry,
     xmatch_configs: Vec<conf::CatalogXmatchConfig>,
     db: mongodb::Database,
@@ -1091,7 +1090,6 @@ impl AlertWorker for LsstAlertWorker {
             db.collection(&decam::ALERT_AUX_COLLECTION);
 
         let worker = LsstAlertWorker {
-            stream_name: STREAM_NAME.to_string(),
             schema_registry: SchemaRegistry::new(
                 Survey::Lsst,
                 schema_registry_url,
@@ -1109,16 +1107,16 @@ impl AlertWorker for LsstAlertWorker {
         Ok(worker)
     }
 
-    fn stream_name(&self) -> String {
-        self.stream_name.clone()
+    fn survey() -> Survey {
+        Survey::Lsst
     }
 
     fn input_queue_name(&self) -> String {
-        format!("{}_alerts_packets_queue", self.stream_name)
+        format!("{}_alerts_packets_queue", LsstAlertWorker::survey())
     }
 
     fn output_queue_name(&self) -> String {
-        format!("{}_alerts_enrichment_queue", self.stream_name)
+        format!("{}_alerts_enrichment_queue", LsstAlertWorker::survey())
     }
 
     #[instrument(skip_all, err)]

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -696,7 +696,6 @@ struct AlertAuxForUpdate {
 }
 
 pub struct ZtfAlertWorker {
-    stream_name: String,
     xmatch_configs: Vec<conf::CatalogXmatchConfig>,
     db: mongodb::Database,
     alert_collection: mongodb::Collection<ZtfAlert>,
@@ -922,7 +921,6 @@ impl AlertWorker for ZtfAlertWorker {
             db.collection(&decam::ALERT_AUX_COLLECTION);
 
         let worker = ZtfAlertWorker {
-            stream_name: STREAM_NAME.to_string(),
             xmatch_configs,
             db,
             alert_collection,
@@ -936,16 +934,16 @@ impl AlertWorker for ZtfAlertWorker {
         Ok(worker)
     }
 
-    fn stream_name(&self) -> String {
-        self.stream_name.clone()
+    fn survey() -> Survey {
+        Survey::Ztf
     }
 
     fn input_queue_name(&self) -> String {
-        format!("{}_alerts_packets_queue", self.stream_name)
+        format!("{}_alerts_packets_queue", ZtfAlertWorker::survey())
     }
 
     fn output_queue_name(&self) -> String {
-        format!("{}_alerts_enrichment_queue", self.stream_name)
+        format!("{}_alerts_enrichment_queue", ZtfAlertWorker::survey())
     }
 
     #[instrument(skip_all, err)]

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -409,9 +409,15 @@ pub struct WorkerConfig {
     pub n_workers: usize,
 }
 
+fn default_filter_refresh_interval_minutes() -> u64 {
+    15
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct SurveyWorkerConfig {
     pub command_interval: u64,
+    #[serde(default = "default_filter_refresh_interval_minutes")]
+    pub filter_refresh_interval_minutes: u64,
     pub alert: WorkerConfig,
     pub enrichment: WorkerConfig,
     pub filter: WorkerConfig,

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -415,7 +415,7 @@ fn default_filter_refresh_interval_minutes() -> u64 {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct SurveyWorkerConfig {
-    pub command_interval: u64,
+    pub command_interval: usize, // in milliseconds
     #[serde(default = "default_filter_refresh_interval_minutes")]
     pub filter_refresh_interval_minutes: u64,
     pub alert: WorkerConfig,

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -413,10 +413,59 @@ fn default_filter_refresh_interval_minutes() -> u64 {
     15
 }
 
+fn deserialize_filter_refresh_interval<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    const MIN_INTERVAL: u64 = 1;
+    const MAX_INTERVAL: u64 = 60;
+    if value < MIN_INTERVAL {
+        return Err(serde::de::Error::custom(format!(
+            "filter_refresh_interval_minutes must be at least {} minutes, got {}",
+            MIN_INTERVAL, value
+        )));
+    }
+    if value > MAX_INTERVAL {
+        return Err(serde::de::Error::custom(format!(
+            "filter_refresh_interval_minutes must be at most {} minutes, got {}",
+            MAX_INTERVAL, value
+        )));
+    }
+    Ok(value)
+}
+
+fn deserialize_command_interval<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    const MIN_INTERVAL: usize = 100;
+    const MAX_INTERVAL: usize = 60000;
+
+    if value < MIN_INTERVAL {
+        return Err(serde::de::Error::custom(format!(
+            "command_interval must be at least {} ms, got {}",
+            MIN_INTERVAL, value
+        )));
+    }
+    if value > MAX_INTERVAL {
+        return Err(serde::de::Error::custom(format!(
+            "command_interval must be at most {} ms, got {}",
+            MAX_INTERVAL, value
+        )));
+    }
+    Ok(value)
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct SurveyWorkerConfig {
+    #[serde(deserialize_with = "deserialize_command_interval")]
     pub command_interval: usize, // in milliseconds
-    #[serde(default = "default_filter_refresh_interval_minutes")]
+    #[serde(
+        default = "default_filter_refresh_interval_minutes",
+        deserialize_with = "deserialize_filter_refresh_interval"
+    )]
     pub filter_refresh_interval_minutes: u64,
     pub alert: WorkerConfig,
     pub enrichment: WorkerConfig,

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -3,6 +3,7 @@ use crate::{
     conf::{self, AppConfig},
     enrichment::models::ModelError,
     utils::{
+        enums::Survey,
         fits::CutoutError,
         o11y::metrics::SCHEDULER_METER,
         worker::{should_terminate, WorkerCmd},
@@ -64,6 +65,8 @@ pub enum EnrichmentWorkerError {
     Redis(#[from] redis::RedisError),
     #[error("failed to read config")]
     ReadConfigError(#[from] conf::BoomConfigError),
+    #[error("worker config missing for survey: {0}")]
+    WorkerConfigMissing(Survey),
     #[error("failed to run model")]
     RunModelError(#[from] ModelError),
     #[error("could not access cutout images")]
@@ -93,6 +96,7 @@ pub trait EnrichmentWorker {
     async fn new(config_path: &str) -> Result<Self, EnrichmentWorkerError>
     where
         Self: Sized;
+    fn survey() -> Survey;
     fn input_queue_name(&self) -> String;
     fn output_queue_name(&self) -> String;
     async fn process_alerts(
@@ -199,12 +203,18 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
     let mut enrichment_worker = T::new(config_path).await?;
 
     let config = AppConfig::from_path(config_path)?;
+    let survey = T::survey();
+    let worker_config = config
+        .workers
+        .get(&survey)
+        .ok_or(EnrichmentWorkerError::WorkerConfigMissing(survey.clone()))?;
+
     let mut con = config.build_redis().await?;
 
     let input_queue = enrichment_worker.input_queue_name();
     let output_queue = enrichment_worker.output_queue_name();
 
-    let command_interval: usize = 500;
+    let command_interval = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
 
     let worker_id_attr = KeyValue::new("worker.id", worker_id.to_string());

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -259,6 +259,8 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
             continue;
         }
 
+        command_check_countdown = command_check_countdown.saturating_sub(candids.len());
+
         let processed_alerts: Vec<String> = enrichment_worker
             .process_alerts(&candids)
             .await
@@ -266,7 +268,6 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
                 ACTIVE.add(-1, &active_attrs);
                 BATCH_PROCESSED.add(1, &processing_error_attrs);
             })?;
-        command_check_countdown = command_check_countdown.saturating_sub(candids.len());
 
         if processed_alerts.is_empty() {
             let attributes = &ok_attrs;

--- a/src/enrichment/decam.rs
+++ b/src/enrichment/decam.rs
@@ -2,6 +2,7 @@ use crate::alert::DecamCandidate;
 use crate::conf::AppConfig;
 use crate::enrichment::{fetch_alerts, EnrichmentWorker, EnrichmentWorkerError};
 use crate::utils::db::{fetch_timeseries_op, mongify};
+use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
     analyze_photometry, prepare_photometry, PerBandProperties, PhotometryMag,
 };
@@ -119,6 +120,10 @@ impl EnrichmentWorker for DecamEnrichmentWorker {
             alert_collection,
             alert_pipeline: create_decam_alert_pipeline(),
         })
+    }
+
+    fn survey() -> Survey {
+        Survey::Decam
     }
 
     fn input_queue_name(&self) -> String {

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -270,6 +270,10 @@ impl EnrichmentWorker for LsstEnrichmentWorker {
         })
     }
 
+    fn survey() -> Survey {
+        Survey::Lsst
+    }
+
     fn input_queue_name(&self) -> String {
         self.input_queue.clone()
     }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -2,6 +2,7 @@ use crate::conf::AppConfig;
 use crate::enrichment::babamul::{Babamul, BabamulZtfAlert};
 use crate::enrichment::LsstMatch;
 use crate::utils::db::mongify;
+use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
     analyze_photometry, prepare_photometry, AllBandsProperties, Band, PerBandProperties,
     PhotometryMag, ZTF_ZP,
@@ -434,6 +435,10 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
             btsbot_model,
             babamul,
         })
+    }
+
+    fn survey() -> Survey {
+        Survey::Ztf
     }
 
     fn input_queue_name(&self) -> String {

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 
+use std::time::{Duration, Instant};
 use std::{collections::HashMap, num::NonZero, sync::LazyLock};
 
 use apache_avro::{serde_avro_bytes, Writer};
@@ -705,6 +706,14 @@ pub async fn build_loaded_filter(
     filter_collection: &mongodb::Collection<Filter>,
 ) -> Result<LoadedFilter, FilterError> {
     let filter = get_filter(filter_id, survey, filter_collection).await?;
+    if SURVEYS_REQUIRING_PERMISSIONS.contains(survey)
+        && filter
+            .permissions
+            .get(survey)
+            .is_none_or(|permissions| permissions.is_empty())
+    {
+        return Err(FilterError::InvalidFilterPermissions);
+    }
 
     let pipeline = get_active_filter_pipeline(&filter)?;
     let pipeline = build_filter_pipeline(&pipeline, &filter.permissions, &filter.survey).await?;
@@ -760,7 +769,13 @@ pub async fn build_loaded_filters(
 
     let mut filters: Vec<LoadedFilter> = Vec::new();
     for filter_id in filter_ids {
-        filters.push(build_loaded_filter(&filter_id, survey, &filter_collection).await?);
+        match build_loaded_filter(&filter_id, survey, filter_collection).await {
+            Ok(filter) => filters.push(filter),
+            Err(err) => {
+                warn!("Skipping filter {} for {:?}: {}", filter_id, survey, err);
+                continue;
+            }
+        }
     }
 
     Ok(filters)
@@ -792,6 +807,8 @@ pub enum FilterWorkerError {
     FilterNotFound,
     #[error("kafka config missing for survey: {0}")]
     KafkaConfigMissing(Survey),
+    #[error("worker config missing for survey: {0}")]
+    WorkerConfigMissing(Survey),
     #[error("Missing PSF for forced photometry point, cannot apply ZP correction")]
     MissingFluxPSF,
     #[error("missing cutouts for candid {0}")]
@@ -812,6 +829,7 @@ pub trait FilterWorker {
     ) -> Result<Self, FilterWorkerError>
     where
         Self: Sized;
+    async fn refresh_filters(&mut self) -> Result<(), FilterWorkerError>;
     fn input_queue_name(&self) -> String;
     fn output_topic_name(&self) -> String;
     fn has_filters(&self) -> bool;
@@ -829,13 +847,13 @@ pub async fn run_filter_worker<T: FilterWorker>(
     debug!(?config_path);
 
     let config = AppConfig::from_path(config_path)?;
+    let survey = T::survey();
+    let worker_config = config
+        .workers
+        .get(&survey)
+        .ok_or(FilterWorkerError::WorkerConfigMissing(survey))?;
 
     let mut filter_worker = T::new(config_path, None).await?;
-
-    if !filter_worker.has_filters() {
-        info!("no filters available for processing, shutting down gracefully");
-        return Ok(());
-    }
 
     // in a never ending loop, loop over the queues
     let mut con = config.build_redis().await?;
@@ -845,6 +863,10 @@ pub async fn run_filter_worker<T: FilterWorker>(
 
     let producer = create_producer(&config.kafka.producer).await?;
     let schema = load_alert_schema()?;
+    let filter_refresh_interval =
+        Duration::from_secs(worker_config.filter_refresh_interval_minutes * 60);
+    let idle_poll_interval = Duration::from_secs(30);
+    let mut next_filter_refresh = Instant::now() + filter_refresh_interval;
 
     let command_interval: usize = 500;
     let mut command_check_countdown = command_interval;
@@ -878,6 +900,33 @@ pub async fn run_filter_worker<T: FilterWorker>(
         KeyValue::new("reason", "kafka_send"),
     ];
     loop {
+        if Instant::now() >= next_filter_refresh {
+            filter_worker.refresh_filters().await?;
+            next_filter_refresh = Instant::now() + filter_refresh_interval;
+
+            if !filter_worker.has_filters() {
+                info!("no active filters available, waiting for the next refresh");
+            }
+        }
+
+        if !filter_worker.has_filters() {
+            if should_terminate(&mut receiver) {
+                producer
+                    .flush(std::time::Duration::from_secs(10))
+                    .map_err(|e| {
+                        FilterWorkerError::Kafka(format!(
+                            "Failed to flush Kafka producer on termination: {}",
+                            e
+                        ))
+                    })?;
+                info!("termination signal received, shutting down gracefully");
+                break;
+            }
+
+            tokio::time::sleep(idle_poll_interval).await;
+            continue;
+        }
+
         if command_check_countdown == 0 {
             if should_terminate(&mut receiver) {
                 // flush the producer before terminating to avoid losing messages

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -865,7 +865,6 @@ pub async fn run_filter_worker<T: FilterWorker>(
     let schema = load_alert_schema()?;
     let filter_refresh_interval =
         Duration::from_secs(worker_config.filter_refresh_interval_minutes * 60);
-    let idle_poll_interval = Duration::from_secs(30);
     let mut next_filter_refresh = Instant::now() + filter_refresh_interval;
 
     let command_interval = worker_config.command_interval;
@@ -909,24 +908,6 @@ pub async fn run_filter_worker<T: FilterWorker>(
             }
         }
 
-        if !filter_worker.has_filters() {
-            if should_terminate(&mut receiver) {
-                producer
-                    .flush(std::time::Duration::from_secs(10))
-                    .map_err(|e| {
-                        FilterWorkerError::Kafka(format!(
-                            "Failed to flush Kafka producer on termination: {}",
-                            e
-                        ))
-                    })?;
-                info!("termination signal received, shutting down gracefully");
-                break;
-            }
-
-            tokio::time::sleep(idle_poll_interval).await;
-            continue;
-        }
-
         if command_check_countdown == 0 {
             if should_terminate(&mut receiver) {
                 // flush the producer before terminating to avoid losing messages
@@ -938,10 +919,16 @@ pub async fn run_filter_worker<T: FilterWorker>(
                             e
                         ))
                     })?;
-                info!("termination signal received, shutting down gracefully");
                 break;
             }
-            command_check_countdown = command_interval + 1;
+            command_check_countdown = command_interval;
+
+            if !filter_worker.has_filters() {
+                // if we don't have any active filter, we call continue to avoid
+                // pooling candids until we have filters to run them through
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                continue;
+            }
         }
 
         ACTIVE.add(1, &active_attrs);
@@ -960,6 +947,8 @@ pub async fn run_filter_worker<T: FilterWorker>(
             continue;
         }
 
+        command_check_countdown = command_check_countdown.saturating_sub(alerts.len());
+
         let alerts_output = filter_worker
             .process_alerts(&alerts)
             .await
@@ -967,7 +956,6 @@ pub async fn run_filter_worker<T: FilterWorker>(
                 ACTIVE.add(-1, &active_attrs);
                 BATCH_PROCESSED.add(1, &processing_error_attrs);
             })?;
-        command_check_countdown = command_check_countdown.saturating_sub(alerts.len());
 
         BATCH_PROCESSED.add(1, &ok_attrs);
         ALERT_PROCESSED.add(

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -868,7 +868,7 @@ pub async fn run_filter_worker<T: FilterWorker>(
     let idle_poll_interval = Duration::from_secs(30);
     let mut next_filter_refresh = Instant::now() + filter_refresh_interval;
 
-    let command_interval: usize = 500;
+    let command_interval = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
 
     let worker_id_attr = KeyValue::new("worker.id", worker_id.to_string());

--- a/src/filter/lsst.rs
+++ b/src/filter/lsst.rs
@@ -9,8 +9,8 @@ use crate::enrichment::{
 use crate::filter::{
     build_loaded_filters, build_ztf_aux_data, insert_ztf_aux_pipeline_if_needed, run_filter,
     update_aliases_index_multiple, uses_field_in_filter, validate_filter_pipeline, Alert,
-    Classification, FilterError, FilterResults, FilterWorker, FilterWorkerError, LoadedFilter,
-    Origin, Photometry, SurveyMatch, SurveyMatches,
+    Classification, Filter, FilterError, FilterResults, FilterWorker, FilterWorkerError,
+    LoadedFilter, Origin, Photometry, SurveyMatch, SurveyMatches,
 };
 use crate::utils::db::{fetch_timeseries_op, get_array_dict_element};
 use crate::utils::enums::Survey;
@@ -429,8 +429,10 @@ pub struct LsstFilterWorker {
     alert_pipeline: Vec<Document>,
     alert_collection: mongodb::Collection<Document>,
     alert_cutout_collection: mongodb::Collection<Document>,
+    filter_collection: mongodb::Collection<Filter>,
     input_queue: String,
     output_topic: String,
+    filter_ids: Option<Vec<String>>,
     filters: Vec<LoadedFilter>,
 }
 
@@ -456,10 +458,23 @@ impl FilterWorker for LsstFilterWorker {
             alert_pipeline: create_lsst_alert_pipeline(),
             alert_collection,
             alert_cutout_collection,
+            filter_collection,
             input_queue,
             output_topic,
+            filter_ids,
             filters,
         })
+    }
+
+    async fn refresh_filters(&mut self) -> Result<(), FilterWorkerError> {
+        info!("refreshing LSST filters from database");
+        self.filters =
+            build_loaded_filters(&self.filter_ids, &Survey::Lsst, &self.filter_collection).await?;
+        info!(
+            "refreshed LSST filters from database; now tracking {} filters",
+            self.filters.len()
+        );
+        Ok(())
     }
 
     fn survey() -> Survey {

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -11,8 +11,8 @@ use crate::enrichment::{
 use crate::filter::{
     build_loaded_filters, build_lsst_aux_data, insert_lsst_aux_pipeline_if_needed,
     parse_programid_candid_tuple, run_filter, update_aliases_index_multiple, uses_field_in_filter,
-    validate_filter_pipeline, Alert, Classification, FilterError, FilterResults, FilterWorker,
-    FilterWorkerError, LoadedFilter, Origin, Photometry, SurveyMatch, SurveyMatches,
+    validate_filter_pipeline, Alert, Classification, Filter, FilterError, FilterResults,
+    FilterWorker, FilterWorkerError, LoadedFilter, Origin, Photometry, SurveyMatch, SurveyMatches,
 };
 use crate::utils::db::{fetch_timeseries_op, get_array_dict_element};
 use crate::utils::{enums::Survey, o11y::logging::as_error};
@@ -580,8 +580,10 @@ pub struct ZtfFilterWorker {
     alert_pipeline: Vec<Document>,
     alert_collection: mongodb::Collection<Document>,
     alert_cutout_collection: mongodb::Collection<Document>,
+    filter_collection: mongodb::Collection<Filter>,
     input_queue: String,
     output_topic: String,
+    filter_ids: Option<Vec<String>>,
     filters: Vec<LoadedFilter>,
     filters_by_permission: HashMap<i32, Vec<String>>,
 }
@@ -607,17 +609,7 @@ impl FilterWorker for ZtfFilterWorker {
         // Create a hashmap of filters per programid (permissions)
         let mut filters_by_permission: HashMap<i32, Vec<String>> = HashMap::new();
         for filter in &filters {
-            let ztf_permissions = match filter.permissions.get(&Survey::Ztf) {
-                Some(perms) => perms,
-                None => {
-                    warn!(
-                        "Filter {} running on ZTF alerts has no ZTF permissions set, skipping",
-                        filter.id
-                    );
-                    continue;
-                }
-            };
-            for permission in ztf_permissions {
+            for permission in filter.permissions.get(&Survey::Ztf).into_iter().flatten() {
                 let entry = filters_by_permission
                     .entry(*permission)
                     .or_insert(Vec::new());
@@ -629,11 +621,39 @@ impl FilterWorker for ZtfFilterWorker {
             alert_pipeline: create_ztf_alert_pipeline(true),
             alert_collection,
             alert_cutout_collection,
+            filter_collection,
             input_queue,
             output_topic,
+            filter_ids,
             filters,
             filters_by_permission,
         })
+    }
+
+    async fn refresh_filters(&mut self) -> Result<(), FilterWorkerError> {
+        info!("refreshing ZTF filters from database");
+        let filters =
+            build_loaded_filters(&self.filter_ids, &Survey::Ztf, &self.filter_collection).await?;
+
+        let mut filters_by_permission: HashMap<i32, Vec<String>> = HashMap::new();
+        for filter in &filters {
+            for permission in filter.permissions.get(&Survey::Ztf).into_iter().flatten() {
+                let entry = filters_by_permission
+                    .entry(*permission)
+                    .or_insert(Vec::new());
+                entry.push(filter.id.clone());
+            }
+        }
+
+        self.filters = filters;
+        self.filters_by_permission = filters_by_permission;
+
+        info!(
+            "refreshed ZTF filters from database; now tracking {} filters",
+            self.filters.len()
+        );
+
+        Ok(())
     }
 
     fn survey() -> Survey {

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -43,6 +43,7 @@ kafka:
 workers:
   ztf:
     command_interval: 500
+    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:
@@ -51,6 +52,7 @@ workers:
       n_workers: 1
   lsst:
     command_interval: 500
+    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:
@@ -59,6 +61,7 @@ workers:
       n_workers: 1
   decam:
     command_interval: 500
+    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:

--- a/tests/test_conf.rs
+++ b/tests/test_conf.rs
@@ -45,6 +45,7 @@ fn test_load_workers_config() {
     assert_eq!(ztf_worker_config.enrichment.n_workers, 1);
     assert_eq!(ztf_worker_config.filter.n_workers, 1);
     assert_eq!(ztf_worker_config.command_interval, 500);
+    assert_eq!(ztf_worker_config.filter_refresh_interval_minutes, 15);
 }
 
 #[test]


### PR DESCRIPTION
For a while now, folks have asked "once I have uploaded a filter, when does it start running?, "how long it takes between me writing a filter and candidates to start flowing?". All valid questions, and my answer was "tell me when you want it to run and I'll restart boom so it picks it up", because the filter worker had no mechanisms to detect new filters and required a full restart.

So, this PR:
- add a configurable "filter refresh" (in minutes) to the configuration, defaults to every 15 minutes. The number I pickes is somewhat arbitrary, but it felt like a very reasonable wait time that would't disrupt real-time operations too much.
- Every N minutes (as configured), we call a new `refresh_filters` method that updated the list of active/running filters a worker is responsible of.
- now, filter workers do not just shutdown on startup if there are no filters to run, they always start and will simply sleep until they find some filters to run.

A more "clever" implementation may figure out a way to remove this fixed refresh time in favor of some implementation where we send a signal to the filter worker in real time to force a refresh, but what I like with the current implementation is the guarantee that we won't have a full refresh (which obviously means we don't process alerts while its happening) at a high cadence if folks start playing with their filters a little too fast. 

Essentially, this mimicks the behavior we had in Kowalski, and from experience folks are definitely ok with some latency between editing/adding a filter and alerts go through them. If we think 15 minutes is too long, we can make that a lot shorter using the config or ENV var overwrites anyways.

Updates:
- Copilot point out that the command interval was hardcoded to 500 everywhere, even though we have it defined in the config. I took advantage of this PR (where we add some config to parse the worker config in the filter worker anyway) to make this right, across all worker types.