### PR TITLE
BTSbot update: v1.0.1 -> v2.0.0; acai vram optimization

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -28,7 +28,6 @@ RUN ORT_CAPI_DIR="$('/opt/ort-py/bin/python' -c 'import pathlib, onnxruntime as 
     cp "${ORT_CAPI_DIR}/libonnxruntime_providers_tensorrt.so" /opt/ort/ && \
     rm -rf /opt/ort-py && ln -sf /opt/ort/libonnxruntime.so.${ONNXRUNTIME_GPU_VERSION} /opt/ort/libonnxruntime.so
 
-COPY data/models/btsbot-v1.0.1.onnx /app/data/models/btsbot-v1.0.1.onnx
 COPY apache-avro-macros /app/apache-avro-macros
 COPY Cargo.toml Cargo.lock /app/
 

--- a/data/models/acai_b.d1_dnn_20201130.onnx
+++ b/data/models/acai_b.d1_dnn_20201130.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e19725bf2778c175d55f9810008648067ef6ceb11d9521c9bdc786faa74bd8b
-size 35206

--- a/data/models/acai_b.d1_dnn_20201130_nchw.onnx
+++ b/data/models/acai_b.d1_dnn_20201130_nchw.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77226ce585cf2134a090092005f81801b3d391a5f0b4db7c6028c7e8f000296
+size 35016

--- a/data/models/acai_h.d1_dnn_20201130.onnx
+++ b/data/models/acai_h.d1_dnn_20201130.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:627893ad62a654f4a72f9fa84fd414e0a8042c479ef50cc08236b7ed962c411b
-size 35206

--- a/data/models/acai_h.d1_dnn_20201130_nchw.onnx
+++ b/data/models/acai_h.d1_dnn_20201130_nchw.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:133457196f277f284eab4da63a82141b82e8cb9fc1afe34f7e27cf129c9d4092
+size 35016

--- a/data/models/acai_n.d1_dnn_20201130.onnx
+++ b/data/models/acai_n.d1_dnn_20201130.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f380616f6fca1ce1034a9b72f3509558c0083d846ea80b8d85236cfbc78248ad
-size 35206

--- a/data/models/acai_n.d1_dnn_20201130_nchw.onnx
+++ b/data/models/acai_n.d1_dnn_20201130_nchw.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7334d0821415a109a620007d4cc6ca92d8cab46e067e034e9e5b5364559eba11
+size 35016

--- a/data/models/acai_o.d1_dnn_20201130.onnx
+++ b/data/models/acai_o.d1_dnn_20201130.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d58eac9f98a3c1df0e00c5391d5bbc70f337196833b94c9f799dcb1f70797d1c
-size 35203

--- a/data/models/acai_o.d1_dnn_20201130_nchw.onnx
+++ b/data/models/acai_o.d1_dnn_20201130_nchw.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d804893b63104e6d2a7bb935d5bcebc4587b6b7ab840d0bf65c626c5b7342992
+size 35016

--- a/data/models/acai_v.d1_dnn_20201130.onnx
+++ b/data/models/acai_v.d1_dnn_20201130.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4dac7ce1b1f8f4db05a0ec36527f84c5745afd6e83afec225dddc8df37efbe5e
-size 35184

--- a/data/models/acai_v.d1_dnn_20201130_nchw.onnx
+++ b/data/models/acai_v.d1_dnn_20201130_nchw.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b204f8ba3e2f12cb30ff850dea4a665c56c9e28dc9362a7151b01b74688c04ee
+size 35000

--- a/data/models/btsbot-v1.0.1.onnx
+++ b/data/models/btsbot-v1.0.1.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad16e6be9719fca9613187e3bc80095a9852af3c6e1d1fd24edfc1f023348da4
-size 916071

--- a/data/models/btsbot-v2.0.0.onnx
+++ b/data/models/btsbot-v2.0.0.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38f61e6013067d9929b9ff3f52ecd9d42aa702c324347944d2ee14d09c9aeba2
+size 35323463

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -44,7 +44,7 @@ fn validate_gpu_inference(device_ids: &[i32]) -> Result<(), Box<dyn std::error::
         info!(device_id, "Running BTSBotModel inference on device");
         let mut model = BtsBotModel::new_on_device("data/models/btsbot-v2.0.0.onnx", device_id)?;
         let metadata = ndarray::Array::from_shape_vec((1, 25), vec![0.5; 25])?;
