### PR TITLE
Restrict prod deploys to version tags and admins/maintainers

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to deploy (tag, branch, or commit SHA)"
+        description: "Version tag to deploy (must match 'v*')"
         required: true
-        default: "main"
+        default: "v0.0.0"
         type: string
 
 jobs:
@@ -20,6 +20,8 @@ jobs:
     runs-on:
       - self-hosted
       - production
+    permissions:
+      contents: read
     env:
       ENVIRONMENT: production
       DOMAIN: ${{ vars.DOMAIN }}
@@ -41,10 +43,74 @@ jobs:
       SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
       SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
     steps:
+      - name: Require maintain/admin actor permissions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const username = context.actor;
+
+            let permission;
+            let roleName;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username,
+              });
+              permission = data.permission;
+              roleName = data.role_name;
+            } catch (error) {
+              core.setFailed(
+                `Unable to determine permissions for actor '${username}'. ${error.message}`
+              );
+              return;
+            }
+
+            const allowedRoles = new Set(["maintain", "admin"]);
+            const normalizedRole = (roleName || "").toLowerCase();
+            const normalizedPermission = (permission || "").toLowerCase();
+
+            const isAllowed =
+              allowedRoles.has(normalizedRole) || normalizedPermission === "admin";
+
+            if (!isAllowed) {
+              core.setFailed(
+                `Actor '${username}' has repository role '${normalizedRole || normalizedPermission || "unknown"}'. ` +
+                  "Deploy requires 'maintain' or 'admin'."
+              );
+              return;
+            }
+
+            core.info(
+              `Actor '${username}' authorized with role '${normalizedRole || normalizedPermission}'.`
+            );
+      - name: Validate and normalize deployment tag
+        id: deploy_tag
+        env:
+          RAW_DEPLOY_REF: ${{ github.event.inputs.version || github.ref }}
+        run: |
+          set -euo pipefail
+
+          ref="$RAW_DEPLOY_REF"
+          if [[ "$ref" == refs/tags/v* ]]; then
+            tag_ref="$ref"
+            tag_name="${ref#refs/tags/}"
+          elif [[ "$ref" == v* ]]; then
+            tag_name="$ref"
+            tag_ref="refs/tags/$tag_name"
+          else
+            echo "Only tags matching 'v*' are allowed for deployment. Received: $ref" >&2
+            exit 1
+          fi
+
+          echo "Deploying tag: $tag_name"
+          echo "tag_ref=$tag_ref" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.version || github.ref }}
+          ref: ${{ steps.deploy_tag.outputs.tag_ref }}
       - run: >
           docker compose --profile prod
           -f docker-compose.yaml build

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -188,4 +188,19 @@ Follow the [official GitHub guide for setting repository secrets](https://docs.g
 See [`.github/workflows/deploy.yaml`](/.github/workflows/deploy.yaml)
 for the secrets that should be set.
 
-That's it. Now BOOM will deploy to production on each GitHub release.
+## GitHub deploy safety controls
+
+Production deploys are intentionally constrained by both repository settings and
+the workflow in [`.github/workflows/deploy.yaml`](/.github/workflows/deploy.yaml):
+
+1. A repository ruleset named `Tag creation` is active for tag refs (`~ALL`).
+   It enforces tag creation/update/deletion protections, with bypass actors set
+   to repository roles 2 and 5 (maintainers/admins).
+1. The `production` environment has a deployment branch/tag rule that only
+   allows tags matching `v*`.
+1. The workflow enforces the same model at runtime:
+   - it checks that the actor has `maintain` or `admin` repository access.
+   - it validates that the selected deploy ref is a tag matching `v*`.
+
+In practice, this means only approved release tags can be deployed to
+production, reducing the risk of accidental or unauthorized production changes.


### PR DESCRIPTION
The repo now also has a ruleset for tag creation, so only maintainers and admins can create/update/delete tags. This gives us a bit more control over how BOOM can be deployed, so we can give others write access to the repo without prod deploy access.

## TODO

- [x] Document repo settings required