### PR TITLE
Improve readme to fit apptainer readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ RUST_LOG=debug,ort=warn BOOM_SPAN_EVENTS=new,close cargo run --bin scheduler -- 
 
 This repository includes a benchmark to test the system and get an idea of the time it takes to process a certain number of alerts.
 This benchmark uses Docker to build the image and run the benchmark.
-The step to run the benchmark are as follows:
+The steps to run the benchmark are as follows:
 
 ### Build Image
 For Docker (docker Image):

--- a/README.md
+++ b/README.md
@@ -323,9 +323,21 @@ docker buildx bake -f tests/throughput/compose.yaml --load
 ```
 
 ### Download Data
-```bash
-mkdir -p ./data/alerts/ztf/public/20250311 # target directory where the producer will download the ZTF archive data
+
+Download a ZTF alerts aux data archive
+
+**For Linux:**
+```
 wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
+```
+**For macOS:**
+```
+curl -sL https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -o ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
+```
+
+Download the NED catalog for crossmatching.
+```
+mkdir -p ./data/alerts/ztf/public/20250311 # target directory where the producer will download the ZTF archive data
 uvx gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ BOOM runs on macOS and Linux. You'll need:
 - `Rust` (a systems programming language) `>= 1.55.0`;
 - `tar`: used to extract archived alerts for testing purposes.
 - `libssl`, `libsasl2`: required for some Rust crates that depend on native libraries for secure connections and authentication.
-- On Linux, you **need** to set `ORT_DYLIB_PATH` to a local ONNX Runtime shared library before running BOOM (for both CPU-only and GPU builds). See the [Linux ONNX Runtime setup](#linux-onnx-runtime-setup) section below for details.
+- On Linux, you **need** to set `ORT_DYLIB_PATH` to a local ONNX Runtime shared library before running BOOM (for both CPU-only and GPU builds). See the [ONNX runtime setup](#onnx-runtime-setup) section below for details.
 
 **Note:** On Linux, BOOM will fail to start with a clear error if `ORT_DYLIB_PATH` is not set. This is a hard requirement due to ONNX Runtime's dynamic loading behavior. The process will not run without it.
 
@@ -57,7 +57,7 @@ BOOM runs on macOS and Linux. You'll need:
   sudo apt install build-essential pkg-config libssl-dev libsasl2-dev -y
   ```
 
