### PR TITLE
LSST: move to topic v11

### DIFF
--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -26,7 +26,7 @@ impl AlertConsumer for LsstAlertConsumer {
         if self.simulated {
             vec!["alerts-simulated".to_string()]
         } else {
-            vec!["lsst-alerts-v10.0".to_string()]
+            vec!["lsst-alerts-v11".to_string()]
         }
     }
     fn output_queue(&self) -> String {


### PR DESCRIPTION
LSST made a new schema release: v11. No new fields, just a bunch of integer fields that were set as optional in the schema (but probably weren't actually optional) are now non-optional. I did not modify our structs because I still need them to tell me if these fields were indeed None on some older alerts, in which case we can keep it as is for backwards compatibility when we re-use our structs to read from the DB.

Also, topic names used to be exact versions: `lsst-alerts-v<MAJOR>.<MINOR>`, but since LSST has committed to not change existing fields (only add) in minor versions, we are not forced to edit our structs when a minor version bump occurs and could switch topics just fine. So instead of requiring us to change the topic name we point to at each minor release, now only MAJOR version bumps warrant a new topic name, and these are now called `lsst-alerts-v<MAJOR>`. This is essentially what this PR does: change the current topic name to `lsst-alerts-v11`.