### PR TITLE
Restrict filter creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1.89"
 base64 = "0.22.1"
 bcrypt = "0.17.1"
 cdshealpix = "0.7.3"
-chrono = "0.4.42"
+chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 config = "0.15.18"
 constcat = "0.6.1"

--- a/config.yaml
+++ b/config.yaml
@@ -43,31 +43,37 @@ kafka:
 workers:
   ztf:
     command_interval: 500
-    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 3
     enrichment:
       n_workers: 3
     filter:
       n_workers: 3
+      refresh_interval_minutes: 15
+      # Activation check: a filter cannot be activated if it matches more than
+      # max_match_rate (out of 100) of the alerts accessible on reference_night.
+      max_match_rate: 25
+      reference_night: "2026-03-16"
   lsst:
     command_interval: 500
-    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 4
     enrichment:
       n_workers: 3
     filter:
       n_workers: 1
+      refresh_interval_minutes: 15
+      max_match_rate: 5
+      reference_night: "2026-02-23"
   decam:
     command_interval: 500
-    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:
       n_workers: 0
     filter:
       n_workers: 1
+      refresh_interval_minutes: 15
 crossmatch:
   ztf:
     - catalog: PS1_DR1

--- a/config.yaml
+++ b/config.yaml
@@ -52,7 +52,7 @@ workers:
       refresh_interval_minutes: 15
       # Activation check: a filter cannot be activated if it matches more than
       # max_match_rate (out of 100) of the alerts accessible on reference_night.
-      max_match_rate: 25
+      max_match_rate: 5
       reference_night: "2026-03-16"
   lsst:
     command_interval: 500

--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,8 @@ workers:
     filter:
       n_workers: 1
       refresh_interval_minutes: 15
+      max_match_rate: 5
+      reference_night:
 crossmatch:
   ztf:
     - catalog: PS1_DR1

--- a/config.yaml
+++ b/config.yaml
@@ -50,8 +50,8 @@ workers:
     filter:
       n_workers: 3
       refresh_interval_minutes: 15
-      # Activation check: a filter cannot be activated if it matches more than
-      # max_match_rate (out of 100) of the alerts accessible on reference_night.
+      # On activation, filters are validated against a designated reference night.
+      # If more than max_match_rate percent of alerts pass, the filter is not validated.
       max_match_rate: 5
       reference_night: "2026-03-16"
   lsst:

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -8,6 +8,7 @@ use crate::{
         models::response,
         routes::users::User,
     },
