### PR TITLE
LSST: update the kafka and schema registry urls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,8 +37,8 @@ kafka:
       server: "localhost:9092"
       group_id: "" # Set via BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID environment variable
     lsst:
-      server: "usdf-alert-stream-dev.lsst.cloud:9094"
-      schema_registry: "https://usdf-alert-schemas-dev.slac.stanford.edu"
+      server: "rubin-alert-stream-bootstrap.slac.stanford.edu:9094"
+      schema_registry: "https://rubin-alert-schemas.slac.stanford.edu/schema-registry"
       schema_github_fallback_url: "https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema"
       group_id: "" # Set via BOOM_KAFKA__CONSUMER__LSST__GROUP_ID environment variable
       username: "" # Set via BOOM_KAFKA__CONSUMER__LSST__USERNAME environment variable

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -39,7 +39,8 @@ pub const LSST_ZTF_XMATCH_RADIUS: f64 =
 pub const LSST_DECAM_XMATCH_RADIUS: f64 =
     (LSST_POSITION_UNCERTAINTY.max(decam::DECAM_POSITION_UNCERTAINTY) / 3600.0_f64).to_radians();
 
-pub const LSST_SCHEMA_REGISTRY_URL: &str = "https://usdf-alert-schemas-dev.slac.stanford.edu";
+pub const LSST_SCHEMA_REGISTRY_URL: &str =
+    "https://rubin-alert-schemas.slac.stanford.edu/schema-registry";
 pub const LSST_SCHEMA_REGISTRY_GITHUB_FALLBACK_URL: &str =
     "https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema";
 

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -29,8 +29,8 @@ kafka:
       server: "localhost:9092"
       group_id: "test" # Set via BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID environment variable
     lsst:
-      server: "usdf-alert-stream-dev.lsst.cloud:9094"
-      schema_registry: "https://usdf-alert-schemas-dev.slac.stanford.edu"
+      server: "rubin-alert-stream-bootstrap.slac.stanford.edu:9094"
+      schema_registry: "https://rubin-alert-schemas.slac.stanford.edu/schema-registry"
       schema_github_fallback_url: "https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema"
       group_id: "test" # Set via BOOM_KAFKA__CONSUMER__LSST__GROUP_ID environment variable
       username: "" # Set via BOOM_KAFKA__CONSUMER__LSST__USERNAME environment variable


### PR DESCRIPTION
Rubin folks have moved their stuff to new URLs, today is the day they are supposed to switch (though I haven't seen some confirmation sent to broker teams).