### PR TITLE
Add reprocess_crossmatch binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +631,7 @@ dependencies = [
  "apache-avro",
  "apache-avro-derive",
  "apache-avro-macros",
+ "async-channel",
  "async-trait",
  "base64 0.22.1",
  "bcrypt",
@@ -929,6 +942,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1466,6 +1488,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3157,6 +3200,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ aes-gcm = "0.10.3"
 apache-avro = { version = "0.21.0", features = ["snappy", "derive"] }
 apache-avro-derive = "0.21.0"
 apache-avro-macros = { version = "1", path = "apache-avro-macros" }
+async-channel = "2.5.0"
 async-trait = "0.1.89"
 base64 = "0.22.1"
 bcrypt = "0.17.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ COPY --from=builder /app/target/release/kafka_producer /app/kafka_producer
 COPY --from=builder /app/target/release/api /app/boom-api
 COPY --from=builder /app/target/release/migrate_fp_flux /app/migrate_fp_flux
 COPY --from=builder /app/target/release/migrate_snr /app/migrate_snr
+COPY --from=builder /app/target/release/reprocess_crossmatch /app/reprocess_crossmatch
 COPY --from=builder /opt/ort /opt/ort
 
 CMD ["/app/scheduler"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -37,7 +37,7 @@ RUN mkdir -p /app/src && \
     cargo build --release && rm -rf /app/src
 
 COPY ./src /app/src
-RUN cargo build --release --bin scheduler --bin migrate_fp_flux --bin migrate_snr
+RUN cargo build --release --bin scheduler --bin migrate_fp_flux --bin migrate_snr --bin reprocess_crossmatch
 
 FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 AS app
 
@@ -56,6 +56,7 @@ WORKDIR /app
 COPY --from=builder /app/target/release/scheduler /app/scheduler
 COPY --from=builder /app/target/release/migrate_fp_flux /app/migrate_fp_flux
 COPY --from=builder /app/target/release/migrate_snr /app/migrate_snr
+COPY --from=builder /app/target/release/reprocess_crossmatch /app/reprocess_crossmatch
 COPY --from=builder /opt/ort /opt/ort
 
 CMD ["/app/scheduler"]

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -7,6 +7,7 @@ use boom::{
             logging::{build_subscriber, log_error, WARN},
             metrics::init_metrics,
         },
+        parser::parse_positive_usize,
     },
 };
 
@@ -36,7 +37,7 @@ struct Cli {
     config: String,
 
     /// Number of processes to use to read the Kafka stream in parallel
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1, value_parser = parse_positive_usize)]
     processes: usize,
 
     /// Clear the in-memory (Valkey) queue of alerts already consumed from Kafka
@@ -45,7 +46,7 @@ struct Cli {
 
     /// Set a maximum number of alerts to hold in memory (Valkey), default is
     /// 15000
-    #[arg(long, value_name = "MAX", default_value_t = 15000)]
+    #[arg(long, value_name = "MAX", default_value_t = 15000, value_parser = parse_positive_usize)]
     max_in_queue: usize,
 
     /// Simulated mode (for testing purposes, LSST only)

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -46,7 +46,7 @@ struct Cli {
 
     /// Set a maximum number of alerts to hold in memory (Valkey), default is
     /// 15000
-    #[arg(long, value_name = "MAX", default_value_t = 15000, value_parser = parse_positive_usize)]
+    #[arg(long, value_name = "MAX", default_value_t = 15000)]
     max_in_queue: usize,
 
     /// Simulated mode (for testing purposes, LSST only)

--- a/src/bin/migrate_fp_flux.rs
+++ b/src/bin/migrate_fp_flux.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use boom::conf::{load_dotenv, AppConfig};
 use boom::utils::data::make_progress_bar;
 use boom::utils::lightcurves::ZTF_ZP;
+use boom::utils::parser::parse_positive_usize;
 use clap::Parser;
 use futures::TryStreamExt;
 use mongodb::bson::{doc, Bson, Document};
@@ -30,10 +31,10 @@ struct Cli {
     config: Option<String>,
 
     /// Number of document IDs to collect per update_many batch
-    #[arg(long, default_value = "5000")]
+    #[arg(long, default_value_t = 5000, value_parser = parse_positive_usize)]
     batch_size: usize,
     /// Whether or not validation should run after migration. Defaults to False (caution, it's very slow!)
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value_t = false)]
     validate: bool,
 }
 

--- a/src/bin/migrate_fp_flux.rs
+++ b/src/bin/migrate_fp_flux.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use boom::conf::{load_dotenv, AppConfig};
+use boom::utils::data::make_progress_bar;
 use boom::utils::lightcurves::ZTF_ZP;
 use clap::Parser;
 use futures::TryStreamExt;
-use indicatif::{ProgressBar, ProgressStyle};
 use mongodb::bson::{doc, Bson, Document};
 use tracing::{error, info, Level};
 use tracing_subscriber::FmtSubscriber;
@@ -47,14 +47,7 @@ async fn run_batched_update(
     estimated_total: u64,
     label: &str,
 ) -> i64 {
-    let pb = ProgressBar::new(estimated_total);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{msg} {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
-    pb.set_message(label.to_string());
+    let pb = make_progress_bar(estimated_total, label.to_string());
 
     let mut cursor = match collection
         .find(filter)
@@ -329,14 +322,7 @@ async fn validate(collection: &mongodb::Collection<Document>) {
         }
     };
 
-    let pb = ProgressBar::new(estimated_count);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "validate {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
-    pb.set_message("validate".to_string());
+    let pb = make_progress_bar(estimated_count, "validate".to_string());
 
     let mut cursor = match collection.aggregate(pipeline).await {
         Ok(c) => c,

--- a/src/bin/migrate_snr.rs
+++ b/src/bin/migrate_snr.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use boom::conf::{load_dotenv, AppConfig};
+use boom::utils::data::make_progress_bar;
 use clap::Parser;
 use futures::TryStreamExt;
-use indicatif::{ProgressBar, ProgressStyle};
 use mongodb::bson::{doc, Bson, Document};
 use tracing::{error, info, Level};
 use tracing_subscriber::FmtSubscriber;
@@ -56,14 +56,7 @@ async fn run_batched_update(
     estimated_total: u64,
     label: &str,
 ) -> i64 {
-    let pb = ProgressBar::new(estimated_total);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{msg} {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
-    pb.set_message(label.to_string());
+    let pb = make_progress_bar(estimated_total, label.to_string());
 
     let mut cursor = match collection
         .find(filter)
@@ -787,13 +780,7 @@ async fn validate_ztf_alerts(db: &mongodb::Database) {
         }
     }];
 
-    let pb = ProgressBar::new(estimated);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "validate ZTF_alerts {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
+    let pb = make_progress_bar(estimated, "validate ZTF_alerts".to_string());
 
     let mut cursor = match collection.aggregate(pipeline).await {
         Ok(c) => c,
@@ -904,13 +891,7 @@ async fn validate_ztf_alerts_aux(db: &mongodb::Database) {
         }
     }];
 
-    let pb = ProgressBar::new(estimated);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "validate ZTF_alerts_aux {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
+    let pb = make_progress_bar(estimated, "validate ZTF_alerts_aux".to_string());
 
     let mut cursor = match collection.aggregate(pipeline).await {
         Ok(c) => c,
@@ -1015,13 +996,7 @@ async fn validate_lsst_alerts(db: &mongodb::Database) {
         }
     }];
 
-    let pb = ProgressBar::new(estimated);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "validate LSST_alerts {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
+    let pb = make_progress_bar(estimated, "validate LSST_alerts".to_string());
 
     let mut cursor = match collection.aggregate(pipeline).await {
         Ok(c) => c,
@@ -1134,13 +1109,7 @@ async fn validate_lsst_alerts_aux(db: &mongodb::Database) {
         }
     }];
 
-    let pb = ProgressBar::new(estimated);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "validate LSST_alerts_aux {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
-        )
-        .unwrap(),
-    );
+    let pb = make_progress_bar(estimated, "validate LSST_alerts_aux".to_string());
 
     let mut cursor = match collection.aggregate(pipeline).await {
         Ok(c) => c,

--- a/src/bin/migrate_snr.rs
+++ b/src/bin/migrate_snr.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use boom::conf::{load_dotenv, AppConfig};
 use boom::utils::data::make_progress_bar;
+use boom::utils::parser::parse_positive_usize;
 use clap::Parser;
 use futures::TryStreamExt;
 use mongodb::bson::{doc, Bson, Document};
@@ -38,11 +39,11 @@ struct Cli {
     config: Option<String>,
 
     /// Number of document IDs to collect per update_many batch
-    #[arg(long, default_value = "5000")]
+    #[arg(long, default_value_t = 5000, value_parser = parse_positive_usize)]
     batch_size: usize,
 
     /// Whether or not validation should run after migration. Defaults to false (caution, it's slow!)
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value_t = false)]
     validate: bool,
 }
 

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -5,22 +5,28 @@ use boom::{
     utils::{
         data::make_progress_bar,
         enums::Survey,
-        spatial::{cm_radius_arcsec, distance_kpc_from_arcsec, get_f64_from_doc, xmatch},
+        spatial::{
+            cm_radius_arcsec, distance_kpc_from_arcsec, get_f64_from_doc, xmatch, Coordinates,
+        },
     },
 };
 use clap::{Parser, ValueEnum};
-use flare::spatial::great_circle_distance;
+use flare::{spatial::great_circle_distance, Time};
 use futures::TryStreamExt;
