### PR TITLE
Fix catalogs return by the endpoints

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -227,7 +227,7 @@ const BABAMUL_PUBLIC_ROUTES: &[&str] = &[
     "/babamul/surveys/ztf/schemas",
     "/babamul/docs",
     "/babamul/stats/nightly",
-    "/babamul/stats/catalogs",
+    "/babamul/stats/collections",
     "/babamul/stats/kafka",
 ];
 

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -107,7 +107,7 @@ pub struct ApiDoc;
         routes::babamul::surveys::cutouts::get_cutouts,
         routes::babamul::surveys::alerts::get_alerts,
         routes::babamul::surveys::alerts::cone_search_alerts,
-        routes::babamul::stats::catalogs::get_catalog_stats,
+        routes::babamul::stats::collections::get_collection_stats,
         routes::babamul::stats::kafka::get_kafka_stats,
         routes::babamul::stats::nightly::get_nightly_stats,
     ),

--- a/src/api/routes/babamul/stats/catalogs.rs
+++ b/src/api/routes/babamul/stats/catalogs.rs
@@ -92,16 +92,19 @@ pub async fn get_catalog_stats(
             return response::internal_error(&format!("Error listing collections: {}", e));
         }
     };
+    let is_safe = |name: &str| {
+        !name.is_empty()
+            && !name.starts_with("system.")
+            && !PROTECTED_COLLECTION_NAMES.contains(&name)
+    };
     let mut expected: HashSet<String> = config
         .crossmatch
         .values()
         .flat_map(|cats| cats.iter().map(|c| c.catalog.clone()))
