### PR TITLE
WIP - Fetch alerts and cutouts concurrently

### DIFF
--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -13,10 +13,10 @@ pub enum ModelError {
     MissingDocumentField(#[from] mongodb::bson::document::ValueAccessError),
     #[error("shape error from ndarray")]
     NdarrayShape(#[from] ndarray::ShapeError),
-    #[error("error from ort")]
-    Ort(#[from] ort::Error),
-    #[error("error from ort session builder")]
-    OrtSessionBuilder(#[from] ort::Error<ort::session::builder::SessionBuilder>),
+    #[error("error from ort: {0}")]
+    Ort(String),
+    #[error("error from ort session builder: {0}")]
+    OrtSessionBuilder(String),
     #[error("error preparing cutout data")]
     PrepareCutoutError(#[from] CutoutError),
     #[error("error converting predictions to vec")]
@@ -25,6 +25,18 @@ pub enum ModelError {
     MissingFeature(&'static str),
     #[error("ORT_DYLIB_PATH is not set on Linux; ONNX Runtime cannot be loaded. Please set ORT_DYLIB_PATH to the path of your libonnxruntime.so.")]
     MissingOrtDylibPath,
+}
+
+impl From<ort::Error> for ModelError {
+    fn from(e: ort::Error) -> Self {
+        ModelError::Ort(e.to_string())
+    }
+}
+
+impl From<ort::Error<ort::session::builder::SessionBuilder>> for ModelError {
+    fn from(e: ort::Error<ort::session::builder::SessionBuilder>) -> Self {
+        ModelError::OrtSessionBuilder(e.to_string())
+    }
 }
 
 /// Load an ONNX model, optionally on a specific CUDA device.

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -459,8 +459,14 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
         &mut self,
         candids: &[i64],
     ) -> Result<Vec<String>, EnrichmentWorkerError> {
-        let alerts: Vec<ZtfAlertForEnrichment> =
-            fetch_alerts(&candids, &self.alert_pipeline, &self.alert_collection).await?;
+        let (alerts, mut candid_to_cutouts) = tokio::try_join!(
+            fetch_alerts::<ZtfAlertForEnrichment>(
+                &candids,
+                &self.alert_pipeline,
+                &self.alert_collection
+            ),
+            fetch_alert_cutouts(&candids, &self.alert_cutout_collection)
+        )?;
 
         if alerts.len() != candids.len() {
             warn!(
@@ -472,9 +478,6 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
         if alerts.is_empty() {
             return Ok(vec![]);
         }
-
-        let mut candid_to_cutouts =
-            fetch_alert_cutouts(&candids, &self.alert_cutout_collection).await?;
 
         if candid_to_cutouts.len() != alerts.len() {
             warn!(

--- a/src/filter/ztf.rs
+++ b/src/filter/ztf.rs
@@ -1,3 +1,4 @@
+use futures::TryFutureExt;
 use mongodb::bson::{doc, Document};
 use std::collections::HashMap;
 use tracing::{info, instrument, warn};
@@ -168,9 +169,12 @@ pub async fn build_ztf_alerts(
         return Ok(Vec::new());
     }
 
-    let alerts: Vec<ZtfAlertEnriched> = fetch_alerts(&candids, &alert_pipeline, alert_collection)
-        .await
-        .map_err(|e| FilterWorkerError::FetchAlertsError(e.to_string()))?;
+    let (alerts, mut candid_to_cutouts): (Vec<ZtfAlertEnriched>, _) = tokio::try_join!(
+        fetch_alerts(&candids, &alert_pipeline, alert_collection)
+            .map_err(|e| FilterWorkerError::FetchAlertsError(e.to_string())),
+        fetch_alert_cutouts(&candids, &alert_cutout_collection)
+            .map_err(|e| FilterWorkerError::FetchCutoutsError(e.to_string()))
+    )?;
 
     if alerts.len() != candids.len() {
         let nb_total = candids.len();
@@ -186,10 +190,6 @@ pub async fn build_ztf_alerts(
             missing_candids
         );
     }
-
-    let mut candid_to_cutouts = fetch_alert_cutouts(&candids, &alert_cutout_collection)
-        .await
-        .map_err(|e| FilterWorkerError::FetchCutoutsError(e.to_string()))?;
 
     if candid_to_cutouts.len() != alerts.len() {
         let mut missing_cutouts_candids: Vec<&i64> = alerts


### PR DESCRIPTION
This PR is an attempt at fetching alerts and cutouts concurrently in the relevant workers (enrichment, filter). The idea here is that while our app is async (and therefore when a thread is awaiting an operation it can be used for another), our single-threaded workers await operations sequentially. So for example in the enrichment worker (same for filter worker) we await for the alerts being fetched, and only when that's done do we fetch the cutouts and wait for those before we proceed with the rest of the compute. But theoretically, since both functions (fetch_alerts, fetch_alert_cutouts) are async in nature, we could just call both without awaits, and use `tokio::try_join`. Effectively, this tells tokio to run both jobs concurrently, and when we hit operations in them that are awaited (i.e. we have no compute to run, we just need to wait) then we should give the compute back to the other jobs in that same `tokio::try_join` scope. TLDR: this should let us minimize the total time needed to fetch alerts and their cutouts by running the MongoDB queries in them concurrently, and all while still using just one thread in the worker. Now obviously this means we ask mongo to handle 2 queries in parallel instead, so I'm curious to see the effect that this has on throughput. Because clearly, getting data back from Mongo represents a good chunk of our walltime in these workers (especially the enrichment worker, because anyways the filter worker only needs alerts that go through filters and that **should** be a small number).

Notes: 
- not sure how well this will work since we use mongodb cursors anyways, meaning data comes back to use regularly as it becomes available, not in one big chunk. So the we don't spend so much time just waiting, but instead we keep switching between short wait times and serialization work in rust.
- we focus on ZTF here, because that's what we use for the throughput test and that's how we can assess if this change is worth it.
- About the seemingly unrelated changes to the `EnrichmentWorkerError` handling of `ort` errors: the ort errors don't implement some async-related traits and that cascaded in compilation errors as soon as I tried to use functions that use `EnrichmentWorkerError` in a `tokio::try_join`.