+use indicatif::ProgressBar;
 use mongodb::{
-    bson::{doc, Bson, Document},
+    bson::{doc, Document},
     options::{UpdateOneModel, WriteModel},
+    Namespace,
 };
 use tracing::{error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
-/// Binary for reprocessing crossmatches between a survey's aux collection and one or more catalogs.
+const QUEUE_MULTIPLIER: usize = 2;
+
+/// Binary for reprocessing crossmatches between a survey's alerts_aux collection and one or more catalogs.
 /// The scheduler pipeline only crossmatches at first insert, so adding a catalog to
-/// `crossmatch.<survey>` in config.yaml leaves pre-existing aux records with
+/// `crossmatch.<survey>` in config.yaml leaves pre-existing alerts_aux records with
 /// no entry for it, so this binary fills in those gaps. It can also be used to reprocess existing
 /// crossmatches if the matching parameters (e.g. radius) for a catalog are changed.
 #[derive(Parser)]
@@ -36,29 +42,454 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = Direction::Auto)]
     direction: Direction,
 
-    #[arg(long, value_name = "FILE")]
-    config: Option<String>,
+    #[arg(long, value_name = "FILE", default_value = "config.yaml")]
+    config: String,
 
-    #[arg(long, default_value = "5000")]
+    #[arg(long, default_value_t = 5000)]
     batch_size: usize,
+
+    /// Number of parallel worker tasks. Each worker holds its own DB connection.
+    #[arg(long, default_value_t = 1)]
+    processes: usize,
 }
 
 /// Reprocessing can be done in two directions:
-/// - Checking the crossmatch catalogs for each aux record,
-/// - Checking the aux collection for each catalog record.
+/// - Checking the crossmatch catalogs for each alerts_aux record,
+/// - Checking the alerts_aux collection for each catalog record.
 ///
 /// To optimize the reprocessing, the binary can loop over either
-/// the aux collection or the catalog collection, depending on which is smaller.
+/// the alerts_aux collection or the catalog collection, depending on which is smaller.
 /// If `--direction` is not provided, it checks the estimated document counts
 /// of each collection and loops over the smaller one.
-#[derive(Copy, Clone, Debug, ValueEnum)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 enum Direction {
     /// Pick `objects` or `catalog` per catalog based on which side has fewer rows.
     Auto,
