### PR TITLE
Babamul Object Search: by position

### DIFF
--- a/src/api/routes/babamul/surveys/alerts.rs
+++ b/src/api/routes/babamul/surveys/alerts.rs
@@ -47,6 +47,7 @@ struct AlertsQuery {
     min_drb: Option<f64>,
     #[serde(alias = "max_reliability")]
     max_drb: Option<f64>,
+    is_positive: Option<bool>,
     is_rock: Option<bool>,
     is_star: Option<bool>,
     is_near_brightstar: Option<bool>,
@@ -76,6 +77,7 @@ enum AlertsQueryResult {
         ("max_magpsf" = Option<f64>, Query, description = "Maximum magpsf for brightness filter"),
         ("min_drb" = Option<f64>, Query, description = "Minimum DRB score for classification filter"),
         ("max_drb" = Option<f64>, Query, description = "Maximum DRB score for classification filter"),
+        ("is_positive" = Option<bool>, Query, description = "Whether to filter for positive/negative difference sources"),
         ("is_rock" = Option<bool>, Query, description = "Whether to filter for likely rock candidates"),
         ("is_star" = Option<bool>, Query, description = "Whether to filter for likely star candidates"),
         ("is_near_brightstar" = Option<bool>, Query, description = "Whether to filter for candidates near bright stars"),
@@ -211,6 +213,10 @@ pub async fn get_alerts(
             drb_filter.insert("$lte", max_drb);
         }
         filter_doc.insert(drb_key, drb_filter);
+    }
+
+    if let Some(is_positive) = query.is_positive {
+        filter_doc.insert("candidate.isdiffpos", is_positive);
     }
 
     if let Some(is_rock) = query.is_rock {

--- a/src/api/routes/babamul/surveys/objects.rs
+++ b/src/api/routes/babamul/surveys/objects.rs
@@ -497,7 +497,10 @@ fn infer_survey_from_objectid(value: &str) -> Result<(Survey, String), String> {
 
 #[derive(Debug, serde::Deserialize)]
 pub struct SearchObjectsQuery {
-    object_id: String,
+    object_id: Option<String>,
+    ra: Option<f64>,
+    dec: Option<f64>,
+    radius: Option<f64>,
     #[serde(default = "default_limit")]
     limit: u32,
 }
@@ -510,9 +513,11 @@ fn default_limit() -> u32 {
 struct SearchObjectResult {
     #[serde(rename = "objectId")]
     object_id: String,
+    survey: Survey,
     ra: f64,
     dec: f64,
-    survey: Survey,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    distance_arcsec: Option<f64>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -522,17 +527,23 @@ struct ObjectMini {
     coordinates: Coordinates,
 }
 
-/// Search for objects by partial object ID across surveys. Supports ZTF and LSST, and returns id, ra, dec for up to `limit` results.
+/// Search for objects by partial object ID or sky position across surveys.
+///
+/// Provide either `object_id` (survey is auto-inferred) or all three of `ra` / `dec` / `radius`
+/// for a cross-survey cone search over both ZTF and LSST. The two modes are mutually exclusive.
 #[utoipa::path(
     get,
     path = "/babamul/objects",
     params(
-        ("object_id" = String, Query, description = "Partial object ID to search for"),
+        ("object_id" = Option<String>, Query, description = "Partial object ID to search for (mutually exclusive with ra/dec/radius)"),
+        ("ra" = Option<f64>, Query, description = "Right ascension in degrees [0, 360) for cone search"),
+        ("dec" = Option<f64>, Query, description = "Declination in degrees [-90, 90] for cone search"),
+        ("radius" = Option<f64>, Query, description = "Search radius in arcseconds (0, 600] for cone search"),
         ("limit" = Option<u32>, Query, description = "Maximum number of results to return (1-100, default 10)"),
     ),
     responses(
         (status = 200, description = "Search results", body = Vec<SearchObjectResult>),
-        (status = 400, description = "Invalid objectId format"),
+        (status = 400, description = "Invalid query parameters"),
         (status = 500, description = "Internal server error")
     ),
     tags=["Surveys"]
@@ -550,59 +561,156 @@ pub async fn get_objects(
         }
     };
 
-    // Validate limit is within bounds
     let limit = if query.limit < 1 || query.limit > 100 {
         return response::bad_request("Limit must be between 1 and 100");
     } else {
         query.limit as i64
     };
 
-    // Infer survey from objectId (and normalize id casing for ZTF)
-    let (survey, normalized_id) = match infer_survey_from_objectid(&query.object_id) {
-        Ok(pair) => pair,
-        Err(e) => return response::bad_request(&e),
-    };
+    let has_object_id = query.object_id.is_some();
+    let has_position = query.ra.is_some() || query.dec.is_some() || query.radius.is_some();
 
-    let collection = db.collection::<ObjectMini>(&format!("{}_alerts_aux", survey));
+    if has_object_id && has_position {
+        return response::bad_request("Provide either object_id or ra/dec/radius, not both");
+    }
+    if !has_object_id && !has_position {
+        return response::bad_request("Must provide either object_id or ra/dec/radius");
+    }
 
-    // Anchor regex to the start so we only match ordered prefixes
-    let filter = doc! {
-        "_id": {
-            "$regex": format!("^{}", normalized_id),
-        }
-    };
+    if has_object_id {
+        let object_id = query.object_id.as_deref().unwrap();
+        let (survey, normalized_id) = match infer_survey_from_objectid(object_id) {
+            Ok(pair) => pair,
+            Err(e) => return response::bad_request(&e),
+        };
 
-    match collection
-        .find(filter)
-        .sort(doc! { "_id": 1 })
-        .limit(limit)
-        .await
-    {
-        Ok(mut cursor) => {
-            let mut results = vec![];
-            loop {
-                match cursor.try_next().await {
-                    Ok(Some(obj)) => {
-                        let (ra, dec) = obj.coordinates.get_radec();
-                        results.push(SearchObjectResult {
-                            object_id: obj.object_id,
-                            ra,
-                            dec,
-                            survey: survey.clone(),
-                        });
-                    }
-                    Ok(None) => break,
-                    Err(error) => {
-                        return response::internal_error(&format!(
-                            "error searching objects: {}",
-                            error
-                        ));
+        let collection = db.collection::<ObjectMini>(&format!("{}_alerts_aux", survey));
+        let filter = doc! {
+            "_id": { "$regex": format!("^{}", normalized_id) }
+        };
+
+        match collection
+            .find(filter)
+            .sort(doc! { "_id": 1 })
+            .limit(limit)
+            .await
+        {
+            Ok(mut cursor) => {
+                let mut results = vec![];
+                loop {
+                    match cursor.try_next().await {
+                        Ok(Some(obj)) => {
+                            let (ra, dec) = obj.coordinates.get_radec();
+                            results.push(SearchObjectResult {
+                                object_id: obj.object_id,
+                                ra,
+                                dec,
+                                survey: survey.clone(),
+                                distance_arcsec: None,
+                            });
+                        }
+                        Ok(None) => break,
+                        Err(error) => {
+                            return response::internal_error(&format!(
+                                "error searching objects: {}",
+                                error
+                            ));
+                        }
                     }
                 }
+                response::ok_ser(&format!("Found {} objects", results.len()), results)
             }
-            response::ok_ser(&format!("Found {} objects", results.len()), results)
+            Err(error) => response::internal_error(&format!("error searching objects: {}", error)),
         }
-        Err(error) => response::internal_error(&format!("error searching objects: {}", error)),
+    } else {
+        let (ra, dec, radius_arcsec) = match (query.ra, query.dec, query.radius) {
+            (Some(ra), Some(dec), Some(r)) => (ra, dec, r),
+            _ => {
+                return response::bad_request(
+                    "Must provide ra, dec, and radius together for position search",
+                )
+            }
+        };
+
+        if ra < 0.0 || ra >= 360.0 {
+            return response::bad_request("ra must be in [0, 360)");
+        }
+        if dec < -90.0 || dec > 90.0 {
+            return response::bad_request("dec must be in [-90, 90]");
+        }
+        if radius_arcsec <= 0.0 || radius_arcsec > 600.0 {
+            return response::bad_request("radius must be between 0 and 600 arcseconds");
+        }
+
+        let radius_radians = (radius_arcsec / 3600.0_f64).to_radians();
+        let near_filter = doc! {
+            "coordinates.radec_geojson": {
+                "$nearSphere": [ra - 180.0, dec],
+                "$maxDistance": radius_radians,
+            }
+        };
+
+        let mut results: Vec<SearchObjectResult> = vec![];
+
+        let ztf_collection = db.collection::<ObjectMini>("ZTF_alerts_aux");
+        match ztf_collection.find(near_filter.clone()).limit(limit).await {
+            Ok(mut cursor) => {
+                while let Ok(Some(obj)) = cursor.try_next().await {
+                    let (obj_ra, obj_dec) = obj.coordinates.get_radec();
+                    results.push(SearchObjectResult {
+                        object_id: obj.object_id,
+                        ra: obj_ra,
+                        dec: obj_dec,
+                        survey: Survey::Ztf,
+                        distance_arcsec: Some(
+                            flare::spatial::great_circle_distance(ra, dec, obj_ra, obj_dec)
+                                * 3600.0,
+                        ),
+                    });
+                }
+            }
+            Err(error) => {
+                return response::internal_error(&format!(
+                    "error searching ZTF objects: {}",
+                    error
+                ));
+            }
+        }
+
+        let lsst_collection = db.collection::<ObjectMini>("LSST_alerts_aux");
+        match lsst_collection.find(near_filter).limit(limit).await {
+            Ok(mut cursor) => {
+                while let Ok(Some(obj)) = cursor.try_next().await {
+                    let (obj_ra, obj_dec) = obj.coordinates.get_radec();
+                    results.push(SearchObjectResult {
+                        object_id: obj.object_id,
+                        ra: obj_ra,
+                        dec: obj_dec,
+                        survey: Survey::Lsst,
+                        distance_arcsec: Some(
+                            flare::spatial::great_circle_distance(ra, dec, obj_ra, obj_dec)
+                                * 3600.0,
+                        ),
+                    });
+                }
+            }
+            Err(error) => {
+                return response::internal_error(&format!(
+                    "error searching LSST objects: {}",
+                    error
+                ));
+            }
+        }
+
+        results.sort_by(|a, b| {
+            a.distance_arcsec
+                .unwrap_or(f64::MAX)
+                .partial_cmp(&b.distance_arcsec.unwrap_or(f64::MAX))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        results.truncate(limit as usize);
+
+        response::ok_ser(&format!("Found {} objects", results.len()), results)
     }
 }
 
@@ -702,6 +810,7 @@ pub async fn cone_search_objects(
                         ra: obj.coordinates.get_radec().0,
                         dec: obj.coordinates.get_radec().1,
                         survey: survey.clone(),
+                        distance_arcsec: None,
                     });
                 }
                 results.insert(object_name.clone(), matches);

--- a/src/api/routes/babamul/surveys/objects.rs
+++ b/src/api/routes/babamul/surveys/objects.rs
@@ -639,7 +639,9 @@ pub async fn get_objects(
             return response::bad_request("dec must be in [-90, 90]");
         }
         if radius_arcsec <= 0.0 || radius_arcsec > 600.0 {
-            return response::bad_request("radius must be between 0 and 600 arcseconds");
+            return response::bad_request(
+                "radius must be greater than 0 and at most 600 arcseconds",
+            );
         }
 
         let radius_radians = (radius_arcsec / 3600.0_f64).to_radians();

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -919,6 +919,212 @@ mod tests {
         }
     }
 
+    /// Test GET /babamul/objects with ra/dec/radius (cross-survey cone search)
+    #[actix_rt::test]
+    async fn test_get_objects_cone_search() {
+        use boom::utils::spatial::Coordinates;
+
+        load_dotenv();
+        let database: Database = get_test_db_api().await;
+        let auth_app_data = get_test_auth(&database).await.unwrap();
+        let test_user = TestUser::create(&database, &auth_app_data).await;
+
+        let unique_suffix = uuid::Uuid::new_v4().to_string()[..8].to_string();
+
+        use rand::RngExt;
+        let mut rng = rand::rng();
+        // Random position away from poles so arcsec offsets are well-behaved
+        let ztf_ra: f64 = rng.random_range(10.0..350.0);
+        let ztf_dec: f64 = rng.random_range(-70.0..70.0);
+        // LSST object ~3 arcsec away in both axes
+        let offset_arcsec = 3.0_f64 / 3600.0;
+        let lsst_ra = ztf_ra + offset_arcsec;
+        let lsst_dec = ztf_dec + offset_arcsec;
+
+        // Insert one ZTF and one LSST object close to each other
+        let ztf_aux: mongodb::Collection<boom::alert::ZtfObject> =
+            database.collection("ZTF_alerts_aux");
+        let lsst_aux: mongodb::Collection<boom::alert::LsstObject> =
+            database.collection("LSST_alerts_aux");
+
+        let ztf_id = format!("ZTF24conetest_{}", unique_suffix);
+        let lsst_id = format!("111{}", unique_suffix);
+
+        ztf_aux
+            .insert_one(boom::alert::ZtfObject {
+                object_id: ztf_id.clone(),
+                coordinates: Coordinates::new(ztf_ra, ztf_dec),
+                prv_candidates: vec![],
+                prv_nondetections: vec![],
+                fp_hists: vec![],
+                aliases: None,
+                created_at: 0.0,
+                updated_at: 0.0,
+                cross_matches: None,
+            })
+            .await
+            .expect("Failed to insert ZTF test object");
+
+        lsst_aux
+            .insert_one(boom::alert::LsstObject {
+                object_id: lsst_id.clone(),
+                coordinates: Coordinates::new(lsst_ra, lsst_dec),
+                prv_candidates: vec![],
+                fp_hists: vec![],
+                is_sso: false,
+                aliases: None,
+                created_at: 0.0,
+                updated_at: 0.0,
+                cross_matches: None,
+            })
+            .await
+            .expect("Failed to insert LSST test object");
+
+        let app = test::init_service(
+            App::new().service(
+                actix_web::web::scope("/babamul")
+                    .app_data(web::Data::new(database.clone()))
+                    .app_data(web::Data::new(auth_app_data.clone()))
+                    .wrap(from_fn(babamul_auth_middleware))
+                    .service(routes::babamul::surveys::get_objects),
+            ),
+        )
+        .await;
+
+        // Successful cone search: both objects should be returned (within 10 arcsec)
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/babamul/objects?ra={}&dec={}&radius=10&limit=10",
+                ztf_ra, ztf_dec
+            ))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Cone search should succeed (error: {})",
+            read_str_response(resp).await
+        );
+
+        let body = read_json_response(resp).await;
+        let results = body["data"].as_array().expect("data should be an array");
+        let ids: Vec<&str> = results
+            .iter()
+            .filter_map(|r| r["objectId"].as_str())
+            .collect();
+        assert!(
+            ids.contains(&ztf_id.as_str()),
+            "ZTF object should be in results"
+        );
+        assert!(
+            ids.contains(&lsst_id.as_str()),
+            "LSST object should be in results"
+        );
+
+        // Results must be sorted nearest-first
+        let distances: Vec<f64> = results
+            .iter()
+            .filter_map(|r| r["distance_arcsec"].as_f64())
+            .collect();
+        assert!(
+            distances.windows(2).all(|w| w[0] <= w[1]),
+            "Results should be sorted by distance ascending"
+        );
+
+        // Tiny radius — no objects expected
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/babamul/objects?ra={}&dec={}&radius=0.001&limit=10",
+                ztf_ra + 1.0,
+                ztf_dec + 1.0
+            ))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = read_json_response(resp).await;
+        assert_eq!(
+            body["data"].as_array().unwrap().len(),
+            0,
+            "Should return no results for tiny radius far from test objects"
+        );
+
+        // Providing both object_id and ra/dec/radius should be rejected
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/babamul/objects?object_id=ZTF24abc&ra={}&dec={}&radius=10",
+                ztf_ra, ztf_dec
+            ))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Should reject both object_id and ra/dec/radius"
+        );
+
+        // Missing one of ra/dec/radius should be rejected
+        let req = test::TestRequest::get()
+            .uri(&format!("/babamul/objects?ra={}&dec={}", ztf_ra, ztf_dec))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Should reject incomplete position params (missing radius)"
+        );
+
+        // Invalid RA
+        let req = test::TestRequest::get()
+            .uri("/babamul/objects?ra=400&dec=0&radius=10")
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Should reject RA out of range"
+        );
+
+        // Invalid radius
+        let req = test::TestRequest::get()
+            .uri("/babamul/objects?ra=83&dec=-5&radius=700")
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Should reject radius > 600"
+        );
+
+        // No params at all should be rejected
+        let req = test::TestRequest::get()
+            .uri("/babamul/objects")
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Should reject request with no search params"
+        );
+
+        // Clean up
+        ztf_aux.delete_one(doc! { "_id": &ztf_id }).await.ok();
+        lsst_aux.delete_one(doc! { "_id": &lsst_id }).await.ok();
+    }
+
     /// Test POST /babamul/kafka-credentials - Create a new Kafka credential
     /// NOTE: This test requires Kafka CLI tools and a reachable Kafka broker
     #[actix_rt::test]

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -941,6 +941,15 @@ mod tests {
         let lsst_ra = ztf_ra + offset_arcsec;
         let lsst_dec = ztf_dec + offset_arcsec;
 
+        // Ensure the 2dsphere index on coordinates.radec_geojson exists for both surveys
+        // so $nearSphere works regardless of test execution order.
+        boom::utils::db::initialize_survey_indexes(&Survey::Ztf, &database)
+            .await
+            .expect("Failed to initialize ZTF indexes");
+        boom::utils::db::initialize_survey_indexes(&Survey::Lsst, &database)
+            .await
+            .expect("Failed to initialize LSST indexes");
+
         // Insert one ZTF and one LSST object close to each other
         let ztf_aux: mongodb::Collection<boom::alert::ZtfObject> =
             database.collection("ZTF_alerts_aux");


### PR DESCRIPTION
This PR adds support for querying babamul objects by position (ra/dec/radious). The object search endpoint of babamul is cross-survey, and in its existing implementation infers what survey to query (ZTF vs LSST) based on the provided partial `objectId`. The newly added position-based query simply queries both surveys for their objects closest to the input position and up to `limit`, aggregates the ZTF+LSST results, sorts by distance to the input position, then keeps up to `limit` results. Effectively giving us a multi-survey object cone-search endpoint.

One minor unrelated change: we add the ability to optionally filter on `candidate.isdiffpos` in the GET alerts endpoint of babamul (`is_positive` parameter).