+    conf::{AppConfig, FilterWorkerConfig},
     enrichment::{LsstAlertProperties, ZtfAlertClassifications, ZtfAlertProperties},
     filter::{
         build_filter_pipeline, Filter, FilterError, FilterVersion, SURVEYS_REQUIRING_PERMISSIONS,
@@ -21,7 +22,6 @@ use crate::{
 use actix_web::{get, patch, post, web, HttpResponse};
 use apache_avro::AvroSchema;
 use apache_avro_macros::serdavro;
-use chrono::NaiveDate;
 use flare::Time;
 use futures::stream::StreamExt;
 use mongodb::{
@@ -127,31 +127,25 @@ async fn build_and_test_filter_version(
     run_test_pipeline(db, survey, test_pipeline).await
 }
 
-const MAX_FILTER_RESULT_RATIO: f64 = 0.20;
-
-/// These are recent, well-populated nights chosen to give a representative
-/// sample of alerts when measuring how selective a filter is.
-fn activation_reference_night(survey: &Survey) -> Result<NaiveDate, String> {
-    match survey {
-        Survey::Ztf => Ok(NaiveDate::from_ymd_opt(2026, 3, 16).unwrap()),
-        Survey::Lsst => Ok(NaiveDate::from_ymd_opt(2026, 2, 23).unwrap()),
-        _ => Err(format!(
-            "filter activation validation is not supported for survey {}",
-            survey
-        )),
-    }
-}
-
 /// Validate that activating this filter is safe by running it against a
 /// reference observing night and ensuring the filter does not match more than
-/// `MAX_FILTER_RESULT_RATIO` of the alerts the filter has access to that night.
+/// `max_result_ratio_percent` of the alerts the filter has access to that night.
 async fn validate_filter_activation(
     db: &Database,
+    config: &FilterWorkerConfig,
     survey: &Survey,
     pipeline: &Vec<serde_json::Value>,
     permissions: &HashMap<Survey, Vec<i32>>,
 ) -> Result<(), String> {
-    let night_date = activation_reference_night(survey)?;
+    let (night_date, max_match_rate) = match (config.reference_night, config.max_match_rate) {
+        (Some(date), Some(rate)) => (date, rate),
+        _ => {
+            return Err(format!(
+                "filter activation validation is not supported for survey {}",
+                survey
+            ));
+        }
+    };
 
     // The user's accessible alerts are restricted by permissions on surveys that
     // expose multiple program streams (ZTF). Surveys without programid (LSST)
@@ -222,16 +216,16 @@ async fn validate_filter_activation(
         None => 0,
     };
 
-    let max_allowed = (night_total as f64 * MAX_FILTER_RESULT_RATIO) as i64;
+    let max_allowed = (night_total as f64 * max_match_rate as f64 / 100.0) as i64;
     if matched > max_allowed {
         return Err(format!(
-            "filter matched {} of {} {} alerts ({:.1}%) on night {}, which exceeds the {:.0}% limit",
+            "filter matched {} of {} {} alerts ({:.1}%) on night {}, which exceeds the {}% limit",
             matched,
             night_total,
             survey,
             (matched as f64 / night_total as f64) * 100.0,
             night_date,
-            MAX_FILTER_RESULT_RATIO * 100.0,
+            max_match_rate,
         ));
     }
     Ok(())
@@ -259,6 +253,7 @@ struct FilterVersionPost {
 #[post("/filters/{filter_id}/versions")]
 pub async fn post_filter_version(
     db: web::Data<Database>,
+    config: web::Data<AppConfig>,
     filter_id: web::Path<String>,
     body: web::Json<FilterVersionPost>,
     current_user: Option<web::ReqData<User>>,
@@ -307,7 +302,18 @@ pub async fn post_filter_version(
     // If this version is going to immediately replace an active filter,
     // re-run the activation check on the new pipeline
     if set_as_active && filter.active {
-        if let Err(e) = validate_filter_activation(&db, &survey, &new_pipeline, &permissions).await
+        let filter_config = match config.workers.get(&survey).map(|w| &w.filter) {
+            Some(c) => c,
+            None => {
+                return response::internal_error(&format!(
+                    "no worker config defined for survey {}",
+                    survey
+                ));
+            }
+        };
+        if let Err(e) =
+            validate_filter_activation(&db, filter_config, &survey, &new_pipeline, &permissions)
+                .await
         {
             return response::bad_request(&e);
         }
@@ -473,6 +479,7 @@ struct FilterPatch {
 #[patch("/filters/{filter_id}")]
 pub async fn patch_filter(
     db: web::Data<Database>,
+    config: web::Data<AppConfig>,
     filter_id: web::Path<String>,
     body: web::Json<FilterPatch>,
     current_user: Option<web::ReqData<User>>,
@@ -577,8 +584,18 @@ pub async fn patch_filter(
             .permissions
             .clone()
             .unwrap_or(filter.permissions.clone());
+        let filter_config = match config.workers.get(&filter.survey).map(|w| &w.filter) {
+            Some(c) => c,
+            None => {
+                return response::internal_error(&format!(
+                    "no worker config defined for survey {}",
+                    filter.survey
+                ));
+            }
+        };
         if let Err(e) =
-            validate_filter_activation(&db, &filter.survey, &pipeline, &permissions).await
+            validate_filter_activation(&db, filter_config, &filter.survey, &pipeline, &permissions)
+                .await
         {
             return response::bad_request(&e);
         }

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -754,7 +754,15 @@ async fn build_test_filter_pipeline(
         ));
     }
 
-    let mut test_pipeline = build_filter_pipeline(&pipeline, &permissions, &survey).await?;
+    let mut test_pipeline = match build_filter_pipeline(&pipeline, &permissions, &survey).await {
+        Ok(p) => p,
+        Err(e) => {
+            return Err(FilterError::InvalidFilterPipeline(format!(
+                "Filter build failed with error: {}",
+                e
+            )));
+        }
+    };
     match test_pipeline.get(0) {
         Some(first_stage) => {
             if first_stage.get("$match").is_none() {

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -12,12 +12,16 @@ use crate::{
     filter::{
         build_filter_pipeline, Filter, FilterError, FilterVersion, SURVEYS_REQUIRING_PERMISSIONS,
     },
-    utils::{db::mongify, enums::Survey},
+    utils::{
+        db::{count_alerts_for_night, mongify},
+        enums::Survey,
+    },
 };
 
 use actix_web::{get, patch, post, web, HttpResponse};
 use apache_avro::AvroSchema;
 use apache_avro_macros::serdavro;
+use chrono::NaiveDate;
 use flare::Time;
 use futures::stream::StreamExt;
 use mongodb::{
@@ -123,6 +127,116 @@ async fn build_and_test_filter_version(
     run_test_pipeline(db, survey, test_pipeline).await
 }
 
+const MAX_FILTER_RESULT_RATIO: f64 = 0.20;
+
+/// These are recent, well-populated nights chosen to give a representative
+/// sample of alerts when measuring how selective a filter is.
+fn activation_reference_night(survey: &Survey) -> Result<NaiveDate, String> {
+    match survey {
+        Survey::Ztf => Ok(NaiveDate::from_ymd_opt(2026, 3, 16).unwrap()),
+        Survey::Lsst => Ok(NaiveDate::from_ymd_opt(2026, 3, 9).unwrap()),
+        _ => Err(format!(
+            "filter activation validation is not supported for survey {}",
+            survey
+        )),
+    }
+}
+
+/// Validate that activating this filter is safe by running it against a
+/// reference observing night and ensuring the filter does not match more than
+/// `MAX_FILTER_RESULT_RATIO` of the alerts the filter has access to that night.
+async fn validate_filter_activation(
+    db: &Database,
+    survey: &Survey,
+    pipeline: &Vec<serde_json::Value>,
+    permissions: &HashMap<Survey, Vec<i32>>,
+) -> Result<(), String> {
+    let night_date = activation_reference_night(survey)?;
+
+    // The user's accessible alerts are restricted by permissions on surveys that
+    // expose multiple program streams (ZTF). Surveys without programid (LSST)
+    // pass None, counting all alerts for the night.
+    let permission_programids: Option<Vec<i32>> = if SURVEYS_REQUIRING_PERMISSIONS.contains(survey)
+    {
+        match permissions.get(survey) {
+            Some(p) if !p.is_empty() => Some(p.clone()),
+            _ => {
+                return Err(format!(
+                    "filter has no permissions defined for survey {}",
+                    survey
+                ));
+            }
+        }
+    } else {
+        None
+    };
+    let pid_slice = permission_programids.as_deref();
+    let night_total = count_alerts_for_night(db, survey, &night_date, pid_slice)
+        .await
+        .map_err(|e| format!("failed to count alerts for {}: {}", night_date, e))?;
+    if night_total == 0 {
+        return Err(if pid_slice.is_some() {
+            format!(
+                "no {} alerts accessible with the given permissions on reference night {}; cannot validate filter activation",
+                survey, night_date
+            )
+        } else {
+            format!(
+                "no {} alerts on reference night {}; cannot validate filter activation",
+                survey, night_date
+            )
+        });
+    }
+
+    // Run the filter pipeline restricted to that night, count matches.
+    let (start_jd, end_jd) = survey.night_jd_window(&night_date);
+    let mut test_pipeline = build_filter_pipeline(pipeline, permissions, survey)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut match_stage = doc! {
+        "candidate.jd": { "$gte": start_jd, "$lt": end_jd },
+    };
+    if let Some(pids) = pid_slice {
+        match_stage.insert("candidate.programid", doc! { "$in": pids.to_vec() });
+    }
+    match test_pipeline.get_mut(0) {
+        Some(first_stage) if first_stage.get("$match").is_some() => {
+            first_stage.insert("$match", match_stage);
+        }
+        _ => return Err("filter pipeline must start with a $match stage".to_string()),
+    }
+    test_pipeline.push(doc! { "$count": "count" });
+
+    let collection: Collection<Document> = db.collection(&format!("{}_alerts", survey));
+    let mut cursor = collection
+        .aggregate(test_pipeline)
+        .await
+        .map_err(|e| format!("failed to run filter on night {}: {}", night_date, e))?;
+    let matched = match cursor.next().await {
+        Some(Ok(doc)) => match doc.get("count") {
+            Some(mongodb::bson::Bson::Int32(c)) => *c as i64,
+            Some(mongodb::bson::Bson::Int64(c)) => *c,
+            _ => 0,
+        },
+        Some(Err(e)) => return Err(format!("failed to read filter result count: {}", e)),
+        None => 0,
+    };
+
+    let max_allowed = (night_total as f64 * MAX_FILTER_RESULT_RATIO) as i64;
+    if matched > max_allowed {
+        return Err(format!(
+            "filter matched {} of {} {} alerts ({:.1}%) on night {}, which exceeds the {:.0}% limit",
+            matched,
+            night_total,
+            survey,
+            (matched as f64 / night_total as f64) * 100.0,
+            night_date,
+            MAX_FILTER_RESULT_RATIO * 100.0,
+        ));
+    }
+    Ok(())
+}
+
 #[derive(serde::Deserialize, Clone, ToSchema)]
 struct FilterVersionPost {
     pipeline: Vec<serde_json::Value>,
@@ -189,6 +303,16 @@ pub async fn post_filter_version(
         }
     }
 
+    let set_as_active = body.set_as_active.unwrap_or(true);
+    // If this version is going to immediately replace an active filter,
+    // re-run the activation check on the new pipeline
+    if set_as_active && filter.active {
+        if let Err(e) = validate_filter_activation(&db, &survey, &new_pipeline, &permissions).await
+        {
+            return response::bad_request(&e);
+        }
+    }
+
     let new_pipeline_id = Uuid::new_v4().to_string();
     let mut fv_update = doc! {
         "fid": &new_pipeline_id,
@@ -203,7 +327,7 @@ pub async fn post_filter_version(
             "fv": fv_update
         },
     };
-    if body.set_as_active.unwrap_or(true) {
+    if set_as_active {
         update_doc.insert("$set", doc! { "active_fid": &new_pipeline_id });
     }
     let update_result = collection
@@ -392,15 +516,18 @@ pub async fn patch_filter(
     if let Some(active) = body.active {
         update_doc.insert("active", active);
     }
-    if let Some(active_fid) = body.active_fid.clone() {
+    let new_active_fid = if let Some(active_fid) = body.active_fid.clone() {
         // Ensure the fid exists in the filter versions
         if !filter.fv.iter().any(|fv| fv.fid == active_fid) {
             return response::bad_request(
                 "active_fid must be one of the existing filter version IDs",
             );
         }
-        update_doc.insert("active_fid", active_fid);
-    }
+        update_doc.insert("active_fid", active_fid.clone());
+        Some(active_fid)
+    } else {
+        None
+    };
     if let Some(permissions) = body.permissions.clone() {
         if permissions.get(&filter.survey).is_none()
             && SURVEYS_REQUIRING_PERMISSIONS.contains(&filter.survey)
@@ -415,6 +542,48 @@ pub async fn patch_filter(
     if update_doc.is_empty() {
         return response::bad_request("no valid fields to update");
     }
+
+    // If the filter is currently active or will be set to active,
+    // and the pipeline or permissions are changing, run the activation check to ensure
+    // the filter is not too permissive.
+    let will_be_active = body.active.unwrap_or(filter.active);
+    let exec_changed = (body.active == Some(true) && !filter.active)
+        || new_active_fid.is_some()
+        || body.permissions.is_some();
+    if will_be_active && exec_changed {
+        let active_fid = new_active_fid
+            .as_deref()
+            .unwrap_or(filter.active_fid.as_str());
+        let active_version = match filter.fv.iter().find(|fv| fv.fid == active_fid) {
+            Some(fv) => fv,
+            None => {
+                return response::internal_error(&format!(
+                    "filter {} has no version matching active_fid {}",
+                    filter_id, active_fid
+                ));
+            }
+        };
+        let pipeline =
+            match serde_json::from_str::<Vec<serde_json::Value>>(&active_version.pipeline) {
+                Ok(p) => p,
+                Err(e) => {
+                    return response::internal_error(&format!(
+                        "failed to parse stored filter pipeline: {}",
+                        e
+                    ));
+                }
+            };
+        let permissions = body
+            .permissions
+            .clone()
+            .unwrap_or(filter.permissions.clone());
+        if let Err(e) =
+            validate_filter_activation(&db, &filter.survey, &pipeline, &permissions).await
+        {
+            return response::bad_request(&e);
+        }
+    }
+
     update_doc.insert("updated_at", Time::now().to_jd());
     let update_result = collection
         .update_one(doc! {"_id": filter_id.clone()}, doc! {"$set": update_doc})
@@ -585,15 +754,7 @@ async fn build_test_filter_pipeline(
         ));
     }
 
-    let mut test_pipeline = match build_filter_pipeline(&pipeline, &permissions, &survey).await {
-        Ok(p) => p,
-        Err(e) => {
-            return Err(FilterError::InvalidFilterPipeline(format!(
-                "Filter build failed with error: {}",
-                e
-            )));
-        }
-    };
+    let mut test_pipeline = build_filter_pipeline(&pipeline, &permissions, &survey).await?;
     match test_pipeline.get(0) {
         Some(first_stage) => {
             if first_stage.get("$match").is_none() {

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -302,7 +302,7 @@ pub async fn post_filter(
         survey,
         id: filter_id,
         user_id: current_user.id.clone(),
-        active: true,
+        active: false,
         active_fid: filter_version.clone(),
         fv: vec![FilterVersion {
             fid: filter_version,

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -196,8 +196,8 @@ async fn validate_filter_activation(
     let mut match_stage = doc! {
         "candidate.jd": { "$gte": start_jd, "$lt": end_jd },
     };
-    if let Some(pids) = pid_slice {
-        match_stage.insert("candidate.programid", doc! { "$in": pids.to_vec() });
+    if let Some(pids) = permission_programids.as_ref() {
+        match_stage.insert("candidate.programid", doc! { "$in": pids });
     }
     match test_pipeline.get_mut(0) {
         Some(first_stage) if first_stage.get("$match").is_some() => {

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -134,7 +134,7 @@ const MAX_FILTER_RESULT_RATIO: f64 = 0.20;
 fn activation_reference_night(survey: &Survey) -> Result<NaiveDate, String> {
     match survey {
         Survey::Ztf => Ok(NaiveDate::from_ymd_opt(2026, 3, 16).unwrap()),
-        Survey::Lsst => Ok(NaiveDate::from_ymd_opt(2026, 3, 9).unwrap()),
+        Survey::Lsst => Ok(NaiveDate::from_ymd_opt(2026, 2, 23).unwrap()),
         _ => Err(format!(
             "filter activation validation is not supported for survey {}",
             survey

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,4 +1,5 @@
 use crate::utils::{enums::Survey, o11y::logging::as_error};
+use chrono::NaiveDate;
 use config::{Config, File, Value};
 use dotenvy;
 use mongodb::bson::doc;
@@ -422,13 +423,13 @@ where
     const MAX_INTERVAL: u64 = 60;
     if value < MIN_INTERVAL {
         return Err(serde::de::Error::custom(format!(
-            "filter_refresh_interval_minutes must be at least {} minutes, got {}",
+            "refresh_interval_minutes must be at least {} minutes, got {}",
             MIN_INTERVAL, value
         )));
     }
     if value > MAX_INTERVAL {
         return Err(serde::de::Error::custom(format!(
-            "filter_refresh_interval_minutes must be at most {} minutes, got {}",
+            "refresh_interval_minutes must be at most {} minutes, got {}",
             MAX_INTERVAL, value
         )));
     }
@@ -458,18 +459,51 @@ where
     Ok(value)
 }
 
+fn deserialize_max_match_rate<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<u8>::deserialize(deserializer)?;
+    if let Some(v) = value {
+        if v == 0 || v > 100 {
+            return Err(serde::de::Error::custom(format!(
+                "max_match_rate must be between 1 and 100, got {}",
+                v
+            )));
+        }
+    }
+    Ok(value)
+}
+
 #[derive(Deserialize, Debug, Clone)]
-pub struct SurveyWorkerConfig {
-    #[serde(deserialize_with = "deserialize_command_interval")]
-    pub command_interval: usize, // in milliseconds
+pub struct FilterWorkerConfig {
+    pub n_workers: usize,
     #[serde(
         default = "default_filter_refresh_interval_minutes",
         deserialize_with = "deserialize_filter_refresh_interval"
     )]
-    pub filter_refresh_interval_minutes: u64,
+    pub refresh_interval_minutes: u64,
+    /// Maximum percentage of alerts that a filter is allowed
+    /// to match before it is considered too permissive to activate. Required
+    /// alongside `reference_night` to allow filter activation on this survey;
+    /// if either is missing, filters cannot be activated.
+    #[serde(default, deserialize_with = "deserialize_max_match_rate")]
+    pub max_match_rate: Option<u8>,
+    /// Reference observing night used to gauge how selective a filter is.
+    /// Should be a recent, well-populated night for the survey. Required
+    /// alongside `max_match_rate` to allow filter activation on this survey;
+    /// if either is missing, filters cannot be activated.
+    #[serde(default)]
+    pub reference_night: Option<NaiveDate>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct SurveyWorkerConfig {
+    #[serde(deserialize_with = "deserialize_command_interval")]
+    pub command_interval: usize, // in milliseconds
     pub alert: WorkerConfig,
     pub enrichment: WorkerConfig,
-    pub filter: WorkerConfig,
+    pub filter: FilterWorkerConfig,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -76,7 +76,7 @@ pub enum FilterError {
     FilterNotFound,
     #[error("filter pipeline could not be parsed")]
     FilterPipelineError,
-    #[error("invalid filter pipeline")]
+    #[error("invalid filter pipeline: {0}")]
     InvalidFilterPipeline(String),
     #[error("invalid filter id")]
     InvalidFilterId,

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -869,7 +869,7 @@ pub async fn run_filter_worker<T: FilterWorker>(
     let producer = create_producer(&config.kafka.producer).await?;
     let schema = load_alert_schema()?;
     let filter_refresh_interval =
-        Duration::from_secs(worker_config.filter_refresh_interval_minutes * 60);
+        Duration::from_secs(worker_config.filter.refresh_interval_minutes * 60);
     let mut next_filter_refresh = Instant::now() + filter_refresh_interval;
 
     let command_interval = worker_config.command_interval;

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDate;
 use mongodb::{
     bson::{doc, to_document, Document},
     options::IndexOptions,
@@ -46,6 +47,31 @@ pub fn cutout2bsonbinary(cutout: Vec<u8>) -> mongodb::bson::Binary {
         subtype: mongodb::bson::spec::BinarySubtype::Generic,
         bytes: cutout,
     };
+}
+
+/// Count alerts in `<survey>_alerts` for the observing night labelled by `date`
+/// (local-noon to local-noon JD window).
+///
+/// `programids`:
+/// - `None` → no permission filter (use for surveys without programid, e.g. LSST,
+///   or when caller wants the full unrestricted count).
+/// - `Some(pids)` → restrict to `candidate.programid ∈ pids`.
+#[instrument(skip(db), err)]
+pub async fn count_alerts_for_night(
+    db: &Database,
+    survey: &Survey,
+    date: &NaiveDate,
+    programids: Option<&[i32]>,
+) -> Result<u64, mongodb::error::Error> {
+    let (start_jd, end_jd) = survey.night_jd_window(date);
+    let mut filter = doc! {
+        "candidate.jd": { "$gte": start_jd, "$lt": end_jd },
+    };
+    if let Some(pids) = programids {
+        filter.insert("candidate.programid", doc! { "$in": pids.to_vec() });
+    }
+    let collection: Collection<Document> = db.collection(&format!("{}_alerts", survey));
+    collection.count_documents(filter).await
 }
 
 // This function, for a given survey name (ZTF, LSST), will create

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 use mongodb::{
-    bson::{doc, to_bson, to_document, Document},
+    bson::{doc, to_document, Document},
     options::IndexOptions,
     Collection, Database, IndexModel,
 };
@@ -69,7 +69,7 @@ pub async fn count_alerts_for_night(
     };
     if *survey == Survey::Ztf {
         if let Some(pids) = programids {
-            filter.insert("candidate.programid", doc! { "$in": to_bson(pids)? });
+            filter.insert("candidate.programid", doc! { "$in": pids });
         }
     }
     let collection: Collection<Document> = db.collection(&format!("{}_alerts", survey));

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 use mongodb::{
-    bson::{doc, to_document, Document},
+    bson::{doc, to_bson, to_document, Document},
     options::IndexOptions,
     Collection, Database, IndexModel,
 };
@@ -68,7 +68,7 @@ pub async fn count_alerts_for_night(
         "candidate.jd": { "$gte": start_jd, "$lt": end_jd },
     };
     if let Some(pids) = programids {
-        filter.insert("candidate.programid", doc! { "$in": pids.to_vec() });
+        filter.insert("candidate.programid", doc! { "$in": to_bson(pids)? });
     }
     let collection: Collection<Document> = db.collection(&format!("{}_alerts", survey));
     collection.count_documents(filter).await

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -67,8 +67,10 @@ pub async fn count_alerts_for_night(
     let mut filter = doc! {
         "candidate.jd": { "$gte": start_jd, "$lt": end_jd },
     };
-    if let Some(pids) = programids {
-        filter.insert("candidate.programid", doc! { "$in": to_bson(pids)? });
+    if *survey == Survey::Ztf {
+        if let Some(pids) = programids {
+            filter.insert("candidate.programid", doc! { "$in": to_bson(pids)? });
+        }
     }
     let collection: Collection<Document> = db.collection(&format!("{}_alerts", survey));
     collection.count_documents(filter).await

--- a/src/utils/enums.rs
+++ b/src/utils/enums.rs
@@ -18,12 +18,14 @@ pub enum Survey {
 impl Survey {
     /// Observatory UTC offset in hours.
     ///
-    /// - ZTF  (Palomar, CA):      UTC−7
-    /// - LSST (Cerro Pachón, CL): UTC−3
+    /// - ZTF   (Palomar, CA, USA)       : UTC−7
+    /// - LSST  (Cerro Pachón, CL, Chile): UTC−3
+    /// - DECam (Cerro Tololo, CL, Chile): UTC−4
     pub fn observatory_utc_offset(&self) -> f64 {
         match self {
             Survey::Ztf => -7.0,
             Survey::Lsst => -3.0,
+            Survey::Decam => -4.0,
             _ => 0.0,
         }
     }

--- a/src/utils/enums.rs
+++ b/src/utils/enums.rs
@@ -1,4 +1,5 @@
 use apache_avro_macros::serdavro;
+use chrono::{Datelike, NaiveDate};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -12,6 +13,56 @@ pub enum Survey {
     Lsst,
     #[serde(alias = "decam")]
     Decam,
+}
+
+impl Survey {
+    /// Observatory UTC offset in hours.
+    ///
+    /// - ZTF  (Palomar, CA):      UTC−7
+    /// - LSST (Cerro Pachón, CL): UTC−3
+    pub fn observatory_utc_offset(&self) -> f64 {
+        match self {
+            Survey::Ztf => -7.0,
+            Survey::Lsst => -3.0,
+            _ => 0.0,
+        }
+    }
+
+    /// Convert a calendar date to Julian Date at **local noon** for the survey's
+    /// observatory.
+    ///
+    /// An astronomical "night" for date D spans from JD(D, local noon) to
+    /// JD(D+1, local noon).
+    pub fn date_to_jd_local_noon(&self, date: &NaiveDate) -> f64 {
+        let y = date.year() as f64;
+        let m = date.month() as f64;
+        let d = date.day() as f64;
+
+        let (y_adj, m_adj) = if m <= 2.0 {
+            (y - 1.0, m + 12.0)
+        } else {
+            (y, m)
+        };
+
+        let a = (y_adj / 100.0_f64).floor();
+        let b = 2.0_f64 - a + (a / 4.0_f64).floor();
+
+        // JD at 0h UT (midnight UTC)
+        let jd_midnight =
+            (365.25_f64 * (y_adj + 4716.0)).floor() + (30.6001_f64 * (m_adj + 1.0)).floor() + d + b
+                - 1524.5;
+
+        // Shift to local noon: local noon = (12 − utc_offset) hours UTC
+        jd_midnight + (12.0 - self.observatory_utc_offset()) / 24.0
+    }
+
+    /// JD window `[start, end)` for the observing night labelled by `date`,
+    /// running from local noon of `date` to local noon of `date + 1`.
+    pub fn night_jd_window(&self, date: &NaiveDate) -> (f64, f64) {
+        let start = self.date_to_jd_local_noon(date);
+        let end = self.date_to_jd_local_noon(&(*date + chrono::Duration::days(1)));
+        (start, end)
+    }
 }
 
 impl std::fmt::Display for Survey {

--- a/tests/api/test_filters.rs
+++ b/tests/api/test_filters.rs
@@ -116,10 +116,12 @@ mod tests {
         load_dotenv();
         let database: Database = get_test_db_api().await;
         let auth_app_data = get_test_auth(&database).await.unwrap();
+        let config = AppConfig::from_test_config().unwrap();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(database.clone()))
                 .app_data(web::Data::new(auth_app_data.clone()))
+                .app_data(web::Data::new(config))
                 .wrap(from_fn(auth_middleware))
                 .service(routes::filters::post_filter_version),
         )
@@ -258,10 +260,12 @@ mod tests {
         let (filter_id, token, database) = create_test_filter().await;
         // Create app for PATCH testing
         let auth_app_data = get_test_auth(&database).await.unwrap();
+        let config = AppConfig::from_test_config().unwrap();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(database.clone()))
                 .app_data(web::Data::new(auth_app_data.clone()))
+                .app_data(web::Data::new(config))
                 .wrap(from_fn(auth_middleware))
                 .service(routes::filters::patch_filter)
                 .service(routes::filters::get_filter),

--- a/tests/api/test_filters.rs
+++ b/tests/api/test_filters.rs
@@ -278,10 +278,12 @@ mod tests {
 
         // first GET the filter and get its current active status
         let filter = get_test_filter(&filter_id, &token).await;
-        assert_eq!(filter["active"], true);
+        // newly created filters default to inactive
+        assert_eq!(filter["active"], false);
         assert_ne!(filter["active_fid"].as_str().unwrap(), active_fid_after);
 
-        // Now patch this filter
+        // Now patch this filter (keep it inactive: activation requires a
+        // real-data check against a reference night).
         let patch_data = serde_json::json!({
             "active": false,
             "active_fid": active_fid_after,

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -43,31 +43,35 @@ kafka:
 workers:
   ztf:
     command_interval: 500
-    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:
       n_workers: 1
     filter:
       n_workers: 1
+      refresh_interval_minutes: 15
+      max_match_rate: 5
+      reference_night: "2026-03-16"
   lsst:
     command_interval: 500
-    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:
       n_workers: 0
     filter:
       n_workers: 1
+      refresh_interval_minutes: 15
+      max_match_rate: 5
+      reference_night: "2026-02-23"
   decam:
     command_interval: 500
-    filter_refresh_interval_minutes: 15
     alert:
       n_workers: 1
     enrichment:
       n_workers: 0
     filter:
       n_workers: 1
+      refresh_interval_minutes: 15
 crossmatch:
   ztf:
     - catalog: PS1_DR1

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -72,6 +72,8 @@ workers:
     filter:
       n_workers: 1
       refresh_interval_minutes: 15
+      max_match_rate: 5
+      reference_night:
 crossmatch:
   ztf:
     - catalog: PS1_DR1

--- a/tests/test_conf.rs
+++ b/tests/test_conf.rs
@@ -45,7 +45,12 @@ fn test_load_workers_config() {
     assert_eq!(ztf_worker_config.enrichment.n_workers, 1);
     assert_eq!(ztf_worker_config.filter.n_workers, 1);
     assert_eq!(ztf_worker_config.command_interval, 500);
-    assert_eq!(ztf_worker_config.filter_refresh_interval_minutes, 15);
+    assert_eq!(ztf_worker_config.filter.refresh_interval_minutes, 15);
+    assert_eq!(ztf_worker_config.filter.max_match_rate, Some(5));
+    assert_eq!(
+        ztf_worker_config.filter.reference_night,
+        Some(chrono::NaiveDate::from_ymd_opt(2026, 3, 16).unwrap())
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Set filter active status to false by default on creation
- New filter activation guard: added validate_filter_activation, which runs the pipeline against reference observing nights (2026-03-16 for ZTF, 2026-02-23 for LSST) and rejects it if it matches more than 5% of the alerts the user can access that night.
- Enforced on POST /filter/version: when the new version will replace a running active pipeline, the validation run.                                                                                                                                                               
- Enforced on PATCH /filter: if the filter become active or execution changes, the resulting pipeline is
  re-validated before the update is applied.
  
@Theodlz feel free to update the MAX_FILTER_RESULT_RATIO/testing date as you want.