-- If you want to use GPU hardware acceleration for enrichment, you need to have the appropriate NVIDIA drivers installed, along with CUDA and cuDNN. See the [GPU inference](#gpu-inference-linux) subsection below for more details.
+- If you want to use GPU hardware acceleration for enrichment, you need to have the appropriate NVIDIA drivers installed, along with CUDA and cuDNN. See the [GPU inference](#gpu-inference) subsection below for more details.
 
 ## Setup
 
@@ -88,7 +88,7 @@ code.
 
 ### Linux only
 
-#### ONNX runtime setup {#linux-onnx-runtime-setup}
+#### ONNX runtime setup
 
 On Linux, BOOM links to the ONNX Runtime shared library at process start via `ORT_DYLIB_PATH`. This is required regardless of whether you use GPU inference or not. You must set this variable before running any BOOM binary natively.
 
@@ -111,7 +111,7 @@ ls .venv/lib/python3.13/site-packages/onnxruntime/capi/libonnxruntime.so.*
 
 You must export `ORT_DYLIB_PATH` in each shell where you run BOOM natively on Linux, or add it once to your shell's configuration file (e.g., `.bashrc` or `.zshrc`) and source it.
 
-#### GPU inference {#gpu-inference-linux}
+#### GPU inference
 
 For GPU inference on Linux you need, in addition to the above:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ BOOM runs on macOS and Linux. You'll need:
 - `Docker` and `docker compose`: used to run the database, cache/task queue, and `Kafka`;
 - `Rust` (a systems programming language) `>= 1.55.0`;
 - `tar`: used to extract archived alerts for testing purposes.
+- `git-lfs`: required to pull the large files (e.g. ML models) tracked via Git LFS.
 - `libssl`, `libsasl2`: required for some Rust crates that depend on native libraries for secure connections and authentication.
 - On Linux, you **need** to set `ORT_DYLIB_PATH` to a local ONNX Runtime shared library before running BOOM (for both CPU-only and GPU builds). See the [Linux ONNX runtime setup](#onnx-runtime-setup) section below for details.
 
@@ -72,8 +73,7 @@ by copying it to `.env`:
 cp .env.example .env
 ```
 
-**Note:** Do not commit `.env` to Git or use the example values
-in production.
+**Note:** Do not commit `.env` to Git or use the example values in production.
 
 #### Email configuration (for notifications)
 
@@ -151,24 +151,23 @@ See [docs/gpu.md](docs/gpu.md) for container-vs-native details, troubleshooting,
     ```
 2. Bring up the local dev stack:
 
-    - With docker, using the provided `docker-compose.yaml` and `docker-compose.override.yaml` file:
+    - With docker, using the provided `docker-compose.yaml` and `docker-compose.override.yaml` files:
       ```bash
       make dev
       ```
       This brings up the hot-reloading `api`, `consumer-ztf`, and `scheduler-ztf` with `cargo watch`, plus
       the supporting Docker services they need.
       This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
-      *To check if the containers are running and healthy, run `docker ps`.*
+      To check if the containers are running and healthy, run `docker ps`.
 
       **Note:** Docker Compose will automatically use the environment variables from your `.env` file to configure the MongoDB container with your specified credentials.
 
-3. Produce alerts for testing:
+3. Delete existing ZTF Kafka topics and produce alerts for testing:
 
     ```bash
     make delete-produce-ztf
     ```
-
-    If you change the producer date or program, make sure the consumer is reading the same topic date/program combination.
+    _If you change the producer date or program, make sure the consumer is reading the same topic date/program combination._
 
 ### Alert Production (not required for production use)
 
@@ -234,9 +233,7 @@ cargo run --release --bin scheduler ztf
 
 ### Using Docker
 
-In production, BOOM runs as a set of dedicated services defined in `docker-compose.yaml`
-under the `prod` profile: `api`, `consumer-ztf`, `consumer-lsst`, `scheduler-ztf`, and `scheduler-lsst`.
-Each service starts its binary automatically at container startup.
+In production, BOOM runs the default services alongside a set of dedicated services defined in `docker-compose.yaml` under the `prod` profile: `api`, `consumer-ztf`, `consumer-lsst`, `scheduler-ztf`, and `scheduler-lsst`. Each of these services starts its binary automatically at container startup.
 
 Bring up the full prod stack with:
 
@@ -254,7 +251,7 @@ To run a binary one-shot with custom arguments (e.g., a specific date and progra
 
 ```bash
 docker compose --profile prod run --rm consumer-ztf /app/kafka_consumer ztf 20240617 --programids public
-docker compose --profile prod run --rm scheduler-ztf /app/scheduler ztf /app/config.yaml
+docker compose --profile prod run --rm scheduler-ztf /app/scheduler ztf
 ```
 
 To tail logs or open a shell in a running container:
@@ -320,23 +317,22 @@ The steps to run the benchmark are as follows:
 ### Build Image
 For Docker (docker Image):
 ```bash
-  docker buildx create --use
-  docker buildx inspect --bootstrap
-  docker buildx bake -f tests/throughput/compose.yaml --load
+docker buildx create --use
+docker buildx inspect --bootstrap
+docker buildx bake -f tests/throughput/compose.yaml --load
 ```
 
 ### Download Data
 ```bash
-  mkdir -p ./data/alerts
-  mkdir -p ./data/alerts/ztf/public/20250311
-  wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
-  gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
+mkdir -p ./data/alerts/ztf/public/20250311 # target directory where the producer will download the ZTF archive data
+wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
+uvx gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
 ```
 
 ### Start Benchmark
 Using Docker:
 ```bash
-  uv run tests/throughput/run.py
+uv run tests/throughput/run.py
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -144,35 +144,31 @@ See [docs/gpu.md](docs/gpu.md) for container-vs-native details, troubleshooting,
 
 ### Start services for local development
 
-Bring up the local dev stack with:
+1. Install lfs and pull the large files:
+    ```bash
+    git lfs install
+    git lfs pull
+    ```
+2. Bring up the local dev stack:
 
-```bash
-make dev
-```
+    - With docker, using the provided `docker-compose.yaml` and `docker-compose.override.yaml` file:
+      ```bash
+      make dev
+      ```
+      This brings up the hot-reloading `api`, `consumer-ztf`, and `scheduler-ztf` with `cargo watch`, plus
+      the supporting Docker services they need.
+      This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
+      *To check if the containers are running and healthy, run `docker ps`.*
 
-This starts `api`, `consumer-ztf`, and `scheduler-ztf` with `cargo watch`, plus
-the supporting Docker services they need.
+      **Note:** Docker Compose will automatically use the environment variables from your `.env` file to configure the MongoDB container with your specified credentials.
 
-## Running BOOM
+3. Produce alerts for testing:
 
-### Local dev pipeline (recommended)
+    ```bash
+    make delete-produce-ztf
+    ```
 
-For local development, use:
-
-```bash
-make dev
-```
-
-This brings up the hot-reloading API, ZTF consumer, and ZTF scheduler.
-
-To produce alerts for testing, run:
-
-```bash
-make delete-produce-ztf
-```
-
-If you change the producer date or program, make sure the consumer is reading
-the same topic date/program combination.
+    If you change the producer date or program, make sure the consumer is reading the same topic date/program combination.
 
 ### Alert Production (not required for production use)
 
@@ -234,6 +230,24 @@ For example, to process ZTF alerts, you can run:
 cargo run --release --bin scheduler ztf
 ```
 
+## Running BOOM in production
+
+### Using Docker
+To run the consumer and the scheduler with Docker, you can open a shell in the `boom` container with:
+```bash
+docker exec -it -w /app boom /bin/bash
+```
+Then you can run the binaries with:
+```bash
+./kafka_consumer <SURVEY> [DATE] --programids [PROGRAMIDS]
+./scheduler <SURVEY> [CONFIG_PATH]
+```
+Or you can run them directly with:
+```bash
+docker exec -it -w /app boom ./kafka_consumer <SURVEY> [DATE] --programids [PROGRAMIDS]
+docker exec -it -w /app boom ./scheduler <SURVEY> [CONFIG_PATH]
+```
+
 The scheduler prints a variety of messages to your terminal, e.g.:
 
 - At the start you should see a bunch of `Processed alert with candid: <alert_candid>, queueing for classification` messages, which means that the fake alert worker is picking up on the alerts, processed them, and is queueing them for classification.
@@ -279,6 +293,34 @@ As a more complete example, the following sets the logging level to DEBUG, with 
 
 ```bash
 RUST_LOG=debug,ort=warn BOOM_SPAN_EVENTS=new,close cargo run --bin scheduler -- ztf
+```
+
+## Running Benchmark
+
+This repository includes a benchmark to test the system and get an idea of the time it takes to process a certain number of alerts.
+This benchmark uses Docker to build the image and run the benchmark.
+The step to run the benchmark are as follows:
+
+### Build Image
+For Docker (docker Image):
+```bash
+  docker buildx create --use
+  docker buildx inspect --bootstrap
+  docker buildx bake -f tests/throughput/compose.yaml --load
+```
+
+### Download Data
+```bash
+  mkdir -p ./data/alerts
+  mkdir -p ./tests/data/alerts/ztf/public/20250311
+  wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
+  gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
+```
+
+### Start Benchmark
+Using Docker:
+```bash
+  uv run tests/throughput/run.py
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -233,19 +233,35 @@ cargo run --release --bin scheduler ztf
 ## Running BOOM in production
 
 ### Using Docker
-To run the consumer and the scheduler with Docker, you can open a shell in the `boom` container with:
+
+In production, BOOM runs as a set of dedicated services defined in `docker-compose.yaml`
+under the `prod` profile: `api`, `consumer-ztf`, `consumer-lsst`, `scheduler-ztf`, and `scheduler-lsst`.
+Each service starts its binary automatically at container startup.
+
+Bring up the full prod stack with:
+
 ```bash
-docker exec -it -w /app boom /bin/bash
+docker compose --profile prod up -d
 ```
-Then you can run the binaries with:
+
+Or start individual services:
+
 ```bash
-./kafka_consumer <SURVEY> [DATE] --programids [PROGRAMIDS]
-./scheduler <SURVEY> [CONFIG_PATH]
+docker compose --profile prod up -d consumer-ztf scheduler-ztf
 ```
-Or you can run them directly with:
+
+To run a binary one-shot with custom arguments (e.g., a specific date and programid for the ZTF consumer), override the service's command with `docker compose run`:
+
 ```bash
-docker exec -it -w /app boom ./kafka_consumer <SURVEY> [DATE] --programids [PROGRAMIDS]
-docker exec -it -w /app boom ./scheduler <SURVEY> [CONFIG_PATH]
+docker compose --profile prod run --rm consumer-ztf /app/kafka_consumer ztf 20240617 --programids public
+docker compose --profile prod run --rm scheduler-ztf /app/scheduler ztf /app/config.yaml
+```
+
+To tail logs or open a shell in a running container:
+
+```bash
+docker compose logs -f scheduler-ztf
+docker compose exec scheduler-ztf /bin/bash
 ```
 
 The scheduler prints a variety of messages to your terminal, e.g.:

--- a/README.md
+++ b/README.md
@@ -314,17 +314,13 @@ This repository includes a benchmark to test the system and get an idea of the t
 This benchmark uses Docker to build the image and run the benchmark.
 The steps to run the benchmark are as follows:
 
-### Build Image
-For Docker (docker Image):
-```bash
-docker buildx create --use
-docker buildx inspect --bootstrap
-docker buildx bake -f tests/throughput/compose.yaml --load
-```
-
 ### Download Data
 
-Download a ZTF alerts aux data archive
+Download the ZTF alerts auxiliary data dump
+
+```
+mkdir -p ./data/alerts
+```
 
 **For Linux:**
 ```
@@ -337,7 +333,6 @@ curl -sL https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.
 
 Download the NED catalog for crossmatching.
 ```
-mkdir -p ./data/alerts/ztf/public/20250311 # target directory where the producer will download the ZTF archive data
 uvx gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
 ```
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ Or start individual services:
 docker compose --profile prod up -d consumer-ztf scheduler-ztf
 ```
 
-To run a binary one-shot with custom arguments (e.g., a specific date and programid for the ZTF consumer), override the service's command with `docker compose run`:
+To run a one-shot operational task, override the service's command with `docker compose run`. This is typically used for database migrations such as `migrate_fp_flux` and `migrate_snr`:
 
 ```bash
-docker compose --profile prod run --rm consumer-ztf /app/kafka_consumer ztf 20240617 --programids public
-docker compose --profile prod run --rm scheduler-ztf /app/scheduler ztf
+docker compose --profile prod run --rm scheduler-ztf /app/migrate_fp_flux
+docker compose --profile prod run --rm scheduler-ztf /app/migrate_snr
 ```
 
 To tail logs or open a shell in a running container:

--- a/README.md
+++ b/README.md
@@ -151,23 +151,23 @@ See [docs/gpu.md](docs/gpu.md) for container-vs-native details, troubleshooting,
     ```
 2. Bring up the local dev stack:
 
-    - With docker, using the provided `docker-compose.yaml` and `docker-compose.override.yaml` files:
-      ```bash
-      make dev
-      ```
-      This brings up the hot-reloading `api`, `consumer-ztf`, and `scheduler-ztf` with `cargo watch`, plus
-      the supporting Docker services they need.
-      This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
-      To check if the containers are running and healthy, run `docker ps`.
+- With docker, using the provided `docker-compose.yaml` and `docker-compose.override.yaml` files:
+  ```bash
+  make dev
+  ```
+  This brings up the hot-reloading `api`, `consumer-ztf`, and `scheduler-ztf` with `cargo watch`, plus
+  the supporting Docker services they need.
+  This may take a couple of minutes the first time you run it, as it needs to download the docker image for each service.
+  To check if the containers are running and healthy, run `docker ps`.
 
-      **Note:** Docker Compose will automatically use the environment variables from your `.env` file to configure the MongoDB container with your specified credentials.
+  **Note:** Docker Compose will automatically use the environment variables from your `.env` file to configure the MongoDB container with your specified credentials.
 
 3. Delete existing ZTF Kafka topics and produce alerts for testing:
 
     ```bash
     make delete-produce-ztf
     ```
-    _If you change the producer date or program, make sure the consumer is reading the same topic date/program combination._
+   _If you change the producer date or program, make sure the consumer is reading the same topic date/program combination._
 
 ### Alert Production (not required for production use)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ BOOM runs on macOS and Linux. You'll need:
 - `Rust` (a systems programming language) `>= 1.55.0`;
 - `tar`: used to extract archived alerts for testing purposes.
 - `libssl`, `libsasl2`: required for some Rust crates that depend on native libraries for secure connections and authentication.
-- On Linux, you **need** to set `ORT_DYLIB_PATH` to a local ONNX Runtime shared library before running BOOM (for both CPU-only and GPU builds). See the [ONNX runtime setup](#onnx-runtime-setup) section below for details.
+- On Linux, you **need** to set `ORT_DYLIB_PATH` to a local ONNX Runtime shared library before running BOOM (for both CPU-only and GPU builds). See the [Linux ONNX runtime setup](#onnx-runtime-setup) section below for details.
 
 **Note:** On Linux, BOOM will fail to start with a clear error if `ORT_DYLIB_PATH` is not set. This is a hard requirement due to ONNX Runtime's dynamic loading behavior. The process will not run without it.
 
@@ -57,7 +57,7 @@ BOOM runs on macOS and Linux. You'll need:
   sudo apt install build-essential pkg-config libssl-dev libsasl2-dev -y
   ```
 
-- If you want to use GPU hardware acceleration for enrichment, you need to have the appropriate NVIDIA drivers installed, along with CUDA and cuDNN. See the [GPU inference](#gpu-inference) subsection below for more details.
+- If you want to use GPU hardware acceleration for enrichment, you need to have the appropriate NVIDIA drivers installed, along with CUDA and cuDNN. See the [Linux GPU inference](#gpu-inference) subsection below for more details.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ For Docker (docker Image):
 ### Download Data
 ```bash
   mkdir -p ./data/alerts
-  mkdir -p ./tests/data/alerts/ztf/public/20250311
+  mkdir -p ./data/alerts/ztf/public/20250311
   wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
   gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
 ```


### PR DESCRIPTION
Update the README to be more close to what I have on the boom apptainer side to simplify when merging the change from the main:
- Improve README to include detailed instructions for production and benchmarking with Docker.
- Fix the link to README section.