### PR TITLE
Add permissions to add_filter

### DIFF
--- a/src/bin/add_filter.rs
+++ b/src/bin/add_filter.rs
@@ -1,5 +1,5 @@
 use boom::conf::{load_dotenv, AppConfig};
-use boom::filter::{Filter, FilterVersion};
+use boom::filter::{Filter, FilterVersion, SURVEYS_REQUIRING_PERMISSIONS};
 use boom::utils::enums::Survey;
 use clap::Parser;
 use std::collections::HashMap;
@@ -20,6 +20,13 @@ struct Cli {
         default_value = "Added via CLI"
     )]
     description: String,
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_values_t = vec![1i32, 2, 3],
+        help = "Comma-separated permission program IDs (ZTF only; ignored for surveys without a permission system)."
+    )]
+    permissions: Vec<i32>,
 }
 
 fn now_jd() -> f64 {
@@ -43,6 +50,11 @@ async fn main() {
     let description = args.description;
     let survey = args.survey;
     let filter_file = args.filter_file;
+    let permissions = if SURVEYS_REQUIRING_PERMISSIONS.contains(&survey) {
+        HashMap::from([(survey.clone(), args.permissions)])
+    } else {
+        HashMap::new()
+    };
 
     // read the JSON as a string
     let filter_pipeline = match std::fs::read_to_string(&filter_file) {
@@ -57,15 +69,14 @@ async fn main() {
     // group_id, and a fv array with one doc that has a fid field and a pipeline field
     let filter_id: String = uuid::Uuid::new_v4().to_string();
 
-    let permissions = HashMap::from([(Survey::Ztf, vec![1, 2, 3])]);
     let filter = Filter {
         id: filter_id.clone(),
-        name: name,
+        name,
         description: Some(description),
         active: true,
         user_id: "cli".to_string(),
-        survey: survey,
-        permissions: permissions,
+        survey,
+        permissions,
         fv: vec![FilterVersion {
             fid: "v2e0fs".to_string(),
             pipeline: filter_pipeline,

--- a/src/bin/add_filter.rs
+++ b/src/bin/add_filter.rs
@@ -23,10 +23,9 @@ struct Cli {
     #[arg(
         long,
         value_delimiter = ',',
-        default_values_t = vec![1i32, 2, 3],
-        help = "Comma-separated permission program IDs (ZTF only; ignored for surveys without a permission system)."
+        help = "Comma-separated permission program IDs. Required for surveys with a permission system (e.g. ZTF: 1=public, 2=partnership, 3=Caltech); ignored for others."
     )]
-    permissions: Vec<i32>,
+    permissions: Option<Vec<i32>>,
 }
 
 fn now_jd() -> f64 {
@@ -51,7 +50,14 @@ async fn main() {
     let survey = args.survey;
     let filter_file = args.filter_file;
     let permissions = if SURVEYS_REQUIRING_PERMISSIONS.contains(&survey) {
-        HashMap::from([(survey.clone(), args.permissions)])
+        let Some(perms) = args.permissions else {
+            eprintln!(
+                "--permissions is required for survey {:?} (e.g. --permissions 1 for public-only)",
+                survey
+            );
+            std::process::exit(1);
+        };
+        HashMap::from([(survey.clone(), perms)])
     } else {
         HashMap::new()
     };

--- a/src/bin/add_filter.rs
+++ b/src/bin/add_filter.rs
@@ -1,5 +1,5 @@
 use boom::conf::{load_dotenv, AppConfig};
-use boom::filter::{Filter, FilterVersion, SURVEYS_REQUIRING_PERMISSIONS};
+use boom::filter::{Filter, FilterVersion, SURVEYS_REQUIRING_PERMISSIONS, VALID_ZTF_PROGRAMIDS};
 use boom::utils::enums::Survey;
 use clap::Parser;
 use std::collections::HashMap;
@@ -57,6 +57,22 @@ async fn main() {
             );
             std::process::exit(1);
         };
+        let valid: &[i32] = match survey {
+            Survey::Ztf => &VALID_ZTF_PROGRAMIDS,
+            _ => &[],
+        };
+        let invalid: Vec<i32> = perms
+            .iter()
+            .copied()
+            .filter(|p| !valid.contains(p))
+            .collect();
+        if !invalid.is_empty() {
+            eprintln!(
+                "Invalid programid(s) {:?} for survey {:?}; valid values are {:?}",
+                invalid, survey, valid
+            );
+            std::process::exit(1);
+        }
         HashMap::from([(survey.clone(), perms)])
     } else {
         HashMap::new()

--- a/src/filter/base.rs
+++ b/src/filter/base.rs
@@ -60,6 +60,9 @@ static ALERT_PROCESSED: LazyLock<Counter<u64>> = LazyLock::new(|| {
 // Surveys that require permissions to be defined in filters
 pub const SURVEYS_REQUIRING_PERMISSIONS: [Survey; 1] = [Survey::Ztf];
 
+// Valid ZTF programids: 1 = public, 2 = partnership, 3 = Caltech.
+pub const VALID_ZTF_PROGRAMIDS: [i32; 3] = [1, 2, 3];
+
 #[derive(thiserror::Error, Debug)]
 pub enum FilterError {
     #[error("value access error from bson")]
@@ -1368,7 +1371,7 @@ mod tests {
         let filter_name = format!("test_filter_{}", &filter_id[..8]);
         // first, insert a filter
         let mut permissions = HashMap::new();
-        permissions.insert(Survey::Ztf, vec![1, 2, 3]);
+        permissions.insert(Survey::Ztf, VALID_ZTF_PROGRAMIDS.to_vec());
         let filter = Filter {
             id: filter_id.clone(),
             name: filter_name.clone(),
@@ -1398,7 +1401,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_active_filter_pipeline() {
         let mut permissions = HashMap::new();
-        permissions.insert(Survey::Ztf, vec![1, 2, 3]);
+        permissions.insert(Survey::Ztf, VALID_ZTF_PROGRAMIDS.to_vec());
         let mut filter = Filter {
             id: "test_filter".to_string(),
             name: "test_filter".to_string(),

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -8,6 +8,7 @@ pub use base::{
     send_alert_to_kafka, to_avro_bytes, uses_field_in_filter, validate_filter_pipeline, Alert,
     Filter, FilterError, FilterResults, FilterVersion, FilterWorker, FilterWorkerError,
     LoadedFilter, Origin, Photometry, SurveyMatch, SurveyMatches, SURVEYS_REQUIRING_PERMISSIONS,
+    VALID_ZTF_PROGRAMIDS,
 };
 use base::{parse_programid_candid_tuple, update_aliases_index_multiple, Classification};
 use lsst::{build_lsst_aux_data, insert_lsst_aux_pipeline_if_needed};


### PR DESCRIPTION
Add permissions argument to add filter CLI for surveys requiring permissions.

_The argument is optional for Survey without permissions, but required for survey with permissions._