### PR TITLE
changes to make GPU throughput testing work again

### DIFF
--- a/tests/throughput/_run.sh
+++ b/tests/throughput/_run.sh
@@ -197,7 +197,7 @@ if [ "${BOOM_GPU__ENABLED:-false}" = "true" ] && [ "$PLATFORM" = "linux" ]; then
     START_TIME=$(date +%s)
 
     check_gpu_ready() {
-      docker compose "${COMPOSE_CONFIG[@]}" logs scheduler | grep -q "Confirmed GPU runtime preconditions, free VRAM guardrail, and GPU inference"
+      ( set +o pipefail; docker compose "${COMPOSE_CONFIG[@]}" logs scheduler | grep -q "Confirmed GPU runtime preconditions, free VRAM guardrail, and GPU inference" )
     }
 
     while ! check_gpu_ready; do

--- a/tests/throughput/compose.yaml
+++ b/tests/throughput/compose.yaml
@@ -155,7 +155,7 @@ services:
       - /app/scheduler
       - ztf
     environment:
-      RUST_LOG: error,boom=debug
+      RUST_LOG: error,boom=debug,scheduler=info
       BOOM_GPU__ENABLED: ${BOOM_GPU__ENABLED:-false}
       BOOM_GPU__DEVICE_IDS: ${BOOM_GPU__DEVICE_IDS:-0}
     networks:


### PR DESCRIPTION
The throughput testing in the main branch was not working for GPU case due to couple of recent changes

Fixes:

- `tests/throughput/compose.yaml` — scheduler service:
  `RUST_LOG: error,boom=debug,scheduler=info` 
  
- `tests/throughput/_run.sh` — wrap `check_gpu_ready`'s pipeline in
  `( set +o pipefail; … )` so SIGPIPE-induced 141 doesn't mask grep's 0.

Both changes are local to the throughput test; nothing else is affected.
