### PR TITLE
feat: Make filter test endpoints publicly accessible

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -170,7 +170,7 @@ pub async fn get_test_auth(db: &Database) -> Result<AuthProvider, std::io::Error
     AuthProvider::new(&app_config, &db).await
 }
 
-pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/"];
+pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/", "/filters/test", "/filters/test/count"];
 
 pub async fn auth_middleware(
     req: ServiceRequest,


### PR DESCRIPTION
Adds `/filters/test` and `/filters/test/count` to the `PUBLIC_ROUTES` list in the auth middleware, allowing these endpoints to be accessed without authentication.

This is needed for the public filter tester UI being added to babamul-web (see companion PR: https://github.com/boom-astro/babamul-web/pull/57), where users can test MongoDB aggregation pipelines against live alert data without needing credentials.

Only the test/count endpoints are made public. Filter CRUD operations (create, update, delete) remain authenticated.