-        let triplet = ndarray::Array::from_shape_vec((1, 63, 63, 3), vec![0.5; 63 * 63 * 3])?;
+        let triplet = ndarray::Array::from_shape_vec((1, 3, 63, 63), vec![0.5; 3 * 63 * 63])?;
         let _ = model.predict(&metadata, &triplet)?;
     }
     Ok(())

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -42,7 +42,7 @@ fn validate_gpu_inference(device_ids: &[i32]) -> Result<(), Box<dyn std::error::
     use boom::enrichment::models::{BtsBotModel, Model};
     for &device_id in device_ids {
         info!(device_id, "Running BTSBotModel inference on device");
-        let mut model = BtsBotModel::new_on_device("data/models/btsbot-v1.0.1.onnx", device_id)?;
+        let mut model = BtsBotModel::new_on_device("data/models/btsbot-v2.0.0.onnx", device_id)?;
         let metadata = ndarray::Array::from_shape_vec((1, 25), vec![0.5; 25])?;
         let triplet = ndarray::Array::from_shape_vec((1, 63, 63, 3), vec![0.5; 63 * 63 * 3])?;
         let _ = model.predict(&metadata, &triplet)?;

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -7,6 +7,19 @@ use ort::session::{builder::GraphOptimizationLevel, Session};
 use std::env;
 use tracing::instrument;
 
+const CUTOUT_CHANNELS: usize = 3; // science, template, difference
+const CUTOUT_HEIGHT: usize = 63;
+const CUTOUT_WIDTH: usize = 63;
+
+fn cutout_to_hw_array(cutout: &[f32]) -> Result<Array<f32, Dim<[usize; 2]>>, ModelError> {
+    // `prepare_triplet` returns a flattened cutout in row-major order (H, then W).
+    // Rebuild the 2D view explicitly as (height, width) before placing it in NCHW.
+    Ok(Array::from_shape_vec(
+        (CUTOUT_HEIGHT, CUTOUT_WIDTH),
+        cutout.to_vec(),
+    )?)
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum ModelError {
     #[error("failed to access document field")]
@@ -92,11 +105,14 @@ pub trait Model {
     fn new(path: &str) -> Result<Self, ModelError>
     where
         Self: Sized;
+
+    /// Build NCHW triplet tensors (N, CUTOUT_CHANNELS, CUTOUT_HEIGHT, CUTOUT_WIDTH) from the cutouts.
     #[instrument(skip_all, err)]
     fn get_triplet(
         alert_cutouts: &[&AlertCutout],
     ) -> Result<Array<f32, Dim<[usize; 4]>>, ModelError> {
-        let mut triplets = Array::zeros((alert_cutouts.len(), 63, 63, 3));
+        let n = alert_cutouts.len();
+        let mut triplets = Array::zeros((n, CUTOUT_CHANNELS, CUTOUT_HEIGHT, CUTOUT_WIDTH));
         for i in 0..alert_cutouts.len() {
             let (cutout_science, cutout_template, cutout_difference) =
                 prepare_triplet(alert_cutouts[i])?;
@@ -104,38 +120,46 @@ pub trait Model {
                 .iter()
                 .enumerate()
             {
-                let mut slice = triplets.slice_mut(ndarray::s![i, .., .., j]);
-                let cutout_array = Array::from_shape_vec((63, 63), cutout.to_vec())?;
+                let mut slice = triplets.slice_mut(ndarray::s![i, j, .., ..]);
+                let cutout_array = cutout_to_hw_array(cutout)?;
                 slice.assign(&cutout_array);
             }
         }
         Ok(triplets)
     }
 
-    /// Build triplets for all valid cutouts and return the original indices kept.
-    /// Invalid cutouts are skipped.
+    /// Build NCHW triplet tensors (N, CUTOUT_CHANNELS, CUTOUT_HEIGHT, CUTOUT_WIDTH) for all valid cutouts and
+    /// return the original indices kept. Invalid cutouts are skipped.
     fn get_triplet_indexed(
         alert_cutouts: &[&AlertCutout],
     ) -> Result<(Vec<usize>, Array<f32, Dim<[usize; 4]>>), ModelError> {
         let mut kept_indices: Vec<usize> = Vec::new();
-        let mut kept_triplets: Vec<(Vec<f32>, Vec<f32>, Vec<f32>)> = Vec::new();
+        let mut kept_triplets: Vec<[Vec<f32>; CUTOUT_CHANNELS]> = Vec::new();
 
         for (idx, cutout) in alert_cutouts.iter().enumerate() {
             if let Ok((science, template, difference)) = prepare_triplet(cutout) {
                 kept_indices.push(idx);
-                kept_triplets.push((science.to_vec(), template.to_vec(), difference.to_vec()));
+                kept_triplets.push([science, template, difference]);
             }
         }
 
         if kept_indices.is_empty() {
-            return Ok((kept_indices, Array::zeros((0, 63, 63, 3))));
+            return Ok((
+                kept_indices,
+                Array::zeros((0, CUTOUT_CHANNELS, CUTOUT_HEIGHT, CUTOUT_WIDTH)),
+            ));
         }
 
-        let mut triplets = Array::zeros((kept_indices.len(), 63, 63, 3));
-        for (i, (science, template, difference)) in kept_triplets.into_iter().enumerate() {
-            for (j, cutout) in [science, template, difference].iter().enumerate() {
-                let mut slice = triplets.slice_mut(ndarray::s![i, .., .., j]);
-                let cutout_array = Array::from_shape_vec((63, 63), cutout.clone())?;
+        let mut triplets = Array::zeros((
+            kept_indices.len(),
+            CUTOUT_CHANNELS,
+            CUTOUT_HEIGHT,
+            CUTOUT_WIDTH,
+        ));
+        for (i, triplet) in kept_triplets.into_iter().enumerate() {
+            for (j, cutout) in triplet.iter().enumerate() {
+                let mut slice = triplets.slice_mut(ndarray::s![i, j, .., ..]);
+                let cutout_array = cutout_to_hw_array(cutout)?;
                 slice.assign(&cutout_array);
             }
         }

--- a/src/enrichment/models/btsbot.rs
+++ b/src/enrichment/models/btsbot.rs
@@ -28,14 +28,19 @@ impl Model for BtsBotModel {
         image_features: &Array<f32, Dim<[usize; 4]>>,
     ) -> Result<Vec<f32>, ModelError> {
         let model_inputs = inputs! {
-            "triplet" => TensorRef::from_array_view(image_features)?,
+            "image" => TensorRef::from_array_view(image_features)?,
             "metadata" => TensorRef::from_array_view(metadata_features)?,
         };
 
         let outputs = self.model.run(model_inputs)?;
 
-        match outputs["fc_out"].try_extract_tensor::<f32>() {
-            Ok((_, scores)) => Ok(scores.to_vec()),
+        // BTSbot v2 outputs logits, and not probabilities, so we need
+        // to apply the sigmoid function to convert them to probabilities.
+        match outputs["logits"].try_extract_tensor::<f32>() {
+            Ok((_, logits)) => Ok(logits
+                .iter()
+                .map(|&x| 1.0f32 / (1.0 + (-x).exp()))
+                .collect()),
             Err(_) => Err(ModelError::ModelOutputToVecError),
         }
     }

--- a/src/enrichment/models/mod.rs
+++ b/src/enrichment/models/mod.rs
@@ -60,7 +60,7 @@ impl SharedModels {
                     id,
                 )?),
                 btsbot: Mutex::new(BtsBotModel::new_on_device(
-                    "data/models/btsbot-v1.0.1.onnx",
+                    "data/models/btsbot-v2.0.0.onnx",
                     id,
                 )?),
             },
@@ -70,7 +70,7 @@ impl SharedModels {
                 acai_v: Mutex::new(AcaiModel::new("data/models/acai_v.d1_dnn_20201130.onnx")?),
                 acai_o: Mutex::new(AcaiModel::new("data/models/acai_o.d1_dnn_20201130.onnx")?),
                 acai_b: Mutex::new(AcaiModel::new("data/models/acai_b.d1_dnn_20201130.onnx")?),
-                btsbot: Mutex::new(BtsBotModel::new("data/models/btsbot-v1.0.1.onnx")?),
+                btsbot: Mutex::new(BtsBotModel::new("data/models/btsbot-v2.0.0.onnx")?),
             },
         };
         info!("all ONNX models loaded successfully");

--- a/src/enrichment/models/mod.rs
+++ b/src/enrichment/models/mod.rs
@@ -40,23 +40,23 @@ impl SharedModels {
         let models = match device_id {
             Some(id) => Self {
                 acai_h: Mutex::new(AcaiModel::new_on_device(
-                    "data/models/acai_h.d1_dnn_20201130.onnx",
+                    "data/models/acai_h.d1_dnn_20201130_nchw.onnx",
                     id,
                 )?),
                 acai_n: Mutex::new(AcaiModel::new_on_device(
-                    "data/models/acai_n.d1_dnn_20201130.onnx",
+                    "data/models/acai_n.d1_dnn_20201130_nchw.onnx",
                     id,
                 )?),
                 acai_v: Mutex::new(AcaiModel::new_on_device(
-                    "data/models/acai_v.d1_dnn_20201130.onnx",
+                    "data/models/acai_v.d1_dnn_20201130_nchw.onnx",
                     id,
                 )?),
                 acai_o: Mutex::new(AcaiModel::new_on_device(
-                    "data/models/acai_o.d1_dnn_20201130.onnx",
+                    "data/models/acai_o.d1_dnn_20201130_nchw.onnx",
                     id,
                 )?),
                 acai_b: Mutex::new(AcaiModel::new_on_device(
-                    "data/models/acai_b.d1_dnn_20201130.onnx",
+                    "data/models/acai_b.d1_dnn_20201130_nchw.onnx",
                     id,
                 )?),
                 btsbot: Mutex::new(BtsBotModel::new_on_device(
@@ -65,11 +65,21 @@ impl SharedModels {
                 )?),
             },
             None => Self {
-                acai_h: Mutex::new(AcaiModel::new("data/models/acai_h.d1_dnn_20201130.onnx")?),
-                acai_n: Mutex::new(AcaiModel::new("data/models/acai_n.d1_dnn_20201130.onnx")?),
-                acai_v: Mutex::new(AcaiModel::new("data/models/acai_v.d1_dnn_20201130.onnx")?),
-                acai_o: Mutex::new(AcaiModel::new("data/models/acai_o.d1_dnn_20201130.onnx")?),
-                acai_b: Mutex::new(AcaiModel::new("data/models/acai_b.d1_dnn_20201130.onnx")?),
+                acai_h: Mutex::new(AcaiModel::new(
+                    "data/models/acai_h.d1_dnn_20201130_nchw.onnx",
+                )?),
+                acai_n: Mutex::new(AcaiModel::new(
+                    "data/models/acai_n.d1_dnn_20201130_nchw.onnx",
+                )?),
+                acai_v: Mutex::new(AcaiModel::new(
+                    "data/models/acai_v.d1_dnn_20201130_nchw.onnx",
+                )?),
+                acai_o: Mutex::new(AcaiModel::new(
+                    "data/models/acai_o.d1_dnn_20201130_nchw.onnx",
+                )?),
+                acai_b: Mutex::new(AcaiModel::new(
+                    "data/models/acai_b.d1_dnn_20201130_nchw.onnx",
+                )?),
                 btsbot: Mutex::new(BtsBotModel::new("data/models/btsbot-v2.0.0.onnx")?),
             },
         };

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -798,8 +798,8 @@ impl ZtfEnrichmentWorker {
             return Ok(results);
         }
 
-        let mut triplet = ndarray::Array::zeros((selected_indices.len(), 63, 63, 3));
-        let mut metadata = ndarray::Array::zeros((selected_indices.len(), 25));
+        let mut triplet = ndarray::Array::zeros((selected_indices.len(), 3, 63, 63));
+        let mut acai_metadata = ndarray::Array::zeros((selected_indices.len(), 25));
         let mut btsbot_metadata = ndarray::Array::zeros((selected_indices.len(), 25));
 
         for (row, idx) in selected_indices.iter().enumerate() {
@@ -810,17 +810,39 @@ impl ZtfEnrichmentWorker {
             triplet
                 .slice_mut(ndarray::s![row, .., .., ..])
                 .assign(&triplet_all.slice(ndarray::s![tpos, .., .., ..]));
-            metadata.row_mut(row).assign(&acai_metadata_all.row(apos));
+            acai_metadata
+                .row_mut(row)
+                .assign(&acai_metadata_all.row(apos));
             btsbot_metadata
                 .row_mut(row)
                 .assign(&bts_metadata_all.row(bpos));
         }
 
-        let acai_h_scores = models.acai_h.lock().unwrap().predict(&metadata, &triplet)?;
-        let acai_n_scores = models.acai_n.lock().unwrap().predict(&metadata, &triplet)?;
-        let acai_v_scores = models.acai_v.lock().unwrap().predict(&metadata, &triplet)?;
-        let acai_o_scores = models.acai_o.lock().unwrap().predict(&metadata, &triplet)?;
-        let acai_b_scores = models.acai_b.lock().unwrap().predict(&metadata, &triplet)?;
+        let acai_h_scores = models
+            .acai_h
+            .lock()
+            .unwrap()
+            .predict(&acai_metadata, &triplet)?;
+        let acai_n_scores = models
+            .acai_n
+            .lock()
+            .unwrap()
+            .predict(&acai_metadata, &triplet)?;
+        let acai_v_scores = models
+            .acai_v
+            .lock()
+            .unwrap()
+            .predict(&acai_metadata, &triplet)?;
+        let acai_o_scores = models
+            .acai_o
+            .lock()
+            .unwrap()
+            .predict(&acai_metadata, &triplet)?;
+        let acai_b_scores = models
+            .acai_b
+            .lock()
+            .unwrap()
+            .predict(&acai_metadata, &triplet)?;
         let btsbot_scores = models
             .btsbot
             .lock()


### PR DESCRIPTION
While the new model is much larger in parameter size (8.8M vs 230k for the old model), performance is improved and VRAM usage on the GPU is a lot smaller (only my system, old model uses around 6GB at batch size = 1024, new one uses around 2GB!!! A huge improvement. Also runtime is better, I see 30 ms instead of 45 ms.

Now here's the issue. BTSbot wants the images in (N,3,63,63) format (NCHW). But acai (and old btsbot) expect (N,63,63,3) format (NWHC). So it's a bit of a pain, because we now need to have 2 sets of tensor images! But then, while I was looking at the ONNX graph of ACAI I noticed something I stumbled upon a few years back: ACAI wants (N,63,63,3) images as input but the first ONNX operator is a transpose (0,3,1,2) that converts it to (N,3,63,63), exactly the input format of btsbot v2! Not just that, but that seemingly unnecessary transpose means cuda has to use twice the memory it needs to the images! That means we do useless compute, and use more VRAM.

So I got claude's help to edit the ONNX files of ACAI to drop the transpose and simply take (N,3,63,63) images as input directly. VRAM usage on a batch size of 1024 drops from 3GB to 2GB. **However**, latency is worse somehow!!! Model takes 20ms instead of 15ms. Since we have 5 ACAI models that accumulates, but the 15ms shaved of from BTSbot compensate a bit. To me, that tradeoff is definitely acceptable given the VRAM savings.

So all in all, with new btsbost and the "nchw" acai to match its input format and lower VRAM, running a 1024 batch size with all the models sequentially uses 7.9GB of VRAM on my system, when previously it needed so much that it went OOM (I believe Sushant said it needed something like 16GB, which if true means a x2 improvement). Throughput might be slightly lower due to the - curious - increased runtime of the modified acai models, but I'd still call that a win, VRAM is our ZTF limiting factor, not throughput.

Notes:
- I wrote scripts to validate that ACAI outputs (old vs new no-transpose model) were identical, and on our ZTF night used for throughput testing, they are literally bit-wise identical!!! So, no worries there.
- BTSbot v2 outputs logits instead of a probability. I asked Nabeel and as I suspected we just need to pipe that through a sigmoid, which is what this PR adds too.
- Even though we need less VRAM than before, I did not lower the 10 GiB requirement we are enforcing at scheduler startup. Clearly it was under-estimated as some edge cases (an enrichment worker processing 1k alerts at once) would go OOM, and now that the max VRAM usage is 8GB, it's not a bad idea to ask for a safety margin and stay at 10GB minimum. Besides, that gives us the room we need for the VRAM budget of the parametric lightcurve fitting :)

TODOs:
- [ ] Validate the btsbot 2.0.0 outputs. I haven't compare it to btsbot v1, would be good to run this over a recent night of ZTF or something like that, and compare with what the v1 gives us (could check against prod).