+        .filter(|name| is_safe(name))
         .collect();
     for name in &collection_names {
-        if (name.starts_with("ZTF_") || name.starts_with("LSST_"))
-            && !PROTECTED_COLLECTION_NAMES.contains(&name.as_str())
-            && !name.starts_with("system.")
-        {
+        if (name.starts_with("ZTF_") || name.starts_with("LSST_")) && is_safe(name) {
             expected.insert(name.clone());
         }
     }

--- a/src/api/routes/babamul/stats/catalogs.rs
+++ b/src/api/routes/babamul/stats/catalogs.rs
@@ -1,11 +1,13 @@
 use super::STATS_COLLECTION;
 use crate::api::db::PROTECTED_COLLECTION_NAMES;
 use crate::api::models::response;
+use crate::conf::AppConfig;
 use actix_web::{get, web, HttpResponse};
 use chrono::Utc;
 use futures::StreamExt;
 use mongodb::{bson::doc, Collection, Database};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use utoipa::ToSchema;
 
 const CATALOG_STATS_CACHE_KEY: &str = "catalog_stats";
@@ -76,12 +78,37 @@ pub struct CatalogStats {
 pub async fn get_catalog_stats(
     query: web::Query<CatalogStatsQuery>,
     db: web::Data<Database>,
+    config: web::Data<AppConfig>,
 ) -> HttpResponse {
     let include_count = query.count.unwrap_or(false);
     let include_size = query.size.unwrap_or(false);
     let now_ts = Utc::now().timestamp() as f64;
 
-    // When extra details are requested, try the cache first
+    // Build the set of catalogs to expose:
+    // configured crossmatch catalogs + survey alert collections (`ZTF_*` / `LSST_*`)
+    let collection_names = match db.list_collection_names().await {
+        Ok(c) => c,
+        Err(e) => {
+            return response::internal_error(&format!("Error listing collections: {}", e));
+        }
+    };
+    let mut expected: HashSet<String> = config
+        .crossmatch
+        .values()
+        .flat_map(|cats| cats.iter().map(|c| c.catalog.clone()))
+        .collect();
+    for name in &collection_names {
+        if (name.starts_with("ZTF_") || name.starts_with("LSST_"))
+            && !PROTECTED_COLLECTION_NAMES.contains(&name.as_str())
+            && !name.starts_with("system.")
+        {
+            expected.insert(name.clone());
+        }
+    }
+
+    // When extra details are requested, try the cache
+    // but only serve it if its set of catalog names matches what we expect now.
+    // If catalogs were added or removed, fall through and refetch.
     if include_count || include_size {
         let stats_collection: Collection<CatalogStatsCacheEntry> = db.collection(STATS_COLLECTION);
 
@@ -92,40 +119,28 @@ pub async fn get_catalog_stats(
             })
             .await
         {
-            let catalogs = cached
-                .catalogs
-                .into_iter()
-                .map(|c| CatalogEntry {
-                    name: c.name,
-                    count: if include_count { c.count } else { None },
-                    size_bytes: if include_size { c.size_bytes } else { None },
-                })
-                .collect::<Vec<_>>();
-            let stats = CatalogStats {
-                n_catalogs: catalogs.len(),
-                catalogs,
-            };
-            return response::ok_ser("catalog stats (cached)", stats);
+            let cached_names: HashSet<String> =
+                cached.catalogs.iter().map(|c| c.name.clone()).collect();
+            if cached_names == expected {
+                let catalogs = cached
+                    .catalogs
+                    .into_iter()
+                    .map(|c| CatalogEntry {
+                        name: c.name,
+                        count: if include_count { c.count } else { None },
+                        size_bytes: if include_size { c.size_bytes } else { None },
+                    })
+                    .collect::<Vec<_>>();
+                let stats = CatalogStats {
+                    n_catalogs: catalogs.len(),
+                    catalogs,
+                };
+                return response::ok_ser("catalog stats (cached)", stats);
+            }
         }
     }
 
-    // List catalog names
-    let collection_names = match db.list_collection_names().await {
-        Ok(c) => c,
-        Err(e) => {
-            return response::internal_error(&format!("Error listing collections: {}", e));
-        }
-    };
-
-    let mut catalog_names: Vec<String> = collection_names
-        .into_iter()
-        .filter(|name| {
-            !PROTECTED_COLLECTION_NAMES.contains(&name.as_str())
-                && !name.starts_with("system.")
-                && !name.starts_with("ZTF_")
-                && !name.starts_with("LSST_")
-        })
-        .collect();
+    let mut catalog_names: Vec<String> = expected.into_iter().collect();
     catalog_names.sort();
 
     let fetch_details = include_count || include_size;

--- a/src/api/routes/babamul/stats/collections.rs
+++ b/src/api/routes/babamul/stats/collections.rs
@@ -10,26 +10,26 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use utoipa::ToSchema;
 
-const CATALOG_STATS_CACHE_KEY: &str = "catalog_stats";
-/// Cache catalog stats for 5 days
-const CATALOG_STATS_CACHE_SECS: f64 = 5.0 * 24.0 * 3600.0;
+const COLLECTION_STATS_CACHE_KEY: &str = "collection_stats";
+/// Cache collection stats for 5 days
+const COLLECTION_STATS_CACHE_SECS: f64 = 5.0 * 24.0 * 3600.0;
 
-/// MongoDB cache document storing the full catalog stats payload (with counts and sizes)
+/// MongoDB cache document storing the full collection stats payload (with counts and sizes)
 /// under a single well-known `_id`, along with the expiration timestamp.
 #[derive(Debug, Serialize, Deserialize)]
-struct CatalogStatsCacheEntry {
+struct CollectionStatsCacheEntry {
     #[serde(rename = "_id")]
     id: String,
-    n_catalogs: usize,
-    catalogs: Vec<CatalogEntry>,
+    n_collections: usize,
+    collections: Vec<CollectionEntry>,
     updated_at: f64,
     cache_until: f64,
 }
 
-/// Per-catalog stats entry. `count` and `size_bytes` are populated only when the
+/// Per-collection stats entry. `count` and `size_bytes` are populated only when the
 /// corresponding query flag is set; otherwise they are omitted from the response.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct CatalogEntry {
+pub struct CollectionEntry {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<u64>,
@@ -38,45 +38,48 @@ pub struct CatalogEntry {
     pub size_bytes: Option<u64>,
 }
 
-/// Query parameters controlling which optional details are included in the catalog
+/// Query parameters controlling which optional details are included in the collection
 /// stats response.
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CatalogStatsQuery {
-    /// Include document counts per catalog.
+pub struct CollectionStatsQuery {
+    /// Include document counts per collection.
     pub count: Option<bool>,
-    /// Include storage size per catalog.
+    /// Include storage size per collection.
     pub size: Option<bool>,
 }
 
-/// Response payload for `/babamul/stats/catalogs`: the catalog count and per-catalog
+/// Response payload for `/babamul/stats/collections`: the collection count and per-collection
 /// entries.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct CatalogStats {
-    pub n_catalogs: usize,
-    pub catalogs: Vec<CatalogEntry>,
+pub struct CollectionStats {
+    pub n_collections: usize,
+    pub collections: Vec<CollectionEntry>,
 }
 
-/// Get catalog statistics.
-///
-/// By default, returns just the list of catalog names. Use `count=true` and/or
-/// `size=true` query parameters to include document counts and storage sizes.
-/// Results with counts/sizes are cached for 5 days since catalogs rarely change.
+/// Get statistics for catalogs declared under `crossmatch` in the application config,
+/// and survey alert collections matching `ZTF_*` / `LSST_*`.
+/// Names matching `system.*` or any `PROTECTED_COLLECTION_NAMES` entry are
+/// always excluded.
+/// By default, returns just the list of collection names. Use `count=true`
+/// and/or `size=true` query parameters to include document counts and storage
+/// sizes. Results with counts/sizes are cached for 5 days; the cache is
+/// auto-invalidated when the set of expected collections changes.
 #[utoipa::path(
     get,
-    path = "/babamul/stats/catalogs",
+    path = "/babamul/stats/collections",
     params(
-        ("count" = Option<bool>, Query, description = "Include document counts per catalog."),
-        ("size" = Option<bool>, Query, description = "Include storage size per catalog."),
+        ("count" = Option<bool>, Query, description = "Include document counts per collection."),
+        ("size" = Option<bool>, Query, description = "Include storage size per collection."),
     ),
     responses(
-        (status = 200, description = "Catalog stats retrieved", body = CatalogStats),
+        (status = 200, description = "Collection stats retrieved", body = CollectionStats),
         (status = 500, description = "Internal server error")
     ),
     tags = ["Stats"]
 )]
-#[get("/stats/catalogs")]
-pub async fn get_catalog_stats(
-    query: web::Query<CatalogStatsQuery>,
+#[get("/stats/collections")]
+pub async fn get_collection_stats(
+    query: web::Query<CollectionStatsQuery>,
     db: web::Data<Database>,
     config: web::Data<AppConfig>,
 ) -> HttpResponse {
@@ -84,7 +87,7 @@ pub async fn get_catalog_stats(
     let include_size = query.size.unwrap_or(false);
     let now_ts = Utc::now().timestamp() as f64;
 
-    // Build the set of catalogs to expose:
+    // Build the set of collections to expose:
     // configured crossmatch catalogs + survey alert collections (`ZTF_*` / `LSST_*`)
     let collection_names = match db.list_collection_names().await {
         Ok(c) => c,
@@ -110,45 +113,46 @@ pub async fn get_catalog_stats(
     }
 
     // When extra details are requested, try the cache
-    // but only serve it if its set of catalog names matches what we expect now.
-    // If catalogs were added or removed, fall through and refetch.
+    // but only serve it if its set of collection names matches what we expect now.
+    // If collections were added or removed, fall through and refetch.
     if include_count || include_size {
-        let stats_collection: Collection<CatalogStatsCacheEntry> = db.collection(STATS_COLLECTION);
+        let stats_collection: Collection<CollectionStatsCacheEntry> =
+            db.collection(STATS_COLLECTION);
 
         if let Ok(Some(cached)) = stats_collection
             .find_one(doc! {
-                "_id": CATALOG_STATS_CACHE_KEY,
+                "_id": COLLECTION_STATS_CACHE_KEY,
                 "cache_until": { "$gt": now_ts },
             })
             .await
         {
             let cached_names: HashSet<String> =
-                cached.catalogs.iter().map(|c| c.name.clone()).collect();
+                cached.collections.iter().map(|c| c.name.clone()).collect();
             if cached_names == expected {
-                let catalogs = cached
-                    .catalogs
+                let collections = cached
+                    .collections
                     .into_iter()
-                    .map(|c| CatalogEntry {
+                    .map(|c| CollectionEntry {
                         name: c.name,
                         count: if include_count { c.count } else { None },
                         size_bytes: if include_size { c.size_bytes } else { None },
                     })
                     .collect::<Vec<_>>();
-                let stats = CatalogStats {
-                    n_catalogs: catalogs.len(),
-                    catalogs,
+                let stats = CollectionStats {
+                    n_collections: collections.len(),
+                    collections,
                 };
-                return response::ok_ser("catalog stats (cached)", stats);
+                return response::ok_ser("collection stats (cached)", stats);
             }
         }
     }
 
-    let mut catalog_names: Vec<String> = expected.into_iter().collect();
-    catalog_names.sort();
+    let mut names: Vec<String> = expected.into_iter().collect();
+    names.sort();
 
     let fetch_details = include_count || include_size;
-    let mut catalogs = Vec::new();
-    for name in &catalog_names {
+    let mut collections = Vec::new();
+    for name in &names {
         let (count, size_bytes) = if fetch_details {
             let collection = db.collection::<mongodb::bson::Document>(name);
             let count = match collection.estimated_document_count().await {
@@ -176,20 +180,23 @@ pub async fn get_catalog_stats(
                         })
                         .map(|v| v as u64)
                         .or_else(|| {
-                            tracing::warn!("Missing or invalid storageSize for catalog {}", name);
+                            tracing::warn!(
+                                "Missing or invalid storageSize for collection {}",
+                                name
+                            );
                             None
                         }),
                     Some(Err(e)) => {
-                        tracing::warn!("Error reading $collStats for catalog {}: {}", name, e);
+                        tracing::warn!("Error reading $collStats for collection {}: {}", name, e);
                         None
                     }
                     None => {
-                        tracing::warn!("Empty $collStats result for catalog {}", name);
+                        tracing::warn!("Empty $collStats result for collection {}", name);
                         None
                     }
                 },
                 Err(e) => {
-                    tracing::warn!("Error running $collStats on catalog {}: {}", name, e);
+                    tracing::warn!("Error running $collStats on collection {}: {}", name, e);
                     None
                 }
             };
@@ -198,7 +205,7 @@ pub async fn get_catalog_stats(
             (None, None)
         };
 
-        catalogs.push(CatalogEntry {
+        collections.push(CollectionEntry {
             name: name.clone(),
             count,
             size_bytes,
@@ -207,36 +214,37 @@ pub async fn get_catalog_stats(
 
     // Upsert full details into cache
     if fetch_details {
-        let stats_collection: Collection<CatalogStatsCacheEntry> = db.collection(STATS_COLLECTION);
-        let cache_entry = CatalogStatsCacheEntry {
-            id: CATALOG_STATS_CACHE_KEY.to_string(),
-            n_catalogs: catalogs.len(),
-            catalogs: catalogs.clone(),
+        let stats_collection: Collection<CollectionStatsCacheEntry> =
+            db.collection(STATS_COLLECTION);
+        let cache_entry = CollectionStatsCacheEntry {
+            id: COLLECTION_STATS_CACHE_KEY.to_string(),
+            n_collections: collections.len(),
+            collections: collections.clone(),
             updated_at: now_ts,
-            cache_until: now_ts + CATALOG_STATS_CACHE_SECS,
+            cache_until: now_ts + COLLECTION_STATS_CACHE_SECS,
         };
         if let Err(e) = stats_collection
-            .replace_one(doc! { "_id": CATALOG_STATS_CACHE_KEY }, &cache_entry)
+            .replace_one(doc! { "_id": COLLECTION_STATS_CACHE_KEY }, &cache_entry)
             .upsert(true)
             .await
         {
-            tracing::warn!("Failed to upsert catalog stats cache: {}", e);
+            tracing::warn!("Failed to upsert collection stats cache: {}", e);
         }
     }
 
-    let catalogs: Vec<CatalogEntry> = catalogs
+    let collections: Vec<CollectionEntry> = collections
         .into_iter()
-        .map(|c| CatalogEntry {
+        .map(|c| CollectionEntry {
             name: c.name,
             count: if include_count { c.count } else { None },
             size_bytes: if include_size { c.size_bytes } else { None },
         })
         .collect();
 
-    let stats = CatalogStats {
-        n_catalogs: catalogs.len(),
-        catalogs,
+    let stats = CollectionStats {
+        n_collections: collections.len(),
+        collections,
     };
 
-    response::ok_ser("catalog stats", stats)
+    response::ok_ser("collection stats", stats)
 }

--- a/src/api/routes/babamul/stats/mod.rs
+++ b/src/api/routes/babamul/stats/mod.rs
@@ -1,9 +1,9 @@
-pub mod catalogs;
+pub mod collections;
 pub mod kafka;
 pub mod nightly;
 
 pub const STATS_COLLECTION: &str = "stats";
 
-pub use catalogs::get_catalog_stats;
+pub use collections::get_collection_stats;
 pub use kafka::get_kafka_stats;
 pub use nightly::get_nightly_stats;

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -78,7 +78,7 @@ async fn main() -> std::io::Result<()> {
                     .service(routes::babamul::surveys::get_alerts)
                     .service(routes::babamul::surveys::cone_search_alerts)
                     .service(routes::babamul::stats::get_nightly_stats)
-                    .service(routes::babamul::stats::get_catalog_stats)
+                    .service(routes::babamul::stats::get_collection_stats)
                     .service(routes::babamul::stats::get_kafka_stats)
                     .service(routes::babamul::tokens::get_tokens)
                     .service(routes::babamul::tokens::post_token)


### PR DESCRIPTION
Enhance catalog stats retrieval by validating cached data against expected catalog names, only return catalogs in the configs and also return the ZTF_ and LSST_ collections.

_@Theodlz You had previously suggested changing this, but at the time I thought there might be some value in keeping it as it was (e.g., displaying catalogs that are already ingested even if they’re not in the config yet)._
_However, while working on the watchlist PR, it became clear that we may also have other collections in the DB that are not catalogs and should remain private (and we don't want to need to think about changing this endpoints every time)._

_I’m currently including `ZTF_` and `LSST_` collections as well since they can be valuable, but I can remove them if you disagree. Since the endpoint now returns more than just catalogs, renaming it to `collections` seems accurate._