-    /// Loop over aux records, query catalog. Best when aux is smaller.
+    /// Loop over alerts_aux records, query catalog. Best when alerts_aux is smaller.
     Objects,
     /// Loop over catalog rows, query aux. Best when catalog is smaller.
     Catalog,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct AuxIdAndCoords {
+    #[serde(rename = "_id")]
+    object_id: String,
+    coordinates: Coordinates,
+}
+
+// -----------------------------------------------------------------------------
+// objects-driven: stream alerts_aux records, fan out to N workers running xmatch().
+// One pass updates all selected catalogs at once via the existing 1×N xmatch.
+// -----------------------------------------------------------------------------
+async fn run_objects_driven(
+    survey: &Survey,
+    catalogs: Vec<CatalogXmatchConfig>,
+    db: mongodb::Database,
+    batch_size: usize,
+    processes: usize,
+) -> Result<(), mongodb::error::Error> {
+    let aux_collection: mongodb::Collection<AuxIdAndCoords> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let estimated = aux_collection.estimated_document_count().await.unwrap_or(0);
+    let label = catalogs
+        .iter()
+        .map(|c| c.catalog.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    let pb = make_progress_bar(estimated, format!("objects→{}", label));
+
+    let processes = processes.max(1);
+    let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
+    let (tx, rx) = async_channel::bounded::<AuxIdAndCoords>(queue_capacity);
+
+    let mut workers = Vec::with_capacity(processes);
+    for _ in 0..processes {
+        let rx = rx.clone();
+        let pb = pb.clone();
+        let survey = survey.clone();
+        let db = db.clone();
+        let catalogs = catalogs.clone();
+        workers.push(tokio::spawn(async move {
+            objects_worker(survey, db, catalogs, rx, batch_size, pb).await;
+        }));
+    }
+    drop(rx);
+
+    let mut cursor = aux_collection
+        .find(doc! {})
+        .projection(doc! { "_id": 1, "coordinates": 1 })
+        .no_cursor_timeout(true)
+        .await?;
+    while let Some(d) = cursor.try_next().await? {
+        if tx.send(d).await.is_err() {
+            break;
+        }
+    }
+    drop(tx);
+
+    for h in workers {
+        if let Err(e) = h.await {
+            error!("worker join failed: {}", e);
+        }
+    }
+    pb.finish();
+    Ok(())
+}
+
+async fn objects_worker(
+    survey: Survey,
+    db: mongodb::Database,
+    catalogs: Vec<CatalogXmatchConfig>,
+    rx: async_channel::Receiver<AuxIdAndCoords>,
+    batch_size: usize,
+    pb: ProgressBar,
+) {
+    let client = db.client().clone();
+    let aux_collection: mongodb::Collection<AuxIdAndCoords> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let aux_ns = aux_collection.namespace();
+
+    let mut batch = Vec::with_capacity(batch_size);
+    while let Ok(item) = rx.recv().await {
+        batch.push(item);
+        if batch.len() >= batch_size {
+            flush_objects_batch(&db, &client, &aux_ns, &catalogs, &mut batch, &pb).await;
+        }
+    }
+    if !batch.is_empty() {
+        flush_objects_batch(&db, &client, &aux_ns, &catalogs, &mut batch, &pb).await;
+    }
+}
+
+async fn flush_objects_batch(
+    db: &mongodb::Database,
+    client: &mongodb::Client,
+    aux_ns: &Namespace,
+    catalogs: &[CatalogXmatchConfig],
+    batch: &mut Vec<AuxIdAndCoords>,
+    pb: &ProgressBar,
+) {
+    let mut writes = Vec::with_capacity(batch.len());
+    for obj in batch.drain(..) {
+        let (ra, dec) = obj.coordinates.get_radec();
+        let xmatches = match xmatch(ra, dec, catalogs, db).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(object_id = %obj.object_id, error = %e, "xmatch failed, skipping");
+                pb.inc(1);
+                continue;
+            }
+        };
+        let mut set_doc = Document::new();
+        for cat in catalogs {
+            let matches = xmatches.get(&cat.catalog).cloned().unwrap_or_default();
+            set_doc.insert(format!("cross_matches.{}", cat.catalog), matches);
+        }
+        writes.push(WriteModel::UpdateOne(
+            UpdateOneModel::builder()
+                .namespace(aux_ns.clone())
+                .filter(doc! { "_id": obj.object_id })
+                .update(doc! { "$set": set_doc })
+                .build(),
+        ));
+        pb.inc(1);
+    }
+    if !writes.is_empty() {
+        if let Err(e) = client.bulk_write(writes).await {
+            error!("bulk_write failed: {}", e);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// catalog-driven: stream catalog rows, fan out to N workers that geo-lookup
+// matching alerts_aux records and accumulate $push updates. Uses a temp field
+// (`cross_matches_temp.<catalog>`) as a buffer so the `cross_matches.<catalog>` field is
+// never empty mid-run.
+//
+// Concurrency with the live ingest pipeline: every phase is gated on
+// `created_at < run_start_jd` so records inserted during the run are left
+// completely untouched (the scheduler pipeline already filled their cross_matches).
+// Without this guard, phase 4's `$set live = $temp` would overwrite a new record's
+// field with a missing/partial temp and silently delete it.
+// Phase 5 then cleans up any orphan temp left.
+// -----------------------------------------------------------------------------
+async fn run_catalog_driven(
+    survey: &Survey,
+    catalog_config: CatalogXmatchConfig,
+    db: mongodb::Database,
+    batch_size: usize,
+    processes: usize,
+) -> Result<(), mongodb::error::Error> {
+    let aux_collection: mongodb::Collection<Document> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let cat_collection: mongodb::Collection<Document> = db.collection(&catalog_config.catalog);
+    let live_field = format!("cross_matches.{}", catalog_config.catalog);
+    let temp_field = format!("cross_matches_temp.{}", catalog_config.catalog);
+    let run_start_jd = Time::now().to_jd();
+    let existing_records = doc! { "created_at": { "$lt": run_start_jd } };
+
+    // Phase 1: clear temp field on every alerts_aux record that existed at run start
+    // so we start from a known empty state. Records inserted later are skipped.
+    info!(
+        "[catalog→{}] phase 1/5: clearing temp field",
+        catalog_config.catalog
+    );
+    let empty: Vec<Document> = Vec::new();
+    aux_collection
+        .update_many(
+            existing_records.clone(),
+            doc! { "$set": { &temp_field: empty } },
+        )
+        .await?;
+
+    // Phase 2: stream catalog rows through a worker pool, $push matches to temp.
+    info!(
+        "[catalog→{}] phase 2/5: streaming catalog rows",
+        catalog_config.catalog
+    );
+    let mut cat_projection = catalog_config.projection.clone();
+    cat_projection.insert("_id", 1);
+    cat_projection.insert("ra", 1);
+    cat_projection.insert("dec", 1);
+    if let Some(dk) = &catalog_config.distance_key {
+        cat_projection.insert(dk.as_str(), 1);
+    }
+
+    let cat_estimated = cat_collection.estimated_document_count().await.unwrap_or(0);
+    let pb = make_progress_bar(cat_estimated, format!("catalog→{}", catalog_config.catalog));
+    let processes = processes.max(1);
+    let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
+    let (tx, rx) = async_channel::bounded::<Document>(queue_capacity);
+
+    let mut workers = Vec::with_capacity(processes);
+    for _ in 0..processes {
+        let rx = rx.clone();
+        let pb = pb.clone();
+        let survey = survey.clone();
+        let db = db.clone();
+        let catalog_config = catalog_config.clone();
+        let temp_field = temp_field.clone();
+        workers.push(tokio::spawn(async move {
+            catalog_worker(
+                survey,
+                db,
+                catalog_config,
+                temp_field,
+                run_start_jd,
+                rx,
+                batch_size,
+                pb,
+            )
+            .await;
+        }));
+    }
+    drop(rx);
+
+    let mut cursor = cat_collection
+        .find(doc! {})
+        .projection(cat_projection)
+        .no_cursor_timeout(true)
+        .await?;
+    while let Some(d) = cursor.try_next().await? {
+        if tx.send(d).await.is_err() {
+            break;
+        }
+    }
+    drop(tx);
+    for h in workers {
+        if let Err(e) = h.await {
+            error!("worker join failed: {}", e);
+        }
+    }
+    pb.finish();
+
+    // Phase 3: sort + trim of accumulated matches per alerts_aux record.
+    info!(
+        "[catalog→{}] phase 3/5: sorting and trimming temp",
+        catalog_config.catalog
+    );
+    aux_collection
+        .update_many(
+            doc! {
+                "created_at": { "$lt": run_start_jd },
+                format!("{}.0", &temp_field): { "$exists": true },
+            },
+            make_sort_trim_pipeline(&catalog_config, &temp_field),
+        )
+        .await?;
+
+    // Phase 4: copy temp to live field, then clear temp.
+    // Gated on created_at to avoid overwriting new records that arrived during the run.
+    info!(
+        "[catalog→{}] phase 4/5: swapping temp into live",
+        catalog_config.catalog
+    );
+    aux_collection
+        .update_many(
+            existing_records,
+            vec![
+                doc! { "$set": { &live_field: format!("${}", &temp_field) } },
+                doc! { "$unset": &temp_field },
+            ],
+        )
+        .await?;
+
+    // Phase 5: clean up any orphan temp fields left on records inserted during the run.
+    info!(
+        "[catalog→{}] phase 5/5: cleaning orphan temp",
+        catalog_config.catalog
+    );
+    aux_collection
+        .update_many(
+            doc! { &temp_field: { "$exists": true } },
+            doc! { "$unset": { &temp_field: "" } },
+        )
+        .await?;
+
+    Ok(())
+}
+
+async fn catalog_worker(
+    survey: Survey,
+    db: mongodb::Database,
+    catalog_config: CatalogXmatchConfig,
+    temp_field: String,
+    run_start_jd: f64,
+    rx: async_channel::Receiver<Document>,
+    batch_size: usize,
+    pb: ProgressBar,
+) {
+    let client = db.client().clone();
+    let aux_collection: mongodb::Collection<Document> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let aux_ns = aux_collection.namespace();
+
+    let mut pending: HashMap<String, Vec<Document>> = HashMap::new();
+    let mut cat_count = 0u64;
+
+    while let Ok(cat_doc) = rx.recv().await {
+        cat_count += 1;
+        pb.inc(1);
+        if let Err(e) = process_cat_doc(
+            &aux_collection,
+            &catalog_config,
+            run_start_jd,
+            &cat_doc,
+            &mut pending,
+        )
+        .await
+        {
+            warn!(error = %e, "catalog row processing failed, skipping");
+        }
+        if cat_count % (batch_size as u64) == 0 && !pending.is_empty() {
+            flush_pending(&client, &aux_ns, &temp_field, &mut pending).await;
+        }
+    }
+    if !pending.is_empty() {
+        flush_pending(&client, &aux_ns, &temp_field, &mut pending).await;
+    }
+}
+
+async fn process_cat_doc(
+    aux_collection: &mongodb::Collection<Document>,
+    catalog_config: &CatalogXmatchConfig,
+    run_start_jd: f64,
+    cat_doc: &Document,
+    pending: &mut HashMap<String, Vec<Document>>,
+) -> Result<(), mongodb::error::Error> {
+    let cat_ra = match get_f64_from_doc(cat_doc, "ra") {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let cat_dec = match get_f64_from_doc(cat_doc, "dec") {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+
+    let use_distance_data: Option<(f64, f64)> = if catalog_config.use_distance {
+        let dk = catalog_config
+            .distance_key
+            .as_ref()
+            .expect("validated in config");
+        let z = match get_f64_from_doc(cat_doc, dk) {
+            Some(v) => v,
+            None => return Ok(()),
+        };
+        let dmax = catalog_config.distance_max.expect("validated in config");
+        let dmax_near = catalog_config
+            .distance_max_near
+            .expect("validated in config");
+        Some((z, cm_radius_arcsec(z, dmax, dmax_near)))
+    } else {
+        None
+    };
+
+    let cat_ra_geojson = cat_ra - 180.0;
+    let aux_filter = doc! {
+        "coordinates.radec_geojson": {
+            "$geoWithin": {
+                "$centerSphere": [[cat_ra_geojson, cat_dec], catalog_config.radius]
+            }
+        },
+        "created_at": { "$lt": run_start_jd },
+    };
+    let mut aux_cursor = aux_collection
+        .find(aux_filter)
+        .projection(doc! { "_id": 1, "coordinates": 1 })
+        .await?;
+
+    while let Some(aux_doc) = aux_cursor.try_next().await? {
+        let aux_id = match aux_doc.get_str("_id") {
+            Ok(s) => s.to_string(),
+            Err(_) => continue,
+        };
+        let (aux_ra, aux_dec) = match extract_radec(&aux_doc) {
+            Some(v) => v,
+            None => continue,
+        };
+        let distance_arcsec = great_circle_distance(aux_ra, aux_dec, cat_ra, cat_dec) * 3600.0;
+
+        let mut match_doc = cat_doc.clone();
+        match_doc.insert("distance_arcsec", distance_arcsec);
+
+        if let Some((z, cm_radius)) = use_distance_data {
+            if distance_arcsec >= cm_radius {
+                continue;
+            }
+            match_doc.insert("distance_kpc", distance_kpc_from_arcsec(distance_arcsec, z));
+        }
+
+        pending.entry(aux_id).or_default().push(match_doc);
+    }
+    Ok(())
+}
+
+async fn flush_pending(
+    client: &mongodb::Client,
+    aux_ns: &Namespace,
+    field: &str,
+    pending: &mut HashMap<String, Vec<Document>>,
+) {
+    let drained: Vec<(String, Vec<Document>)> = pending.drain().collect();
+    let models: Vec<WriteModel> = drained
+        .into_iter()
+        .map(|(aux_id, docs)| {
+            WriteModel::UpdateOne(
+                UpdateOneModel::builder()
+                    .namespace(aux_ns.clone())
+                    .filter(doc! { "_id": aux_id })
+                    .update(doc! { "$push": { field: { "$each": docs } } })
+                    .build(),
+            )
+        })
+        .collect();
+    if !models.is_empty() {
+        if let Err(e) = client.bulk_write(models).await {
+            error!("bulk_write failed: {}", e);
+        }
+    }
 }
 
 /// `coordinates.radec_geojson.coordinates` is `[ra - 180, dec]`.
@@ -81,261 +512,23 @@ fn extract_radec(doc: &Document) -> Option<(f64, f64)> {
     Some((ra_geojson + 180.0, dec))
 }
 
-async fn run_objects_driven(
-    survey: &Survey,
-    catalog_config: &CatalogXmatchConfig,
-    db: &mongodb::Database,
-    batch_size: usize,
-) -> Result<u64, mongodb::error::Error> {
-    let aux_collection: mongodb::Collection<Document> =
-        db.collection(&format!("{}_alerts_aux", survey));
-    let client = db.client();
-
-    let estimated = aux_collection.estimated_document_count().await.unwrap_or(0);
-    let pb = make_progress_bar(estimated, format!("objects→{}", catalog_config.catalog));
-    let cat_field = format!("cross_matches.{}", catalog_config.catalog);
-
-    let mut cursor = aux_collection
-        .find(doc! {})
-        .projection(doc! { "_id": 1, "coordinates": 1 })
-        .no_cursor_timeout(true)
-        .await?;
-
-    let configs = vec![catalog_config.clone()];
-    let mut pending_writes: Vec<WriteModel> = Vec::with_capacity(batch_size);
-    let mut updated = 0u64;
-
-    while let Some(d) = cursor.try_next().await? {
-        pb.inc(1);
-
-        let object_id = match d.get_str("_id") {
-            Ok(s) => s.to_string(),
-            Err(_) => continue,
-        };
-        let (ra, dec) = match extract_radec(&d) {
-            Some(v) => v,
-            None => {
-                warn!(object_id = %object_id, "missing/invalid coordinates, skipping");
-                continue;
-            }
-        };
-
-        let xmatch_result = match xmatch(ra, dec, &configs, db).await {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(object_id = %object_id, error = %e, "xmatch failed, skipping");
-                continue;
-            }
-        };
-        let matches = xmatch_result
-            .get(&catalog_config.catalog)
-            .cloned()
-            .unwrap_or_default();
-
-        pending_writes.push(WriteModel::UpdateOne(
-            UpdateOneModel::builder()
-                .namespace(aux_collection.namespace())
-                .filter(doc! { "_id": &object_id })
-                .update(doc! { "$set": { &cat_field: matches } })
-                .build(),
-        ));
-
-        if pending_writes.len() >= batch_size {
-            let n = pending_writes.len() as u64;
-            client
-                .bulk_write(std::mem::take(&mut pending_writes))
-                .await?;
-            updated += n;
-        }
-    }
-
-    if !pending_writes.is_empty() {
-        let n = pending_writes.len() as u64;
-        client.bulk_write(pending_writes).await?;
-        updated += n;
-    }
-
-    pb.finish();
-    Ok(updated)
-}
-
-async fn run_catalog_driven(
-    survey: &Survey,
-    catalog_config: &CatalogXmatchConfig,
-    db: &mongodb::Database,
-    batch_size: usize,
-    run_start_jd: f64,
-) -> Result<u64, mongodb::error::Error> {
-    let aux_collection: mongodb::Collection<Document> =
-        db.collection(&format!("{}_alerts_aux", survey));
-    let cat_collection: mongodb::Collection<Document> = db.collection(&catalog_config.catalog);
-    let client = db.client();
-    let cat_field = format!("cross_matches.{}", catalog_config.catalog);
-
-    // Skip aux records inserted during this run: the live worker already
-    // populated their cross_matches via the live xmatch.
-    let pre_existing = doc! { "created_at": { "$lt": run_start_jd } };
-
-    let empty_array: Vec<Document> = Vec::new();
-    aux_collection
-        .update_many(
-            pre_existing.clone(),
-            doc! { "$set": { &cat_field: empty_array } },
-        )
-        .await?;
-
-    let mut cat_projection = catalog_config.projection.clone();
-    cat_projection.insert("_id", 1);
-    cat_projection.insert("ra", 1);
-    cat_projection.insert("dec", 1);
-    if let Some(dk) = &catalog_config.distance_key {
-        cat_projection.insert(dk.as_str(), 1);
-    }
-
-    let cat_estimated = cat_collection.estimated_document_count().await.unwrap_or(0);
-    let pb = make_progress_bar(cat_estimated, format!("catalog→{}", catalog_config.catalog));
-
-    let mut cursor = cat_collection
-        .find(doc! {})
-        .projection(cat_projection)
-        .no_cursor_timeout(true)
-        .await?;
-
-    let mut pending: HashMap<String, Vec<Document>> = HashMap::new();
-    let mut total_pushes = 0u64;
-    let mut cat_count = 0u64;
-
-    while let Some(cat_doc) = cursor.try_next().await? {
-        cat_count += 1;
-        pb.inc(1);
-
-        let cat_ra = match get_f64_from_doc(&cat_doc, "ra") {
-            Some(v) => v,
-            None => continue,
-        };
-        let cat_dec = match get_f64_from_doc(&cat_doc, "dec") {
-            Some(v) => v,
-            None => continue,
-        };
-
-        let use_distance_data: Option<(f64, f64)> = if catalog_config.use_distance {
-            let dk = catalog_config
-                .distance_key
-                .as_ref()
-                .expect("validated in config");
-            let z = match get_f64_from_doc(&cat_doc, dk) {
-                Some(v) => v,
-                None => continue,
-            };
-            let dmax = catalog_config.distance_max.expect("validated in config");
-            let dmax_near = catalog_config
-                .distance_max_near
-                .expect("validated in config");
-            Some((z, cm_radius_arcsec(z, dmax, dmax_near)))
-        } else {
-            None
-        };
-
-        let cat_ra_geojson = cat_ra - 180.0;
-        let aux_filter = doc! {
-            "coordinates.radec_geojson": {
-                "$geoWithin": { "$centerSphere": [[cat_ra_geojson, cat_dec], catalog_config.radius] }
-            },
-            "created_at": { "$lt": run_start_jd },
-        };
-        let mut aux_cursor = aux_collection
-            .find(aux_filter)
-            .projection(doc! { "_id": 1, "coordinates": 1 })
-            .await?;
-
-        while let Some(aux_doc) = aux_cursor.try_next().await? {
-            let aux_id = match aux_doc.get_str("_id") {
-                Ok(s) => s.to_string(),
-                Err(_) => continue,
-            };
-            let (aux_ra, aux_dec) = match extract_radec(&aux_doc) {
-                Some(v) => v,
-                None => continue,
-            };
-            let distance_arcsec = great_circle_distance(aux_ra, aux_dec, cat_ra, cat_dec) * 3600.0;
-
-            let mut match_doc = cat_doc.clone();
-            match_doc.insert("distance_arcsec", distance_arcsec);
-
-            if let Some((z, cm_radius)) = use_distance_data {
-                if distance_arcsec >= cm_radius {
-                    continue;
-                }
-                match_doc.insert("distance_kpc", distance_kpc_from_arcsec(distance_arcsec, z));
-            }
-
-            pending.entry(aux_id).or_default().push(match_doc);
-            total_pushes += 1;
-        }
-
-        if cat_count % (batch_size as u64) == 0 && !pending.is_empty() {
-            flush_pending(client, &aux_collection, &cat_field, &mut pending).await?;
-        }
-    }
-
-    if !pending.is_empty() {
-        flush_pending(client, &aux_collection, &cat_field, &mut pending).await?;
-    }
-    pb.finish();
-
-    aux_collection
-        .update_many(
-            doc! { format!("{}.0", &cat_field): { "$exists": true } },
-            make_sort_trim_pipeline(catalog_config),
-        )
-        .await?;
-
-    Ok(total_pushes)
-}
-
-async fn flush_pending(
-    client: &mongodb::Client,
-    aux_collection: &mongodb::Collection<Document>,
-    cat_field: &str,
-    pending: &mut HashMap<String, Vec<Document>>,
-) -> Result<(), mongodb::error::Error> {
-    let drained: Vec<(String, Vec<Document>)> = pending.drain().collect();
-    let models: Vec<WriteModel> = drained
-        .into_iter()
-        .map(|(aux_id, docs)| {
-            WriteModel::UpdateOne(
-                UpdateOneModel::builder()
-                    .namespace(aux_collection.namespace())
-                    .filter(doc! { "_id": aux_id })
-                    .update(doc! { "$push": { cat_field: { "$each": docs } } })
-                    .build(),
-            )
-        })
-        .collect();
-    if !models.is_empty() {
-        client.bulk_write(models).await?;
-    }
-    Ok(())
-}
-
 /// Mongo-aggregation mirror of the in-Rust sort/trim performed by
 /// `utils::spatial::xmatch` (see that function for the source of truth on
 /// ordering semantics). `use_distance` and `max_results` are mutually
 /// exclusive at config load.
-fn make_sort_trim_pipeline(catalog_config: &CatalogXmatchConfig) -> Vec<Document> {
-    let cat_field = format!("cross_matches.{}", catalog_config.catalog);
+fn make_sort_trim_pipeline(catalog_config: &CatalogXmatchConfig, field: &str) -> Vec<Document> {
     let sort_by = if catalog_config.use_distance {
         doc! { "distance_kpc": 1, "distance_arcsec": 1 }
     } else {
         doc! { "distance_arcsec": 1 }
     };
-    let sorted = doc! { "$sortArray": { "input": format!("${}", &cat_field), "sortBy": sort_by } };
-    let final_value = if let Some(max) = catalog_config.max_results {
-        Bson::Document(doc! { "$slice": [sorted, max as i64] })
+    let sorted = doc! { "$sortArray": { "input": format!("${}", field), "sortBy": sort_by } };
+    let final_value: Document = if let Some(max) = catalog_config.max_results {
+        doc! { "$slice": [sorted, max as i64] }
     } else {
-        Bson::Document(sorted)
+        sorted
     };
-    vec![doc! { "$set": { &cat_field: final_value } }]
+    vec![doc! { "$set": { field: final_value } }]
 }
 
 async fn pick_direction(
@@ -375,15 +568,10 @@ async fn main() {
         std::process::exit(1);
     }
 
-    let default_config_path = "config.yaml".to_string();
-    let config_path = args.config.unwrap_or_else(|| {
-        tracing::warn!("no --config provided, using {}", default_config_path);
-        default_config_path
-    });
-    let config = match AppConfig::from_path(&config_path) {
+    let config = match AppConfig::from_path(&args.config) {
         Ok(c) => c,
         Err(e) => {
-            error!("failed to load config from {}: {}", config_path, e);
+            error!("failed to load config from {}: {}", args.config, e);
             std::process::exit(1);
         }
     };
@@ -403,7 +591,7 @@ async fn main() {
                 "survey '{}' has no `crossmatch.{}` section in {}",
                 args.survey,
                 args.survey.to_string().to_lowercase(),
-                config_path,
+                args.config,
             );
             std::process::exit(1);
         }
@@ -417,56 +605,65 @@ async fn main() {
                     "catalog '{}' not declared under crossmatch.{} in {}",
                     name,
                     args.survey.to_string().to_lowercase(),
-                    config_path,
+                    args.config,
                 );
                 std::process::exit(1);
             }
         }
     }
 
-    let run_start_jd = flare::Time::now().to_jd();
-    info!(
-        "starting reprocess: survey={} catalogs={:?} direction={:?} run_start_jd={:.6}",
-        args.survey, args.catalogs, args.direction, run_start_jd
-    );
-
-    for catalog_config in &resolved {
+    // If direction is Auto, split catalogs into two groups based on which collection is smaller.
+    let mut objects_catalogs: Vec<CatalogXmatchConfig> = Vec::new();
+    let mut catalog_catalogs: Vec<CatalogXmatchConfig> = Vec::new();
+    for cat in resolved {
         let direction = match args.direction {
-            Direction::Auto => pick_direction(&args.survey, catalog_config, &db).await,
+            Direction::Auto => pick_direction(&args.survey, &cat, &db).await,
             d => d,
         };
-        info!(
-            "=== catalog '{}': direction={:?} ===",
-            catalog_config.catalog, direction
-        );
-        let result = match direction {
+        match direction {
+            Direction::Objects => objects_catalogs.push(cat),
+            Direction::Catalog => catalog_catalogs.push(cat),
             Direction::Auto => unreachable!(),
-            Direction::Objects => {
-                run_objects_driven(&args.survey, catalog_config, &db, args.batch_size).await
-            }
-            Direction::Catalog => {
-                run_catalog_driven(
-                    &args.survey,
-                    catalog_config,
-                    &db,
-                    args.batch_size,
-                    run_start_jd,
-                )
-                .await
-            }
-        };
-        match result {
-            Ok(n) => info!(
-                "catalog '{}': done ({} updates / pushes)",
-                catalog_config.catalog, n
-            ),
-            Err(e) => {
-                error!(
-                    "catalog '{}': failed ({}). Stopping.",
-                    catalog_config.catalog, e
-                );
-                std::process::exit(1);
-            }
+        }
+    }
+
+    info!(
+        "starting reprocess: survey={} processes={} batch_size={} objects_catalogs={:?} catalog_catalogs={:?}",
+        args.survey,
+        args.processes,
+        args.batch_size,
+        objects_catalogs.iter().map(|c| &c.catalog).collect::<Vec<_>>(),
+        catalog_catalogs.iter().map(|c| &c.catalog).collect::<Vec<_>>(),
+    );
+
+    if !objects_catalogs.is_empty() {
+        if let Err(e) = run_objects_driven(
+            &args.survey,
+            objects_catalogs,
+            db.clone(),
+            args.batch_size,
+            args.processes,
+        )
+        .await
+        {
+            error!("objects-driven run failed: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    for cat in catalog_catalogs {
+        let name = cat.catalog.clone();
+        if let Err(e) = run_catalog_driven(
+            &args.survey,
+            cat,
+            db.clone(),
+            args.batch_size,
+            args.processes,
+        )
+        .await
+        {
+            error!("catalog-driven run for '{}' failed: {}", name, e);
+            std::process::exit(1);
         }
     }
 

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -1,0 +1,474 @@
+use std::collections::HashMap;
+
+use boom::{
+    conf::{load_dotenv, AppConfig, CatalogXmatchConfig},
+    utils::{
+        data::make_progress_bar,
+        enums::Survey,
+        spatial::{cm_radius_arcsec, distance_kpc_from_arcsec, get_f64_from_doc, xmatch},
+    },
+};
+use clap::{Parser, ValueEnum};
+use flare::spatial::great_circle_distance;
+use futures::TryStreamExt;
+use mongodb::{
+    bson::{doc, Bson, Document},
+    options::{UpdateOneModel, WriteModel},
+};
+use tracing::{error, info, warn, Level};
+use tracing_subscriber::FmtSubscriber;
+
+/// Binary for reprocessing crossmatches between a survey's aux collection and one or more catalogs.
+/// The scheduler pipeline only crossmatches at first insert, so adding a catalog to
+/// `crossmatch.<survey>` in config.yaml leaves pre-existing aux records with
+/// no entry for it, so this binary fills in those gaps. It can also be used to reprocess existing
+/// crossmatches if the matching parameters (e.g. radius) for a catalog are changed.
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, value_enum)]
+    survey: Survey,
+
+    /// Each catalog must already be declared under `crossmatch.<survey>` in
+    /// config.yaml (radius / projection / etc. are read from there).
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    catalogs: Vec<String>,
+
+    #[arg(long, value_enum, default_value_t = Direction::Auto)]
+    direction: Direction,
+
+    #[arg(long, value_name = "FILE")]
+    config: Option<String>,
+
+    #[arg(long, default_value = "5000")]
+    batch_size: usize,
+}
+
+/// Reprocessing can be done in two directions:
+/// - Checking the crossmatch catalogs for each aux record,
+/// - Checking the aux collection for each catalog record.
+///
+/// To optimize the reprocessing, the binary can loop over either
+/// the aux collection or the catalog collection, depending on which is smaller.
+/// If `--direction` is not provided, it checks the estimated document counts
+/// of each collection and loops over the smaller one.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum Direction {
+    /// Pick `objects` or `catalog` per catalog based on which side has fewer rows.
+    Auto,
+    /// Loop over aux records, query catalog. Best when aux is smaller.
+    Objects,
+    /// Loop over catalog rows, query aux. Best when catalog is smaller.
+    Catalog,
+}
+
+/// `coordinates.radec_geojson.coordinates` is `[ra - 180, dec]`.
+fn extract_radec(doc: &Document) -> Option<(f64, f64)> {
+    let arr = doc
+        .get_document("coordinates")
+        .ok()?
+        .get_document("radec_geojson")
+        .ok()?
+        .get_array("coordinates")
+        .ok()?;
+    if arr.len() != 2 {
+        return None;
+    }
+    let ra_geojson = arr[0].as_f64()?;
+    let dec = arr[1].as_f64()?;
+    if !ra_geojson.is_finite() || !dec.is_finite() {
+        return None;
+    }
+    Some((ra_geojson + 180.0, dec))
+}
+
+async fn run_objects_driven(
+    survey: &Survey,
+    catalog_config: &CatalogXmatchConfig,
+    db: &mongodb::Database,
+    batch_size: usize,
+) -> Result<u64, mongodb::error::Error> {
+    let aux_collection: mongodb::Collection<Document> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let client = db.client();
+
+    let estimated = aux_collection.estimated_document_count().await.unwrap_or(0);
+    let pb = make_progress_bar(estimated, format!("objects→{}", catalog_config.catalog));
+    let cat_field = format!("cross_matches.{}", catalog_config.catalog);
+
+    let mut cursor = aux_collection
+        .find(doc! {})
+        .projection(doc! { "_id": 1, "coordinates": 1 })
+        .no_cursor_timeout(true)
+        .await?;
+
+    let configs = vec![catalog_config.clone()];
+    let mut pending_writes: Vec<WriteModel> = Vec::with_capacity(batch_size);
+    let mut updated = 0u64;
+
+    while let Some(d) = cursor.try_next().await? {
+        pb.inc(1);
+
+        let object_id = match d.get_str("_id") {
+            Ok(s) => s.to_string(),
+            Err(_) => continue,
+        };
+        let (ra, dec) = match extract_radec(&d) {
+            Some(v) => v,
+            None => {
+                warn!(object_id = %object_id, "missing/invalid coordinates, skipping");
+                continue;
+            }
+        };
+
+        let xmatch_result = match xmatch(ra, dec, &configs, db).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(object_id = %object_id, error = %e, "xmatch failed, skipping");
+                continue;
+            }
+        };
+        let matches = xmatch_result
+            .get(&catalog_config.catalog)
+            .cloned()
+            .unwrap_or_default();
+
+        pending_writes.push(WriteModel::UpdateOne(
+            UpdateOneModel::builder()
+                .namespace(aux_collection.namespace())
+                .filter(doc! { "_id": &object_id })
+                .update(doc! { "$set": { &cat_field: matches } })
+                .build(),
+        ));
+
+        if pending_writes.len() >= batch_size {
+            let n = pending_writes.len() as u64;
+            client
+                .bulk_write(std::mem::take(&mut pending_writes))
+                .await?;
+            updated += n;
+        }
+    }
+
+    if !pending_writes.is_empty() {
+        let n = pending_writes.len() as u64;
+        client.bulk_write(pending_writes).await?;
+        updated += n;
+    }
+
+    pb.finish();
+    Ok(updated)
+}
+
+async fn run_catalog_driven(
+    survey: &Survey,
+    catalog_config: &CatalogXmatchConfig,
+    db: &mongodb::Database,
+    batch_size: usize,
+    run_start_jd: f64,
+) -> Result<u64, mongodb::error::Error> {
+    let aux_collection: mongodb::Collection<Document> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let cat_collection: mongodb::Collection<Document> = db.collection(&catalog_config.catalog);
+    let client = db.client();
+    let cat_field = format!("cross_matches.{}", catalog_config.catalog);
+
+    // Skip aux records inserted during this run: the live worker already
+    // populated their cross_matches via the live xmatch.
+    let pre_existing = doc! { "created_at": { "$lt": run_start_jd } };
+
+    let empty_array: Vec<Document> = Vec::new();
+    aux_collection
+        .update_many(
+            pre_existing.clone(),
+            doc! { "$set": { &cat_field: empty_array } },
+        )
+        .await?;
+
+    let mut cat_projection = catalog_config.projection.clone();
+    cat_projection.insert("_id", 1);
+    cat_projection.insert("ra", 1);
+    cat_projection.insert("dec", 1);
+    if let Some(dk) = &catalog_config.distance_key {
+        cat_projection.insert(dk.as_str(), 1);
+    }
+
+    let cat_estimated = cat_collection.estimated_document_count().await.unwrap_or(0);
+    let pb = make_progress_bar(cat_estimated, format!("catalog→{}", catalog_config.catalog));
+
+    let mut cursor = cat_collection
+        .find(doc! {})
+        .projection(cat_projection)
+        .no_cursor_timeout(true)
+        .await?;
+
+    let mut pending: HashMap<String, Vec<Document>> = HashMap::new();
+    let mut total_pushes = 0u64;
+    let mut cat_count = 0u64;
+
+    while let Some(cat_doc) = cursor.try_next().await? {
+        cat_count += 1;
+        pb.inc(1);
+
+        let cat_ra = match get_f64_from_doc(&cat_doc, "ra") {
+            Some(v) => v,
+            None => continue,
+        };
+        let cat_dec = match get_f64_from_doc(&cat_doc, "dec") {
+            Some(v) => v,
+            None => continue,
+        };
+
+        let use_distance_data: Option<(f64, f64)> = if catalog_config.use_distance {
+            let dk = catalog_config
+                .distance_key
+                .as_ref()
+                .expect("validated in config");
+            let z = match get_f64_from_doc(&cat_doc, dk) {
+                Some(v) => v,
+                None => continue,
+            };
+            let dmax = catalog_config.distance_max.expect("validated in config");
+            let dmax_near = catalog_config
+                .distance_max_near
+                .expect("validated in config");
+            Some((z, cm_radius_arcsec(z, dmax, dmax_near)))
+        } else {
+            None
+        };
+
+        let cat_ra_geojson = cat_ra - 180.0;
+        let aux_filter = doc! {
+            "coordinates.radec_geojson": {
+                "$geoWithin": { "$centerSphere": [[cat_ra_geojson, cat_dec], catalog_config.radius] }
+            },
+            "created_at": { "$lt": run_start_jd },
+        };
+        let mut aux_cursor = aux_collection
+            .find(aux_filter)
+            .projection(doc! { "_id": 1, "coordinates": 1 })
+            .await?;
+
+        while let Some(aux_doc) = aux_cursor.try_next().await? {
+            let aux_id = match aux_doc.get_str("_id") {
+                Ok(s) => s.to_string(),
+                Err(_) => continue,
+            };
+            let (aux_ra, aux_dec) = match extract_radec(&aux_doc) {
+                Some(v) => v,
+                None => continue,
+            };
+            let distance_arcsec = great_circle_distance(aux_ra, aux_dec, cat_ra, cat_dec) * 3600.0;
+
+            let mut match_doc = cat_doc.clone();
+            match_doc.insert("distance_arcsec", distance_arcsec);
+
+            if let Some((z, cm_radius)) = use_distance_data {
+                if distance_arcsec >= cm_radius {
+                    continue;
+                }
+                match_doc.insert("distance_kpc", distance_kpc_from_arcsec(distance_arcsec, z));
+            }
+
+            pending.entry(aux_id).or_default().push(match_doc);
+            total_pushes += 1;
+        }
+
+        if cat_count % (batch_size as u64) == 0 && !pending.is_empty() {
+            flush_pending(client, &aux_collection, &cat_field, &mut pending).await?;
+        }
+    }
+
+    if !pending.is_empty() {
+        flush_pending(client, &aux_collection, &cat_field, &mut pending).await?;
+    }
+    pb.finish();
+
+    aux_collection
+        .update_many(
+            doc! { format!("{}.0", &cat_field): { "$exists": true } },
+            make_sort_trim_pipeline(catalog_config),
+        )
+        .await?;
+
+    Ok(total_pushes)
+}
+
+async fn flush_pending(
+    client: &mongodb::Client,
+    aux_collection: &mongodb::Collection<Document>,
+    cat_field: &str,
+    pending: &mut HashMap<String, Vec<Document>>,
+) -> Result<(), mongodb::error::Error> {
+    let drained: Vec<(String, Vec<Document>)> = pending.drain().collect();
+    let models: Vec<WriteModel> = drained
+        .into_iter()
+        .map(|(aux_id, docs)| {
+            WriteModel::UpdateOne(
+                UpdateOneModel::builder()
+                    .namespace(aux_collection.namespace())
+                    .filter(doc! { "_id": aux_id })
+                    .update(doc! { "$push": { cat_field: { "$each": docs } } })
+                    .build(),
+            )
+        })
+        .collect();
+    if !models.is_empty() {
+        client.bulk_write(models).await?;
+    }
+    Ok(())
+}
+
+/// Mongo-aggregation mirror of the in-Rust sort/trim performed by
+/// `utils::spatial::xmatch` (see that function for the source of truth on
+/// ordering semantics). `use_distance` and `max_results` are mutually
+/// exclusive at config load.
+fn make_sort_trim_pipeline(catalog_config: &CatalogXmatchConfig) -> Vec<Document> {
+    let cat_field = format!("cross_matches.{}", catalog_config.catalog);
+    let sort_by = if catalog_config.use_distance {
+        doc! { "distance_kpc": 1, "distance_arcsec": 1 }
+    } else {
+        doc! { "distance_arcsec": 1 }
+    };
+    let sorted = doc! { "$sortArray": { "input": format!("${}", &cat_field), "sortBy": sort_by } };
+    let final_value = if let Some(max) = catalog_config.max_results {
+        Bson::Document(doc! { "$slice": [sorted, max as i64] })
+    } else {
+        Bson::Document(sorted)
+    };
+    vec![doc! { "$set": { &cat_field: final_value } }]
+}
+
+async fn pick_direction(
+    survey: &Survey,
+    catalog_config: &CatalogXmatchConfig,
+    db: &mongodb::Database,
+) -> Direction {
+    let aux_collection: mongodb::Collection<Document> =
+        db.collection(&format!("{}_alerts_aux", survey));
+    let cat_collection: mongodb::Collection<Document> = db.collection(&catalog_config.catalog);
+    let aux_count = aux_collection.estimated_document_count().await.unwrap_or(0);
+    let cat_count = cat_collection.estimated_document_count().await.unwrap_or(0);
+    info!(
+        "auto: catalog '{}' ~{} rows, '{}_alerts_aux' ~{} rows",
+        catalog_config.catalog, cat_count, survey, aux_count
+    );
+    if cat_count < aux_count {
+        Direction::Catalog
+    } else {
+        Direction::Objects
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    load_dotenv();
+
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting subscriber failed");
+
+    let args = Cli::parse();
+
+    if args.catalogs.is_empty() {
+        error!("--catalogs requires at least one catalog name");
+        std::process::exit(1);
+    }
+
+    let default_config_path = "config.yaml".to_string();
+    let config_path = args.config.unwrap_or_else(|| {
+        tracing::warn!("no --config provided, using {}", default_config_path);
+        default_config_path
+    });
+    let config = match AppConfig::from_path(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("failed to load config from {}: {}", config_path, e);
+            std::process::exit(1);
+        }
+    };
+
+    let db = match config.build_db().await {
+        Ok(db) => db,
+        Err(e) => {
+            error!("failed to build mongo client: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let survey_configs: &Vec<CatalogXmatchConfig> = match config.crossmatch.get(&args.survey) {
+        Some(v) => v,
+        None => {
+            error!(
+                "survey '{}' has no `crossmatch.{}` section in {}",
+                args.survey,
+                args.survey.to_string().to_lowercase(),
+                config_path,
+            );
+            std::process::exit(1);
+        }
+    };
+    let mut resolved: Vec<CatalogXmatchConfig> = Vec::with_capacity(args.catalogs.len());
+    for name in &args.catalogs {
+        match survey_configs.iter().find(|c| &c.catalog == name) {
+            Some(c) => resolved.push(c.clone()),
+            None => {
+                error!(
+                    "catalog '{}' not declared under crossmatch.{} in {}",
+                    name,
+                    args.survey.to_string().to_lowercase(),
+                    config_path,
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let run_start_jd = flare::Time::now().to_jd();
+    info!(
+        "starting reprocess: survey={} catalogs={:?} direction={:?} run_start_jd={:.6}",
+        args.survey, args.catalogs, args.direction, run_start_jd
+    );
+
+    for catalog_config in &resolved {
+        let direction = match args.direction {
+            Direction::Auto => pick_direction(&args.survey, catalog_config, &db).await,
+            d => d,
+        };
+        info!(
+            "=== catalog '{}': direction={:?} ===",
+            catalog_config.catalog, direction
+        );
+        let result = match direction {
+            Direction::Auto => unreachable!(),
+            Direction::Objects => {
+                run_objects_driven(&args.survey, catalog_config, &db, args.batch_size).await
+            }
+            Direction::Catalog => {
+                run_catalog_driven(
+                    &args.survey,
+                    catalog_config,
+                    &db,
+                    args.batch_size,
+                    run_start_jd,
+                )
+                .await
+            }
+        };
+        match result {
+            Ok(n) => info!(
+                "catalog '{}': done ({} updates / pushes)",
+                catalog_config.catalog, n
+            ),
+            Err(e) => {
+                error!(
+                    "catalog '{}': failed ({}). Stopping.",
+                    catalog_config.catalog, e
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    info!("reprocess_crossmatch complete.");
+}

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -5,6 +5,7 @@ use boom::{
     utils::{
         data::make_progress_bar,
         enums::Survey,
+        parser::parse_positive_usize,
         spatial::{
             cm_radius_arcsec, distance_kpc_from_arcsec, get_f64_from_doc, xmatch, Coordinates,
         },
@@ -45,11 +46,11 @@ struct Cli {
     #[arg(long, value_name = "FILE", default_value = "config.yaml")]
     config: String,
 
-    #[arg(long, default_value_t = 5000)]
+    #[arg(long, default_value_t = 5000, value_parser = parse_positive_usize)]
     batch_size: usize,
 
     /// Number of parallel worker tasks. Each worker holds its own DB connection.
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1, value_parser = parse_positive_usize)]
     processes: usize,
 }
 
@@ -99,7 +100,6 @@ async fn run_objects_driven(
         .join(",");
     let pb = make_progress_bar(estimated, format!("objects→{}", label));
 
-    let processes = processes.max(1);
     let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
     let (tx, rx) = async_channel::bounded::<AuxIdAndCoords>(queue_capacity);
 
@@ -259,7 +259,6 @@ async fn run_catalog_driven(
 
     let cat_estimated = cat_collection.estimated_document_count().await.unwrap_or(0);
     let pb = make_progress_bar(cat_estimated, format!("catalog→{}", catalog_config.catalog));
-    let processes = processes.max(1);
     let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
     let (tx, rx) = async_channel::bounded::<Document>(queue_capacity);
 

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -205,7 +205,7 @@ async fn flush_objects_batch(
 // -----------------------------------------------------------------------------
 // catalog-driven: stream catalog rows, fan out to N workers that geo-lookup
 // matching alerts_aux records and accumulate $push updates. Uses a temp field
-// (`cross_matches_temp.<catalog>`) as a buffer so the `cross_matches.<catalog>` field is
+// (`cross_matches.<catalog>_temp`) as a buffer so the `cross_matches.<catalog>` field is
 // never empty mid-run.
 //
 // Concurrency with the live ingest pipeline: every phase is gated on
@@ -226,14 +226,14 @@ async fn run_catalog_driven(
         db.collection(&format!("{}_alerts_aux", survey));
     let cat_collection: mongodb::Collection<Document> = db.collection(&catalog_config.catalog);
     let live_field = format!("cross_matches.{}", catalog_config.catalog);
-    let temp_field = format!("cross_matches_temp.{}", catalog_config.catalog);
+    let temp_field = format!("cross_matches.{}_temp", catalog_config.catalog);
     let run_start_jd = Time::now().to_jd();
     let existing_records = doc! { "created_at": { "$lt": run_start_jd } };
 
     // Phase 1: clear temp field on every alerts_aux record that existed at run start
     // so we start from a known empty state. Records inserted later are skipped.
     info!(
-        "[catalog→{}] phase 1/5: clearing temp field",
+        "[catalog→{}] phase 1/5: cleaning temp field",
         catalog_config.catalog
     );
     let empty: Vec<Document> = Vec::new();
@@ -627,7 +627,7 @@ async fn main() {
     }
 
     info!(
-        "starting reprocess: survey={} processes={} batch_size={} objects_catalogs={:?} catalog_catalogs={:?}",
+        "starting reprocess: survey={} processes={} batch_size={} objects_driven={:?} catalogs_driven={:?}",
         args.survey,
         args.processes,
         args.batch_size,

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -222,7 +222,7 @@ async fn flush_objects_batch(
 // Concurrency with the live ingest pipeline: every phase is gated on
 // `created_at < run_start_jd` so records inserted during the run are left
 // completely untouched (the scheduler pipeline already filled their cross_matches).
-// Without this guard, phase 4's `$set live = $temp` would overwrite a new record's
+// Without this guard, the final `$set live = $temp` would overwrite a new record's
 // field with a missing/partial temp and silently delete it.
 // -----------------------------------------------------------------------------
 async fn run_catalog_driven(

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -111,7 +111,7 @@ async fn run_objects_driven(
         let db = db.clone();
         let catalogs = catalogs.clone();
         workers.push(tokio::spawn(async move {
-            objects_worker(survey, db, catalogs, rx, batch_size, pb).await;
+            objects_worker(survey, db, catalogs, rx, batch_size, pb).await
         }));
     }
     drop(rx);
@@ -128,12 +128,23 @@ async fn run_objects_driven(
     }
     drop(tx);
 
+    let mut first_err: Option<mongodb::error::Error> = None;
     for h in workers {
-        if let Err(e) = h.await {
-            error!("worker join failed: {}", e);
+        match h.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                error!("worker failed: {}", e);
+                first_err.get_or_insert(e);
+            }
+            Err(e) => {
+                error!("worker join failed: {}", e);
+            }
         }
     }
     pb.finish();
+    if let Some(e) = first_err {
+        return Err(e);
+    }
     Ok(())
 }
 
@@ -144,7 +155,7 @@ async fn objects_worker(
     rx: async_channel::Receiver<AuxIdAndCoords>,
     batch_size: usize,
     pb: ProgressBar,
-) {
+) -> Result<(), mongodb::error::Error> {
     let client = db.client().clone();
     let aux_collection: mongodb::Collection<AuxIdAndCoords> =
         db.collection(&format!("{}_alerts_aux", survey));
@@ -154,12 +165,13 @@ async fn objects_worker(
     while let Ok(item) = rx.recv().await {
         batch.push(item);
         if batch.len() >= batch_size {
-            flush_objects_batch(&db, &client, &aux_ns, &catalogs, &mut batch, &pb).await;
+            flush_objects_batch(&db, &client, &aux_ns, &catalogs, &mut batch, &pb).await?;
         }
     }
     if !batch.is_empty() {
-        flush_objects_batch(&db, &client, &aux_ns, &catalogs, &mut batch, &pb).await;
+        flush_objects_batch(&db, &client, &aux_ns, &catalogs, &mut batch, &pb).await?;
     }
+    Ok(())
 }
 
 async fn flush_objects_batch(
@@ -169,7 +181,7 @@ async fn flush_objects_batch(
     catalogs: &[CatalogXmatchConfig],
     batch: &mut Vec<AuxIdAndCoords>,
     pb: &ProgressBar,
-) {
+) -> Result<(), mongodb::error::Error> {
     let mut writes = Vec::with_capacity(batch.len());
     for obj in batch.drain(..) {
         let (ra, dec) = obj.coordinates.get_radec();
@@ -196,10 +208,9 @@ async fn flush_objects_batch(
         pb.inc(1);
     }
     if !writes.is_empty() {
-        if let Err(e) = client.bulk_write(writes).await {
-            error!("bulk_write failed: {}", e);
-        }
+        client.bulk_write(writes).await?;
     }
+    Ok(())
 }
 
 // -----------------------------------------------------------------------------
@@ -281,7 +292,7 @@ async fn run_catalog_driven(
                 batch_size,
                 pb,
             )
-            .await;
+            .await
         }));
     }
     drop(rx);
@@ -297,12 +308,27 @@ async fn run_catalog_driven(
         }
     }
     drop(tx);
+    let mut first_err: Option<mongodb::error::Error> = None;
     for h in workers {
-        if let Err(e) = h.await {
-            error!("worker join failed: {}", e);
+        match h.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                error!("worker failed: {}", e);
+                first_err.get_or_insert(e);
+            }
+            Err(e) => {
+                error!("worker join failed: {}", e);
+            }
         }
     }
     pb.finish();
+    if let Some(e) = first_err {
+        // CRITICAL: phase 1 cleared temp on every existing record. If phase 2 partially failed,
+        // some records have empty temp; running phase 4 would overwrite their valid live
+        // cross_matches with that empty temp. Abort before phase 3 to preserve existing data.
+        // Phase 5-style cleanup of any orphan temp must still run on retry.
+        return Err(e);
+    }
 
     // Phase 3: sort + trim of accumulated matches per alerts_aux record.
     info!(
@@ -359,7 +385,7 @@ async fn catalog_worker(
     rx: async_channel::Receiver<Document>,
     batch_size: usize,
     pb: ProgressBar,
-) {
+) -> Result<(), mongodb::error::Error> {
     let client = db.client().clone();
     let aux_collection: mongodb::Collection<Document> =
         db.collection(&format!("{}_alerts_aux", survey));
@@ -383,12 +409,13 @@ async fn catalog_worker(
             warn!(error = %e, "catalog row processing failed, skipping");
         }
         if cat_count % (batch_size as u64) == 0 && !pending.is_empty() {
-            flush_pending(&client, &aux_ns, &temp_field, &mut pending).await;
+            flush_pending(&client, &aux_ns, &temp_field, &mut pending).await?;
         }
     }
     if !pending.is_empty() {
-        flush_pending(&client, &aux_ns, &temp_field, &mut pending).await;
+        flush_pending(&client, &aux_ns, &temp_field, &mut pending).await?;
     }
+    Ok(())
 }
 
 async fn process_cat_doc(
@@ -470,7 +497,7 @@ async fn flush_pending(
     aux_ns: &Namespace,
     field: &str,
     pending: &mut HashMap<String, Vec<Document>>,
-) {
+) -> Result<(), mongodb::error::Error> {
     let drained: Vec<(String, Vec<Document>)> = pending.drain().collect();
     let models: Vec<WriteModel> = drained
         .into_iter()
@@ -485,10 +512,9 @@ async fn flush_pending(
         })
         .collect();
     if !models.is_empty() {
-        if let Err(e) = client.bulk_write(models).await {
-            error!("bulk_write failed: {}", e);
-        }
+        client.bulk_write(models).await?;
     }
+    Ok(())
 }
 
 /// `coordinates.radec_geojson.coordinates` is `[ra - 180, dec]`.

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -224,7 +224,6 @@ async fn flush_objects_batch(
 // completely untouched (the scheduler pipeline already filled their cross_matches).
 // Without this guard, phase 4's `$set live = $temp` would overwrite a new record's
 // field with a missing/partial temp and silently delete it.
-// Phase 5 then cleans up any orphan temp left.
 // -----------------------------------------------------------------------------
 async fn run_catalog_driven(
     survey: &Survey,
@@ -244,7 +243,7 @@ async fn run_catalog_driven(
     // Phase 1: clear temp field on every alerts_aux record that existed at run start
     // so we start from a known empty state. Records inserted later are skipped.
     info!(
-        "[catalog→{}] phase 1/5: cleaning temp field",
+        "[catalog→{}] phase 1/4: cleaning temp field",
         catalog_config.catalog
     );
     let empty: Vec<Document> = Vec::new();
@@ -257,7 +256,7 @@ async fn run_catalog_driven(
 
     // Phase 2: stream catalog rows through a worker pool, $push matches to temp.
     info!(
-        "[catalog→{}] phase 2/5: streaming catalog rows",
+        "[catalog→{}] phase 2/4: streaming catalog rows",
         catalog_config.catalog
     );
     let mut cat_projection = catalog_config.projection.clone();
@@ -326,13 +325,13 @@ async fn run_catalog_driven(
         // CRITICAL: phase 1 cleared temp on every existing record. If phase 2 partially failed,
         // some records have empty temp; running phase 4 would overwrite their valid live
         // cross_matches with that empty temp. Abort before phase 3 to preserve existing data.
-        // Phase 5-style cleanup of any orphan temp must still run on retry.
+        // The next run's phase 1 will reset temp to [] on every existing record before phase 4 unsets it.
         return Err(e);
     }
 
     // Phase 3: sort + trim of accumulated matches per alerts_aux record.
     info!(
-        "[catalog→{}] phase 3/5: sorting and trimming temp",
+        "[catalog→{}] phase 3/4: sorting and trimming temp",
         catalog_config.catalog
     );
     aux_collection
@@ -348,7 +347,7 @@ async fn run_catalog_driven(
     // Phase 4: copy temp to live field, then clear temp.
     // Gated on created_at to avoid overwriting new records that arrived during the run.
     info!(
-        "[catalog→{}] phase 4/5: swapping temp into live",
+        "[catalog→{}] phase 4/4: swapping temp into live",
         catalog_config.catalog
     );
     aux_collection
@@ -358,18 +357,6 @@ async fn run_catalog_driven(
                 doc! { "$set": { &live_field: format!("${}", &temp_field) } },
                 doc! { "$unset": &temp_field },
             ],
-        )
-        .await?;
-
-    // Phase 5: clean up any orphan temp fields left on records inserted during the run.
-    info!(
-        "[catalog→{}] phase 5/5: cleaning orphan temp",
-        catalog_config.catalog
-    );
-    aux_collection
-        .update_many(
-            doc! { &temp_field: { "$exists": true } },
-            doc! { "$unset": { &temp_field: "" } },
         )
         .await?;
 

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -16,6 +16,8 @@ use boom::{
 use std::time::Duration;
 
 use clap::Parser;
+use futures::TryStreamExt;
+use mongodb::bson::{doc, Document};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use tokio::sync::oneshot;
 use tracing::{info, info_span, instrument, warn, Instrument};
@@ -142,6 +144,70 @@ fn validate_gpu_free_vram(
     Ok(())
 }
 
+/// Sample one aux record at random and warn if it's missing crossmatches for
+/// any catalog declared under `crossmatch.<survey>` in the config. The live
+/// pipeline only crossmatches at first insert, so newly added catalogs never
+/// reach pre-existing records — the user has to run `reprocess_crossmatch`.
+async fn warn_if_missing_crossmatches(survey: &Survey, db: &mongodb::Database, config: &AppConfig) {
+    let configured = match config.crossmatch.get(survey) {
+        Some(v) if !v.is_empty() => v,
+        _ => return,
+    };
+    let aux_collection: mongodb::Collection<Document> =
+        db.collection(&format!("{}_alerts_aux", survey));
+
+    let mut cursor = match aux_collection
+        .aggregate(vec![
+            doc! { "$sample": { "size": 1 } },
+            doc! { "$project": { "_id": 1, "cross_matches": 1 } },
+        ])
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(survey = %survey, error = %e, "crossmatch coverage check: failed to sample");
+            return;
+        }
+    };
+    let sample = match cursor.try_next().await {
+        Ok(Some(d)) => d,
+        Ok(None) => return,
+        Err(e) => {
+            warn!(survey = %survey, error = %e, "crossmatch coverage check: failed to fetch sample");
+            return;
+        }
+    };
+
+    let object_id = sample.get_str("_id").unwrap_or("<unknown>").to_string();
+    let cross_matches = sample.get_document("cross_matches").ok();
+    let missing: Vec<&str> = configured
+        .iter()
+        .filter(|c| match cross_matches {
+            Some(cm) => !cm.contains_key(&c.catalog),
+            None => true,
+        })
+        .map(|c| c.catalog.as_str())
+        .collect();
+
+    if !missing.is_empty() {
+        warn!(
+            survey = %survey,
+            sampled_object_id = %object_id,
+            missing_catalogs = ?missing,
+            "The configured catalogs `{}` are missing from the cross_matches of a random alerts_aux sample `{}`. \
+             This may indicate that newly added catalogs have not been reprocessed for existing records. \
+             The scheduler only crossmatches new alerts_aux, so existing objects \
+             will not be updated with new catalogs. To populate the detected missing crossmatches \
+             for existing records, run `cargo run --bin reprocess_crossmatch -- \
+             --survey {} --catalogs {}`.",
+            missing.join(", "),
+            object_id,
+            survey.to_string().to_lowercase(),
+            missing.join(",")
+        );
+    }
+}
+
 #[derive(Parser)]
 struct Cli {
     /// Name of stream/survey to process alerts for.
@@ -188,6 +254,8 @@ async fn run(args: Cli, meter_provider: SdkMeterProvider) {
     initialize_survey_indexes(&args.survey, &db)
         .await
         .expect("could not initialize indexes");
+
+    warn_if_missing_crossmatches(&args.survey, &db, &config).await;
 
     #[cfg(target_os = "linux")]
     {

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -198,8 +198,8 @@ async fn warn_if_missing_crossmatches(survey: &Survey, db: &mongodb::Database, c
              This may indicate that newly added catalogs have not been reprocessed for existing records. \
              The scheduler only crossmatches new alerts_aux, so existing objects \
              will not be updated with new catalogs. To populate the detected missing crossmatches \
-             for existing records, run `cargo run --bin reprocess_crossmatch -- \
-             --survey {} --catalogs {}`.",
+             for existing records, run `reprocess_crossmatch --survey {} --catalogs {}` \
+             with the appropriate processes and batch_size.",
             missing.join(", "),
             object_id,
             survey.to_string().to_lowercase(),

--- a/src/utils/data.rs
+++ b/src/utils/data.rs
@@ -1,6 +1,20 @@
 use futures::StreamExt;
-use indicatif::ProgressBar;
+use indicatif::{ProgressBar, ProgressStyle};
 use std::io::Write;
+
+/// Standard progress bar used by long-running maintenance binaries
+/// (`reprocess_crossmatch`, `migrate_*`).
+pub fn make_progress_bar(total: u64, label: String) -> ProgressBar {
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "{msg} {bar:40} {pos}/{len} [{elapsed_precise} < {eta_precise}]",
+        )
+        .unwrap(),
+    );
+    pb.set_message(label);
+    pb
+}
 
 // let's make this more generic so we can take any file type, not just a NamedTempFile
 pub async fn download_to_file(

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,7 @@ pub mod enums;
 pub mod fits;
 pub mod lightcurves;
 pub mod o11y;
+pub mod parser;
 pub mod spatial;
 pub mod testing;
 pub mod worker;

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -1,0 +1,7 @@
+pub fn parse_positive_usize(s: &str) -> Result<usize, String> {
+    let n: usize = s.parse().map_err(|e| format!("not a usize: {e}"))?;
+    if n == 0 {
+        return Err("must be > 0".to_string());
+    }
+    Ok(n)
+}

--- a/src/utils/spatial.rs
+++ b/src/utils/spatial.rs
@@ -57,7 +57,7 @@ impl Coordinates {
     }
 }
 
-fn get_f64_from_doc(doc: &mongodb::bson::Document, key: &str) -> Option<f64> {
+pub fn get_f64_from_doc(doc: &mongodb::bson::Document, key: &str) -> Option<f64> {
     let value = match doc.get(key) {
         Some(mongodb::bson::Bson::Double(v)) => *v,
         Some(mongodb::bson::Bson::Int32(v)) => *v as f64,
@@ -73,6 +73,30 @@ fn get_f64_from_doc(doc: &mongodb::bson::Document, key: &str) -> Option<f64> {
         return None;
     }
     Some(value)
+}
+
+/// Effective match radius in arcsec for a `use_distance` catalog row at
+/// redshift `z`. For very nearby objects (z < 0.01) we use the fixed
+/// `distance_max_near`; otherwise the radius scales as
+/// `distance_max * 0.05 / z`.
+pub fn cm_radius_arcsec(z: f64, distance_max: f64, distance_max_near: f64) -> f64 {
+    if z < 0.01 {
+        distance_max_near
+    } else {
+        distance_max * (0.05 / z)
+    }
+}
+
+/// Projected distance in kpc from an angular separation (arcsec) at redshift
+/// `z`. Returns `-1.0` for very nearby objects (z <= 0.005), where the
+/// physical distance is meaningless and `-1.0` is used as a sort sentinel
+/// (sorted before positive values).
+pub fn distance_kpc_from_arcsec(distance_arcsec: f64, z: f64) -> f64 {
+    if z > 0.005 {
+        distance_arcsec * (z / 0.05)
+    } else {
+        -1.0
+    }
 }
 
 #[instrument(skip(xmatch_configs, db), fields(database = db.name()), err)]
@@ -258,26 +282,13 @@ pub async fn xmatch(
                     }
                 };
 
-                let cm_radius_arcsec = if doc_z < 0.01 {
-                    distance_max_near // in arcsec
-                } else {
-                    distance_max * (0.05 / doc_z) // in arcsec
-                };
+                let cm_radius = cm_radius_arcsec(doc_z, distance_max, distance_max_near);
                 let distance_arcsec =
-                    great_circle_distance(ra, dec, xmatch_ra, xmatch_dec) * 3600.0; // convert to arcsec
+                    great_circle_distance(ra, dec, xmatch_ra, xmatch_dec) * 3600.0;
 
-                if distance_arcsec < cm_radius_arcsec {
-                    // calculate the distance between objs in kpc
-                    // let distance_kpc = angular_separation * (doc_z / 0.05);
-                    let distance_kpc = if doc_z > 0.005 {
-                        distance_arcsec * (doc_z / 0.05)
-                    } else {
-                        -1.0
-                    };
-
-                    // we make a mutable copy of the xmatch_doc
+                if distance_arcsec < cm_radius {
+                    let distance_kpc = distance_kpc_from_arcsec(distance_arcsec, doc_z);
                     let mut xmatch_doc = xmatch_doc.clone();
-                    // add the distance fields to the xmatch_doc
                     xmatch_doc.insert("distance_arcsec", distance_arcsec);
                     xmatch_doc.insert("distance_kpc", distance_kpc);
                     matches_filtered.push(xmatch_doc);

--- a/src/utils/spatial.rs
+++ b/src/utils/spatial.rs
@@ -103,7 +103,7 @@ pub fn distance_kpc_from_arcsec(distance_arcsec: f64, z: f64) -> f64 {
 pub async fn xmatch(
     ra: f64,
     dec: f64,
-    xmatch_configs: &Vec<conf::CatalogXmatchConfig>,
+    xmatch_configs: &[conf::CatalogXmatchConfig],
     db: &mongodb::Database,
 ) -> Result<HashMap<String, Vec<mongodb::bson::Document>>, XmatchError> {
     // TODO, make the xmatch config a hashmap for faster access


### PR DESCRIPTION
Add reprocess_crossmatch binary + scheduler crossmatch coverage check:

- `reprocess_crossmatch` backfills `cross_matches.<catalog>` on existing aux records. Useful when a catalog is added or its parameters are changed. Supports `--direction objects|catalog|auto` to loop over the smaller side of the spatial join.
- Parallelize `reprocess_crossmatch` with a worker pool (`--processes`) using an async channel, and batch all object-driven catalogs into a single xmatch pass.
- Process catalog-driven mode into 5 phases with a buffer field `cross_matches_temp.<catalog>`, ensuring `cross_matches.<catalog>` is never empty mid-run. Writes are gated by `created_at < run_start_jd` to avoid touching live inserts.
- Scheduler boot samples one aux record per survey and warns if any configured catalog is missing from `cross_matches`, pointing to the new binary as the fix with already populate arguments.
- Extract shared helpers used by `xmatch`, the new binary, and the `migrate_*` binaries: `cm_radius_arcsec`, `distance_kpc_from_arcsec`, `get_f64_from_doc` in `utils::spatial`, `make_progress_bar` in `utils::data`.