### PR TITLE
Feat: RTF + mTAN encoder integration: feature preparation, inference, and embedding storage

### DIFF
--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -2,7 +2,7 @@ name: Build and push BOOM image
 
 on:
   push:
-    branches: [feat/public-filter-endpoints]
+    branches: [feat/public-filter-endpoints, feat/rtf-mtan-encoders]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-fork.yaml
+++ b/.github/workflows/build-fork.yaml
@@ -1,0 +1,41 @@
+name: Build and push BOOM image
+
+on:
+  push:
+    branches: [feat/public-filter-endpoints]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: keshavmajithia/boom
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          platforms: linux/amd64
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     ca-certificates curl bash tar xz-utils gcc g++ python3 python3-venv libhdf5-dev \
     perl make libsasl2-dev libsasl2-2 default-jre-headless pkg-config clang libclang-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    curl -fsSL https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -o /tmp/kafka.tgz && \
+    curl -fsSL https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -o /tmp/kafka.tgz && \
     tar -xzf /tmp/kafka.tgz -C /opt && \
     ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka && \
     rm -f /tmp/kafka.tgz

--- a/k8s/08-boom-scheduler-ztf.yaml
+++ b/k8s/08-boom-scheduler-ztf.yaml
@@ -1,0 +1,99 @@
+##############################################
+# BOOM Scheduler ZTF — Deployment
+##############################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boom-scheduler-ztf
+  namespace: umn-babamul
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boom-scheduler-ztf
+  template:
+    metadata:
+      labels:
+        app: boom-scheduler-ztf
+    spec:
+      initContainers:
+        # Downloads all ONNX model files from HuggingFace into a shared
+        # emptyDir volume before the main scheduler container starts.
+        # Models are loaded from /app/data/models/ at runtime.
+        #
+        # NOTE: The ACAI and BTSBot models should also be uploaded to
+        # the boom-astro/boomEncoders HuggingFace repository so they
+        # can be downloaded here alongside RTF and mTAN.
+        - name: download-models
+          image: curlimages/curl:8.7.1
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              HF_BASE="https://huggingface.co/boom-astro/boomEncoders/resolve/main"
+
+              # RTF encoder (8.7 MB)
+              echo "Downloading rtf_embed.onnx ..."
+              curl -fsSL "${HF_BASE}/rtf_embed.onnx" -o /models/rtf_embed.onnx
+
+              # mTAN encoder (383 KB)
+              echo "Downloading mtan_embed.onnx ..."
+              curl -fsSL "${HF_BASE}/mtan_embed.onnx" -o /models/mtan_embed.onnx
+
+              echo "All models downloaded."
+              ls -lh /models/
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      containers:
+        - name: scheduler-ztf
+          image: ghcr.io/keshavmajithia/boom:latest
+          command: ["/app/scheduler", "ztf"]
+          env:
+            - name: BOOM_DATABASE__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: boom-secrets
+                  key: BOOM_DATABASE__PASSWORD
+            - name: BOOM_API__AUTH__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: boom-secrets
+                  key: BOOM_API__AUTH__SECRET_KEY
+            - name: BOOM_API__AUTH__ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: boom-secrets
+                  key: BOOM_API__AUTH__ADMIN_PASSWORD
+            - name: BOOM_DATABASE__HOST
+              value: "mongo"
+            - name: BOOM_DATABASE__USERNAME
+              value: "mongoadmin"
+            - name: BOOM_REDIS__HOST
+              value: "valkey"
+            - name: BOOM_BABAMUL__ENABLED
+              value: "false"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4317"
+          volumeMounts:
+            - name: boom-config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: models
+              mountPath: /app/data/models
+              readOnly: true
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+      volumes:
+        - name: boom-config
+          configMap:
+            name: boom-config
+        - name: models
+          emptyDir: {}

--- a/k8s/08-boom-scheduler-ztf.yaml
+++ b/k8s/08-boom-scheduler-ztf.yaml
@@ -20,10 +20,6 @@ spec:
         # Downloads all ONNX model files from HuggingFace into a shared
         # emptyDir volume before the main scheduler container starts.
         # Models are loaded from /app/data/models/ at runtime.
-        #
-        # NOTE: The ACAI and BTSBot models should also be uploaded to
-        # the boom-astro/boomEncoders HuggingFace repository so they
-        # can be downloaded here alongside RTF and mTAN.
         - name: download-models
           image: curlimages/curl:8.7.1
           command:

--- a/k8s/08-boom-scheduler-ztf.yaml
+++ b/k8s/08-boom-scheduler-ztf.yaml
@@ -33,6 +33,16 @@ spec:
               set -e
               HF_BASE="https://huggingface.co/boom-astro/boomEncoders/resolve/main"
 
+              # ACAI classifiers (~35 KB each)
+              for variant in acai_h acai_n acai_v acai_o acai_b; do
+                echo "Downloading ${variant}.d1_dnn_20201130.onnx ..."
+                curl -fsSL "${HF_BASE}/${variant}.d1_dnn_20201130.onnx" -o "/models/${variant}.d1_dnn_20201130.onnx"
+              done
+
+              # BTSBot classifier (~900 KB)
+              echo "Downloading btsbot-v1.0.1.onnx ..."
+              curl -fsSL "${HF_BASE}/btsbot-v1.0.1.onnx" -o /models/btsbot-v1.0.1.onnx
+
               # RTF encoder (8.7 MB)
               echo "Downloading rtf_embed.onnx ..."
               curl -fsSL "${HF_BASE}/rtf_embed.onnx" -o /models/rtf_embed.onnx

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -170,7 +170,7 @@ pub async fn get_test_auth(db: &Database) -> Result<AuthProvider, std::io::Error
     AuthProvider::new(&app_config, &db).await
 }
 
-pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/"];
+pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/", "/filters/test", "/filters/test/count"];
 
 pub async fn auth_middleware(
     req: ServiceRequest,

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -170,7 +170,7 @@ pub async fn get_test_auth(db: &Database) -> Result<AuthProvider, std::io::Error
     AuthProvider::new(&app_config, &db).await
 }
 
-pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/", "/filters/test", "/filters/test/count", "/surveys/ZTF/schemas"];
+pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/", "/filters/test", "/filters/test/count", "/surveys/ZTF/schemas", "/filters/schemas/ZTF", "/filters/schemas/LSST"];
 
 pub async fn auth_middleware(
     req: ServiceRequest,

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -170,7 +170,7 @@ pub async fn get_test_auth(db: &Database) -> Result<AuthProvider, std::io::Error
     AuthProvider::new(&app_config, &db).await
 }
 
-pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/", "/filters/test", "/filters/test/count"];
+pub const PUBLIC_ROUTES: &[&str] = &["/docs", "/auth", "/", "/filters/test", "/filters/test/count", "/surveys/ZTF/schemas"];
 
 pub async fn auth_middleware(
     req: ServiceRequest,

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -853,14 +853,7 @@ impl FilterTestResponse {
 pub async fn post_filter_test(
     db: web::Data<Database>,
     body: web::Json<FilterTestRequest>,
-    current_user: Option<web::ReqData<User>>,
 ) -> HttpResponse {
-    let _current_user = match current_user {
-        Some(user) => user,
-        None => {
-            return HttpResponse::Unauthorized().body("Unauthorized");
-        }
-    };
     let body = body.clone();
     let survey = body.survey;
     let permissions = body.permissions;
@@ -987,14 +980,7 @@ impl FilterTestCountResponse {
 pub async fn post_filter_test_count(
     db: web::Data<Database>,
     body: web::Json<FilterTestCountRequest>,
-    current_user: Option<web::ReqData<User>>,
 ) -> HttpResponse {
-    let _current_user = match current_user {
-        Some(user) => user,
-        None => {
-            return HttpResponse::Unauthorized().body("Unauthorized");
-        }
-    };
     let body = body.clone();
     let survey = body.survey;
     let permissions = body.permissions;

--- a/src/enrichment/models/mod.rs
+++ b/src/enrichment/models/mod.rs
@@ -1,10 +1,14 @@
 mod acai;
 mod base;
 mod btsbot;
+mod mtan;
+mod rtf;
 
 pub use acai::AcaiModel;
 pub use base::{load_model, load_model_on_device, Model, ModelError};
 pub use btsbot::BtsBotModel;
+pub use mtan::MtanModel;
+pub use rtf::RtfModel;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -24,6 +28,8 @@ pub struct SharedModels {
     pub acai_o: Mutex<AcaiModel>,
     pub acai_b: Mutex<AcaiModel>,
     pub btsbot: Mutex<BtsBotModel>,
+    pub rtf_embed: Mutex<RtfModel>,
+    pub mtan_embed: Mutex<MtanModel>,
 }
 
 impl std::fmt::Debug for SharedModels {
@@ -63,6 +69,14 @@ impl SharedModels {
                     "data/models/btsbot-v1.0.1.onnx",
                     id,
                 )?),
+                rtf_embed: Mutex::new(RtfModel::new_on_device(
+                    "data/models/rtf_embed.onnx",
+                    id,
+                )?),
+                mtan_embed: Mutex::new(MtanModel::new_on_device(
+                    "data/models/mtan_embed.onnx",
+                    id,
+                )?),
             },
             None => Self {
                 acai_h: Mutex::new(AcaiModel::new("data/models/acai_h.d1_dnn_20201130.onnx")?),
@@ -71,6 +85,8 @@ impl SharedModels {
                 acai_o: Mutex::new(AcaiModel::new("data/models/acai_o.d1_dnn_20201130.onnx")?),
                 acai_b: Mutex::new(AcaiModel::new("data/models/acai_b.d1_dnn_20201130.onnx")?),
                 btsbot: Mutex::new(BtsBotModel::new("data/models/btsbot-v1.0.1.onnx")?),
+                rtf_embed: Mutex::new(RtfModel::new("data/models/rtf_embed.onnx")?),
+                mtan_embed: Mutex::new(MtanModel::new("data/models/mtan_embed.onnx")?),
             },
         };
         info!("all ONNX models loaded successfully");

--- a/src/enrichment/models/mtan.rs
+++ b/src/enrichment/models/mtan.rs
@@ -161,6 +161,9 @@ impl MtanModel {
                 mask: [0.0, 0.0],
             };
 
+            // Within the merge window, later observations overwrite earlier ones
+            // for the same band (last-write-wins). This intentionally matches the
+            // Python training pipeline (fritz_to_mtan.py) for numerical consistency.
             let mut j = i;
             while j < points.len() && (points[j].jd - t).abs() <= MERGE_TOL_DAYS {
                 let band = points[j].band_idx;
@@ -215,10 +218,7 @@ impl MtanModel {
             .map(|mp| ((mp.jd - first_jd) * 24.0) as f32)
             .collect();
 
-        let max_time = times_hours
-            .iter()
-            .copied()
-            .fold(0.0f32, f32::max);
+        let max_time = times_hours.iter().copied().fold(0.0f32, f32::max);
 
         if max_time > 0.0 {
             for t in times_hours.iter_mut() {

--- a/src/enrichment/models/mtan.rs
+++ b/src/enrichment/models/mtan.rs
@@ -19,6 +19,8 @@
 //!   - output:      (B, Q, 4)   [qz0_mean(2), qz0_logvar(2)] per query time
 
 use crate::enrichment::models::{load_model, load_model_on_device, ModelError};
+use crate::enrichment::ztf::ZtfAlertForEnrichment;
+use crate::utils::lightcurves::Band;
 use ndarray::{Array, Dim};
 use ort::{inputs, session::Session, value::TensorRef};
 use tracing::instrument;
@@ -26,6 +28,15 @@ use tracing::instrument;
 /// mTAN model constants matching the Python training configuration.
 pub const MTAN_DIM: usize = 2;
 pub const MTAN_LATENT_DIM: usize = 2;
+
+/// Maximum observation sequence length
+const MAX_SEQ_LEN: usize = 200;
+/// Number of query time points
+const MAX_QUERY_LEN: usize = 50;
+/// Minimum number of g+r observations required for mTAN inference
+const MIN_OBS: usize = 3;
+/// Merge tolerance in days (~1 minute) for nearby observations
+const MERGE_TOL_DAYS: f64 = 1.0 / (24.0 * 60.0);
 
 pub struct MtanModel {
     model: Session,
@@ -76,5 +87,178 @@ impl MtanModel {
             Ok((_, raw)) => Ok(raw.to_vec()),
             Err(_) => Err(ModelError::ModelOutputToVecError),
         }
+    }
+
+    /// Prepare mTAN input tensors from a single alert's photometry.
+    ///
+    /// Extracts g-band and r-band photometry, merges observations at similar
+    /// times, normalizes magnitudes and timestamps, and builds the input tensors.
+    ///
+    /// Returns `Err` if the alert has fewer than 3 g+r observations.
+    pub fn prepare_features(
+        alert: &ZtfAlertForEnrichment,
+    ) -> Result<
+        (
+            Array<f32, Dim<[usize; 3]>>, // x: (1, MAX_SEQ_LEN, 4)
+            Array<f32, Dim<[usize; 2]>>, // time_steps: (1, MAX_SEQ_LEN)
+            Array<f32, Dim<[usize; 2]>>, // query_times: (1, MAX_QUERY_LEN)
+        ),
+        ModelError,
+    > {
+        let current_jd = alert.candidate.candidate.jd;
+
+        // Step 1: Collect g and r band photometry with valid magnitudes
+        struct PhotoPoint {
+            jd: f64,
+            mag: f64,
+            band_idx: usize, // 0 = g, 1 = r
+        }
+
+        let mut points: Vec<PhotoPoint> = Vec::new();
+
+        for p in alert.prv_candidates.iter().chain(alert.fp_hists.iter()) {
+            if p.jd > current_jd {
+                continue;
+            }
+            if let Some(mag) = p.magpsf {
+                let band_idx = match p.band {
+                    Band::G => 0,
+                    Band::R => 1,
+                    _ => continue, // mTAN only uses g and r
+                };
+                points.push(PhotoPoint {
+                    jd: p.jd,
+                    mag,
+                    band_idx,
+                });
+            }
+        }
+
+        if points.len() < MIN_OBS {
+            return Err(ModelError::MissingFeature(
+                "mTAN requires at least 3 g+r observations",
+            ));
+        }
+
+        // Step 2: Sort by JD
+        points.sort_by(|a, b| a.jd.partial_cmp(&b.jd).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Step 3: Merge observations at similar times (within ~1 minute)
+        // Each merged time step has [mag_g, mag_r, mask_g, mask_r]
+        struct MergedPoint {
+            jd: f64,
+            mag: [f32; 2],  // [g, r]
+            mask: [f32; 2], // [g, r]
+        }
+
+        let mut merged: Vec<MergedPoint> = Vec::new();
+        let mut i = 0;
+        while i < points.len() {
+            let t = points[i].jd;
+            let mut mp = MergedPoint {
+                jd: t,
+                mag: [0.0, 0.0],
+                mask: [0.0, 0.0],
+            };
+
+            let mut j = i;
+            while j < points.len() && (points[j].jd - t).abs() <= MERGE_TOL_DAYS {
+                let band = points[j].band_idx;
+                mp.mag[band] = points[j].mag as f32;
+                mp.mask[band] = 1.0;
+                j += 1;
+            }
+
+            merged.push(mp);
+            i = j;
+        }
+
+        if merged.len() < MIN_OBS {
+            return Err(ModelError::MissingFeature(
+                "mTAN requires at least 3 merged time steps",
+            ));
+        }
+
+        // Step 4: Truncate to MAX_SEQ_LEN
+        if merged.len() > MAX_SEQ_LEN {
+            merged.truncate(MAX_SEQ_LEN);
+        }
+
+        let n_steps = merged.len();
+
+        // Step 5: Normalize magnitudes — (mag - min_mag) / 2.5
+        // Find min magnitude across all observed values
+        let mut min_mag = f32::INFINITY;
+        for mp in &merged {
+            for band in 0..2 {
+                if mp.mask[band] > 0.0 && mp.mag[band] < min_mag {
+                    min_mag = mp.mag[band];
+                }
+            }
+        }
+
+        // Apply normalization, zero out unobserved positions
+        for mp in merged.iter_mut() {
+            for band in 0..2 {
+                if mp.mask[band] > 0.0 {
+                    mp.mag[band] = (mp.mag[band] - min_mag) / 2.5;
+                } else {
+                    mp.mag[band] = 0.0;
+                }
+            }
+        }
+
+        // Step 6: Convert JD to hours from first detection, then normalize to [0, 1]
+        let first_jd = merged[0].jd;
+        let mut times_hours: Vec<f32> = merged
+            .iter()
+            .map(|mp| ((mp.jd - first_jd) * 24.0) as f32)
+            .collect();
+
+        let max_time = times_hours
+            .iter()
+            .copied()
+            .fold(0.0f32, f32::max);
+
+        if max_time > 0.0 {
+            for t in times_hours.iter_mut() {
+                *t /= max_time;
+            }
+        }
+
+        // Step 7: Build output tensors
+        // x: (1, MAX_SEQ_LEN, 4) — [mag_g, mag_r, mask_g, mask_r]
+        let mut x = Array::<f32, _>::zeros((1, MAX_SEQ_LEN, 4));
+        let mut time_steps = Array::<f32, _>::zeros((1, MAX_SEQ_LEN));
+
+        for (i, mp) in merged.iter().enumerate() {
+            x[[0, i, 0]] = mp.mag[0];
+            x[[0, i, 1]] = mp.mag[1];
+            x[[0, i, 2]] = mp.mask[0];
+            x[[0, i, 3]] = mp.mask[1];
+            time_steps[[0, i]] = times_hours[i];
+        }
+        // Remaining positions stay zero-padded
+
+        // query_times: (1, MAX_QUERY_LEN) — uniform grid in [0, 1]
+        let mut query_times = Array::<f32, _>::zeros((1, MAX_QUERY_LEN));
+        for i in 0..MAX_QUERY_LEN {
+            query_times[[0, i]] = i as f32 / (MAX_QUERY_LEN - 1) as f32;
+        }
+
+        Ok((x, time_steps, query_times))
+    }
+
+    /// Mean-pool qz0_mean from raw mTAN output to produce a 2D embedding.
+    ///
+    /// The raw output is (B, Q, 4) where channels are [qz0_mean_0, qz0_mean_1, qz0_logvar_0, qz0_logvar_1].
+    /// We average qz0_mean (first 2 channels) across all Q query times.
+    pub fn pool_embedding(raw_output: &[f32], n_query: usize) -> Vec<f32> {
+        let mut sum = [0.0f32; 2];
+        for qi in 0..n_query {
+            sum[0] += raw_output[qi * 4];
+            sum[1] += raw_output[qi * 4 + 1];
+        }
+        vec![sum[0] / n_query as f32, sum[1] / n_query as f32]
     }
 }

--- a/src/enrichment/models/mtan.rs
+++ b/src/enrichment/models/mtan.rs
@@ -184,7 +184,7 @@ impl MtanModel {
             merged.truncate(MAX_SEQ_LEN);
         }
 
-        let n_steps = merged.len();
+        let _n_steps = merged.len();
 
         // Step 5: Normalize magnitudes — (mag - min_mag) / 2.5
         // Find min magnitude across all observed values

--- a/src/enrichment/models/mtan.rs
+++ b/src/enrichment/models/mtan.rs
@@ -1,0 +1,80 @@
+//! mTAN (multi-Time Attention Network) encoder model for BOOM deployment.
+//!
+//! Loads `mtan_embed.onnx` and produces 2-dimensional latent embeddings
+//! from ZTF alert photometry light curves (g, r bands only).
+//!
+//! The mTAN encoder processes irregularly-sampled time series using
+//! learned time embeddings and multi-head attention, outputting
+//! (qz0_mean, qz0_logvar) at each query time point.
+//!
+//! For the vector database, we use the mean of qz0_mean across
+//! valid query times to produce a single 2D embedding per source.
+//!
+//! ONNX inputs:
+//!   - x:           (B, T, 4)   [observed_g, observed_r, mask_g, mask_r]
+//!   - time_steps:  (B, T)      observation timestamps (normalized to [0,1])
+//!   - query_times: (B, Q)      query time grid (normalized to [0,1])
+//!
+//! ONNX output:
+//!   - output:      (B, Q, 4)   [qz0_mean(2), qz0_logvar(2)] per query time
+
+use crate::enrichment::models::{load_model, load_model_on_device, ModelError};
+use ndarray::{Array, Dim};
+use ort::{inputs, session::Session, value::TensorRef};
+use tracing::instrument;
+
+/// mTAN model constants matching the Python training configuration.
+pub const MTAN_DIM: usize = 2;
+pub const MTAN_LATENT_DIM: usize = 2;
+
+pub struct MtanModel {
+    model: Session,
+}
+
+impl MtanModel {
+    /// Load mTAN ONNX model on CPU.
+    #[instrument(err)]
+    pub fn new(path: &str) -> Result<Self, ModelError> {
+        Ok(Self {
+            model: load_model(path)?,
+        })
+    }
+
+    /// Load mTAN ONNX model on a specific CUDA device.
+    pub fn new_on_device(path: &str, device_id: i32) -> Result<Self, ModelError> {
+        Ok(Self {
+            model: load_model_on_device(path, Some(device_id))?,
+        })
+    }
+
+    /// Run the mTAN encoder to produce raw query-level outputs.
+    ///
+    /// # Arguments
+    /// * `x` - Observation tensor of shape (B, T, 4).
+    ///         Channels: [observed_g, observed_r, mask_g, mask_r]
+    /// * `time_steps` - Observation timestamps of shape (B, T), normalized to [0,1].
+    /// * `query_times` - Query time grid of shape (B, Q), normalized to [0,1].
+    ///
+    /// # Returns
+    /// Vec<f32> of length B * Q * 4, containing [qz0_mean, qz0_logvar] at each query time.
+    #[instrument(skip_all, err)]
+    pub fn embed_raw(
+        &mut self,
+        x: &Array<f32, Dim<[usize; 3]>>,
+        time_steps: &Array<f32, Dim<[usize; 2]>>,
+        query_times: &Array<f32, Dim<[usize; 2]>>,
+    ) -> Result<Vec<f32>, ModelError> {
+        let model_inputs = inputs! {
+            "x" => TensorRef::from_array_view(x)?,
+            "time_steps" => TensorRef::from_array_view(time_steps)?,
+            "query_times" => TensorRef::from_array_view(query_times)?,
+        };
+
+        let outputs = self.model.run(model_inputs)?;
+
+        match outputs["output"].try_extract_tensor::<f32>() {
+            Ok((_, raw)) => Ok(raw.to_vec()),
+            Err(_) => Err(ModelError::ModelOutputToVecError),
+        }
+    }
+}

--- a/src/enrichment/models/rtf.rs
+++ b/src/enrichment/models/rtf.rs
@@ -214,7 +214,7 @@ impl RtfModel {
 
     /// Extract the 30 metadata values from a ZTF candidate in the exact order
     /// matching ALERT_META_KEYS from the RTF Python training pipeline.
-    fn extract_metadata(candidate: &crate::alert::ztf::Candidate) -> [f32; N_META] {
+    fn extract_metadata(candidate: &crate::alert::Candidate) -> [f32; N_META] {
         let opt_f32 = |v: Option<f32>| v.unwrap_or(0.0);
         let opt_f64_as_f32 = |v: Option<f64>| v.unwrap_or(0.0) as f32;
 

--- a/src/enrichment/models/rtf.rs
+++ b/src/enrichment/models/rtf.rs
@@ -1,0 +1,77 @@
+//! RTF (Radio Transient Finder) encoder model for BOOM deployment.
+//!
+//! Loads `rtf_embed.onnx` and produces 128-dimensional latent embeddings
+//! from ZTF alert photometry sequences + cutout images.
+//!
+//! ONNX inputs:
+//!   - x:        (B, 257, 37)  padded photometry tensor
+//!   - pad_mask: (B, 257)      bool padding mask (true = padded)
+//!   - images:   (B, 3, 63, 63) science/template/difference cutout stamps
+//!
+//! ONNX output:
+//!   - output:   (B, 128)      latent embedding
+
+use crate::enrichment::models::{load_model, load_model_on_device, ModelError};
+use ndarray::{Array, Dim};
+use ort::{inputs, session::Session, value::TensorRef};
+use tracing::instrument;
+
+/// RTF model constants matching the Python export configuration.
+pub const RTF_MAX_LEN: usize = 257;
+pub const RTF_IN_CHANNELS: usize = 37;
+pub const RTF_LATENT_DIM: usize = 128;
+
+pub struct RtfModel {
+    model: Session,
+}
+
+impl RtfModel {
+    /// Load RTF ONNX model on CPU.
+    #[instrument(err)]
+    pub fn new(path: &str) -> Result<Self, ModelError> {
+        Ok(Self {
+            model: load_model(path)?,
+        })
+    }
+
+    /// Load RTF ONNX model on a specific CUDA device.
+    pub fn new_on_device(path: &str, device_id: i32) -> Result<Self, ModelError> {
+        Ok(Self {
+            model: load_model_on_device(path, Some(device_id))?,
+        })
+    }
+
+    /// Run the RTF encoder to produce 128D embeddings.
+    ///
+    /// # Arguments
+    /// * `x` - Padded photometry tensor of shape (B, 257, 37).
+    ///         Channels: [log1p(dt), log1p(dt_prev), logflux, logflux_err,
+    ///                    band_g, band_r, band_i, + 30 metadata channels]
+    /// * `pad_mask` - Boolean padding mask of shape (B, 257).
+    ///               `true` = padded position, `false` = valid observation.
+    /// * `images` - Cutout stamp tensor of shape (B, 3, 63, 63).
+    ///             Channels: [science, template, difference].
+    ///
+    /// # Returns
+    /// Vec<f32> of length B * 128, containing the flattened embeddings.
+    #[instrument(skip_all, err)]
+    pub fn embed(
+        &mut self,
+        x: &Array<f32, Dim<[usize; 3]>>,
+        pad_mask: &Array<bool, Dim<[usize; 2]>>,
+        images: &Array<f32, Dim<[usize; 4]>>,
+    ) -> Result<Vec<f32>, ModelError> {
+        let model_inputs = inputs! {
+            "x" => TensorRef::from_array_view(x)?,
+            "pad_mask" => TensorRef::from_array_view(pad_mask)?,
+            "images" => TensorRef::from_array_view(images)?,
+        };
+
+        let outputs = self.model.run(model_inputs)?;
+
+        match outputs["output"].try_extract_tensor::<f32>() {
+            Ok((_, embeddings)) => Ok(embeddings.to_vec()),
+            Err(_) => Err(ModelError::ModelOutputToVecError),
+        }
+    }
+}

--- a/src/enrichment/models/rtf.rs
+++ b/src/enrichment/models/rtf.rs
@@ -11,7 +11,7 @@
 //! ONNX output:
 //!   - output:   (B, 128)      latent embedding
 
-use crate::alert::AlertCutout;
+use crate::utils::cutouts::AlertCutout;
 use crate::enrichment::models::{load_model, load_model_on_device, ModelError};
 use crate::enrichment::ztf::ZtfAlertForEnrichment;
 use crate::utils::fits::prepare_triplet;
@@ -219,36 +219,36 @@ impl RtfModel {
         let opt_f64_as_f32 = |v: Option<f64>| v.unwrap_or(0.0) as f32;
 
         [
-            opt_f32(candidate.sgscore1),    // 0: sgscore1
-            opt_f32(candidate.sgscore2),    // 1: sgscore2
-            opt_f32(candidate.distpsnr1),   // 2: distpsnr1
-            opt_f32(candidate.distpsnr2),   // 3: distpsnr2
-            candidate.nmtchps as f32,       // 4: nmtchps
-            opt_f32(candidate.sharpnr),     // 5: sharpnr
+            opt_f32(candidate.sgscore1),     // 0: sgscore1
+            opt_f32(candidate.sgscore2),     // 1: sgscore2
+            opt_f32(candidate.distpsnr1),    // 2: distpsnr1
+            opt_f32(candidate.distpsnr2),    // 3: distpsnr2
+            candidate.nmtchps as f32,        // 4: nmtchps
+            opt_f32(candidate.sharpnr),      // 5: sharpnr
             opt_f64_as_f32(candidate.scorr), // 6: scorr
-            opt_f32(candidate.diffmaglim),  // 7: diffmaglim
-            opt_f32(candidate.sky),         // 8: sky
-            candidate.ndethist as f32,      // 9: ndethist
-            candidate.ncovhist as f32,      // 10: ncovhist
-            candidate.sigmapsf,             // 11: sigmapsf
-            opt_f32(candidate.chinr),       // 12: chinr
-            opt_f32(candidate.classtar),    // 13: classtar
-            opt_f32(candidate.rb),          // 14: rb
-            opt_f32(candidate.chipsf),      // 15: chipsf
-            opt_f32(candidate.distnr),      // 16: distnr
-            opt_f32(candidate.magnr),       // 17: magnr
-            opt_f32(candidate.fwhm),        // 18: fwhm
-            opt_f32(candidate.srmag1),      // 19: srmag1
-            opt_f32(candidate.sgmag1),      // 20: sgmag1
-            opt_f32(candidate.simag1),      // 21: simag1
-            opt_f32(candidate.szmag1),      // 22: szmag1
-            opt_f32(candidate.srmag2),      // 23: srmag2
-            opt_f32(candidate.sgmag2),      // 24: sgmag2
-            opt_f32(candidate.simag2),      // 25: simag2
-            opt_f32(candidate.szmag2),      // 26: szmag2
-            opt_f32(candidate.clrcoeff),    // 27: clrcoeff
-            opt_f32(candidate.clrcounc),    // 28: clrcounc
-            0.0,                            // 29: zpclrcov (not in Candidate struct)
+            opt_f32(candidate.diffmaglim),   // 7: diffmaglim
+            opt_f32(candidate.sky),          // 8: sky
+            candidate.ndethist as f32,       // 9: ndethist
+            candidate.ncovhist as f32,       // 10: ncovhist
+            candidate.sigmapsf,              // 11: sigmapsf
+            opt_f32(candidate.chinr),        // 12: chinr
+            opt_f32(candidate.classtar),     // 13: classtar
+            opt_f32(candidate.rb),           // 14: rb
+            opt_f32(candidate.chipsf),       // 15: chipsf
+            opt_f32(candidate.distnr),       // 16: distnr
+            opt_f32(candidate.magnr),        // 17: magnr
+            opt_f32(candidate.fwhm),         // 18: fwhm
+            opt_f32(candidate.srmag1),       // 19: srmag1
+            opt_f32(candidate.sgmag1),       // 20: sgmag1
+            opt_f32(candidate.simag1),       // 21: simag1
+            opt_f32(candidate.szmag1),       // 22: szmag1
+            opt_f32(candidate.srmag2),       // 23: srmag2
+            opt_f32(candidate.sgmag2),       // 24: sgmag2
+            opt_f32(candidate.simag2),       // 25: simag2
+            opt_f32(candidate.szmag2),       // 26: szmag2
+            opt_f32(candidate.clrcoeff),     // 27: clrcoeff
+            opt_f32(candidate.clrcounc),     // 28: clrcounc
+            0.0,                             // 29: zpclrcov (not in Candidate struct)
         ]
     }
 }

--- a/src/enrichment/models/rtf.rs
+++ b/src/enrichment/models/rtf.rs
@@ -11,7 +11,11 @@
 //! ONNX output:
 //!   - output:   (B, 128)      latent embedding
 
+use crate::alert::AlertCutout;
 use crate::enrichment::models::{load_model, load_model_on_device, ModelError};
+use crate::enrichment::ztf::ZtfAlertForEnrichment;
+use crate::utils::fits::prepare_triplet;
+use crate::utils::lightcurves::Band;
 use ndarray::{Array, Dim};
 use ort::{inputs, session::Session, value::TensorRef};
 use tracing::instrument;
@@ -20,6 +24,15 @@ use tracing::instrument;
 pub const RTF_MAX_LEN: usize = 257;
 pub const RTF_IN_CHANNELS: usize = 37;
 pub const RTF_LATENT_DIM: usize = 128;
+
+/// Number of continuous base channels: log1p(dt), log1p(dt_prev), logflux, logflux_err
+const N_CONT_BASE: usize = 4;
+/// Number of one-hot band channels: g, r, i
+const N_BAND: usize = 3;
+/// Number of alert metadata channels
+const N_META: usize = 30;
+/// Cutout stamp size
+const STAMP_SIZE: usize = 63;
 
 pub struct RtfModel {
     model: Session,
@@ -73,5 +86,169 @@ impl RtfModel {
             Ok((_, embeddings)) => Ok(embeddings.to_vec()),
             Err(_) => Err(ModelError::ModelOutputToVecError),
         }
+    }
+
+    /// Prepare RTF input tensors from a single alert and its cutout.
+    ///
+    /// Builds the (1, 257, 37) photometry tensor, (1, 257) padding mask,
+    /// and (1, 3, 63, 63) cutout image tensor from the raw alert data.
+    ///
+    /// The 37 channels per observation are:
+    ///   [0]  log1p(dt)       — log of days since first observation
+    ///   [1]  log1p(dt_prev)  — log of days since previous observation
+    ///   [2]  logflux         — -0.4 * magpsf
+    ///   [3]  logflux_err     — 0.4 * sigmapsf
+    ///   [4]  band_g          — 1.0 if g-band, else 0.0
+    ///   [5]  band_r          — 1.0 if r-band, else 0.0
+    ///   [6]  band_i          — 1.0 if i-band, else 0.0
+    ///   [7..37] 30 alert metadata fields (broadcast from current candidate)
+    pub fn prepare_features(
+        alert: &ZtfAlertForEnrichment,
+        cutout: &AlertCutout,
+    ) -> Result<
+        (
+            Array<f32, Dim<[usize; 3]>>,  // x: (1, 257, 37)
+            Array<bool, Dim<[usize; 2]>>, // pad_mask: (1, 257)
+            Array<f32, Dim<[usize; 4]>>,  // images: (1, 3, 63, 63)
+        ),
+        ModelError,
+    > {
+        let candidate = &alert.candidate.candidate;
+        let current_jd = candidate.jd;
+
+        // Collect valid photometry points (must have magpsf and sigmapsf)
+        // from prv_candidates and fp_hists, filtered to jd <= current jd
+        struct PhotoPoint {
+            jd: f64,
+            magpsf: f64,
+            sigmapsf: f64,
+            band: Band,
+        }
+
+        let mut points: Vec<PhotoPoint> = Vec::new();
+
+        for p in alert.prv_candidates.iter().chain(alert.fp_hists.iter()) {
+            if p.jd > current_jd {
+                continue;
+            }
+            if let (Some(mag), Some(sig)) = (p.magpsf, p.sigmapsf) {
+                points.push(PhotoPoint {
+                    jd: p.jd,
+                    magpsf: mag,
+                    sigmapsf: sig,
+                    band: p.band.clone(),
+                });
+            }
+        }
+
+        // Sort by JD ascending
+        points.sort_by(|a, b| a.jd.partial_cmp(&b.jd).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Truncate to max 257 observations
+        if points.len() > RTF_MAX_LEN {
+            points.truncate(RTF_MAX_LEN);
+        }
+
+        let n_obs = points.len();
+
+        // Build the 30-element metadata vector from the current candidate.
+        // These values are broadcast across all time steps (same candidate metadata
+        // for every observation), matching the training pipeline behavior.
+        let meta = Self::extract_metadata(candidate);
+
+        // Initialize output tensors
+        let mut x = Array::<f32, _>::zeros((1, RTF_MAX_LEN, RTF_IN_CHANNELS));
+        let mut pad_mask = Array::<bool, _>::from_elem((1, RTF_MAX_LEN), true);
+
+        let first_jd = if n_obs > 0 { points[0].jd } else { 0.0 };
+
+        for (i, point) in points.iter().enumerate() {
+            // Mark as valid (not padded)
+            pad_mask[[0, i]] = false;
+
+            // Time features
+            let dt = (point.jd - first_jd) as f32;
+            let dt_prev = if i > 0 {
+                (point.jd - points[i - 1].jd) as f32
+            } else {
+                0.0f32
+            };
+
+            x[[0, i, 0]] = (1.0 + dt).ln();
+            x[[0, i, 1]] = (1.0 + dt_prev).ln();
+
+            // Photometry features
+            x[[0, i, 2]] = -0.4 * point.magpsf as f32;
+            x[[0, i, 3]] = 0.4 * point.sigmapsf as f32;
+
+            // One-hot band encoding
+            match point.band {
+                Band::G => x[[0, i, N_CONT_BASE]] = 1.0,
+                Band::R => x[[0, i, N_CONT_BASE + 1]] = 1.0,
+                Band::I => x[[0, i, N_CONT_BASE + 2]] = 1.0,
+                _ => {} // ZTF only has g, r, i
+            }
+
+            // Metadata (same for all time steps)
+            for (j, &val) in meta.iter().enumerate() {
+                x[[0, i, N_CONT_BASE + N_BAND + j]] = val;
+            }
+        }
+
+        // Prepare cutout image in CHW format (1, 3, 63, 63)
+        let (science, template, difference) = prepare_triplet(cutout)?;
+        let mut images = Array::<f32, _>::zeros((1, 3, STAMP_SIZE, STAMP_SIZE));
+
+        // Each cutout is a flattened Vec<f32> of size 63*63 in row-major order.
+        // We need to place them as separate channels in CHW format.
+        for (ch, cutout_flat) in [&science, &template, &difference].iter().enumerate() {
+            for row in 0..STAMP_SIZE {
+                for col in 0..STAMP_SIZE {
+                    images[[0, ch, row, col]] = cutout_flat[row * STAMP_SIZE + col];
+                }
+            }
+        }
+
+        Ok((x, pad_mask, images))
+    }
+
+    /// Extract the 30 metadata values from a ZTF candidate in the exact order
+    /// matching ALERT_META_KEYS from the RTF Python training pipeline.
+    fn extract_metadata(candidate: &crate::alert::ztf::Candidate) -> [f32; N_META] {
+        let opt_f32 = |v: Option<f32>| v.unwrap_or(0.0);
+        let opt_f64_as_f32 = |v: Option<f64>| v.unwrap_or(0.0) as f32;
+
+        [
+            opt_f32(candidate.sgscore1),    // 0: sgscore1
+            opt_f32(candidate.sgscore2),    // 1: sgscore2
+            opt_f32(candidate.distpsnr1),   // 2: distpsnr1
+            opt_f32(candidate.distpsnr2),   // 3: distpsnr2
+            candidate.nmtchps as f32,       // 4: nmtchps
+            opt_f32(candidate.sharpnr),     // 5: sharpnr
+            opt_f64_as_f32(candidate.scorr), // 6: scorr
+            opt_f32(candidate.diffmaglim),  // 7: diffmaglim
+            opt_f32(candidate.sky),         // 8: sky
+            candidate.ndethist as f32,      // 9: ndethist
+            candidate.ncovhist as f32,      // 10: ncovhist
+            candidate.sigmapsf,             // 11: sigmapsf
+            opt_f32(candidate.chinr),       // 12: chinr
+            opt_f32(candidate.classtar),    // 13: classtar
+            opt_f32(candidate.rb),          // 14: rb
+            opt_f32(candidate.chipsf),      // 15: chipsf
+            opt_f32(candidate.distnr),      // 16: distnr
+            opt_f32(candidate.magnr),       // 17: magnr
+            opt_f32(candidate.fwhm),        // 18: fwhm
+            opt_f32(candidate.srmag1),      // 19: srmag1
+            opt_f32(candidate.sgmag1),      // 20: sgmag1
+            opt_f32(candidate.simag1),      // 21: simag1
+            opt_f32(candidate.szmag1),      // 22: szmag1
+            opt_f32(candidate.srmag2),      // 23: srmag2
+            opt_f32(candidate.sgmag2),      // 24: sgmag2
+            opt_f32(candidate.simag2),      // 25: simag2
+            opt_f32(candidate.szmag2),      // 26: szmag2
+            opt_f32(candidate.clrcoeff),    // 27: clrcoeff
+            opt_f32(candidate.clrcounc),    // 28: clrcounc
+            0.0,                            // 29: zpclrcov (not in Candidate struct)
+        ]
     }
 }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -3,7 +3,7 @@ use crate::conf::AppConfig;
 use crate::enrichment::{
     babamul::{Babamul, BabamulZtfAlert},
     fetch_alerts,
-    models::{AcaiModel, BtsBotModel, MtanModel, Model, RtfModel, SharedModels},
+    models::{AcaiModel, BtsBotModel, Model, MtanModel, RtfModel, SharedModels},
     EnrichmentWorker, EnrichmentWorkerError, LsstMatch,
 };
 use crate::utils::cutouts::{AlertCutout, CutoutStorage};
@@ -527,12 +527,12 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
             };
 
         // Compute RTF + mTAN embeddings
-        let embeddings_list: Vec<Option<ZtfAlertEmbeddings>> =
-            if let Some(ref models) = self.models {
-                self.compute_embeddings(&models, &work_items)
-            } else {
-                vec![None; work_items.len()]
-            };
+        let embeddings_list: Vec<Option<ZtfAlertEmbeddings>> = if let Some(ref models) = self.models
+        {
+            self.compute_embeddings(&models, &work_items)
+        } else {
+            vec![None; work_items.len()]
+        };
 
         for ((item, classifications), embeddings) in work_items
             .into_iter()
@@ -889,15 +889,19 @@ impl ZtfEnrichmentWorker {
         for item in work_items {
             // RTF embedding
             let rtf_embedding = match RtfModel::prepare_features(&item.alert, &item.cutouts) {
-                Ok((x, pad_mask, images)) => {
-                    match models.rtf_embed.lock().unwrap().embed(&x, &pad_mask, &images) {
+                Ok((x, pad_mask, images)) => match models.rtf_embed.lock() {
+                    Ok(mut model) => match model.embed(&x, &pad_mask, &images) {
                         Ok(emb) => Some(emb),
                         Err(e) => {
                             warn!("RTF inference failed for candid {}: {}", item.candid, e);
                             None
                         }
+                    },
+                    Err(e) => {
+                        warn!("RTF mutex poisoned for candid {}: {}", item.candid, e);
+                        None
                     }
-                }
+                },
                 Err(e) => {
                     warn!("RTF feature prep failed for candid {}: {}", item.candid, e);
                     None
@@ -906,27 +910,31 @@ impl ZtfEnrichmentWorker {
 
             // mTAN embedding
             let mtan_embedding = match MtanModel::prepare_features(&item.alert) {
-                Ok((x, time_steps, query_times)) => {
-                    match models
-                        .mtan_embed
-                        .lock()
-                        .unwrap()
-                        .embed_raw(&x, &time_steps, &query_times)
-                    {
+                Ok((x, time_steps, query_times)) => match models.mtan_embed.lock() {
+                    Ok(mut model) => match model.embed_raw(&x, &time_steps, &query_times) {
                         Ok(raw) => Some(MtanModel::pool_embedding(&raw, 50)),
                         Err(e) => {
                             warn!("mTAN inference failed for candid {}: {}", item.candid, e);
                             None
                         }
+                    },
+                    Err(e) => {
+                        warn!("mTAN mutex poisoned for candid {}: {}", item.candid, e);
+                        None
                     }
-                }
+                },
                 Err(_) => None, // Insufficient photometry, silently skip
             };
 
-            results.push(Some(ZtfAlertEmbeddings {
-                rtf: rtf_embedding,
-                mtan: mtan_embedding,
-            }));
+            // Only store embeddings if at least one model succeeded
+            if rtf_embedding.is_some() || mtan_embedding.is_some() {
+                results.push(Some(ZtfAlertEmbeddings {
+                    rtf: rtf_embedding,
+                    mtan: mtan_embedding,
+                }));
+            } else {
+                results.push(None);
+            }
         }
 
         results

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -11,7 +11,7 @@ use crate::{
     alert::ZtfCandidate,
     enrichment::{
         fetch_alert_cutouts, fetch_alerts,
-        models::{AcaiModel, BtsBotModel, Model, SharedModels},
+        models::{AcaiModel, BtsBotModel, MtanModel, Model, RtfModel, SharedModels},
         EnrichmentWorker, EnrichmentWorkerError,
     },
 };
@@ -375,6 +375,15 @@ pub struct ZtfAlertClassifications {
     pub btsbot: f32,
 }
 
+/// RTF + mTAN latent space embeddings computed during enrichment.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, AvroSchema, utoipa::ToSchema)]
+pub struct ZtfAlertEmbeddings {
+    /// 128-dimensional RTF embedding (None if cutout was invalid)
+    pub rtf: Option<Vec<f32>>,
+    /// 2-dimensional mTAN embedding (None if insufficient photometry)
+    pub mtan: Option<Vec<f32>>,
+}
+
 /// Per-alert intermediate data used during enrichment processing.
 struct AlertWork {
     candid: i64,
@@ -516,25 +525,35 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
                 vec![None; work_items.len()]
             };
 
-        for (item, classifications) in work_items.into_iter().zip(classifications_list) {
-            let update_alert_document = if let Some(ref cls) = classifications {
-                doc! { "$set": {
-                    "classifications": mongify(cls),
-                    "properties": mongify(&item.properties),
-                    "updated_at": now,
-                }}
+        // Compute RTF + mTAN embeddings
+        let embeddings_list: Vec<Option<ZtfAlertEmbeddings>> =
+            if let Some(ref models) = self.models {
+                self.compute_embeddings(&models, &work_items)
             } else {
-                doc! { "$set": {
-                    "properties": mongify(&item.properties),
-                    "updated_at": now,
-                }}
+                vec![None; work_items.len()]
             };
+
+        for ((item, classifications), embeddings) in work_items
+            .into_iter()
+            .zip(classifications_list)
+            .zip(embeddings_list)
+        {
+            let mut set_doc = doc! {
+                "properties": mongify(&item.properties),
+                "updated_at": now,
+            };
+            if let Some(ref cls) = classifications {
+                set_doc.insert("classifications", mongify(cls));
+            }
+            if let Some(ref emb) = embeddings {
+                set_doc.insert("embeddings", mongify(emb));
+            }
 
             let update = WriteModel::UpdateOne(
                 UpdateOneModel::builder()
                     .namespace(self.alert_collection.namespace())
                     .filter(doc! {"_id": item.candid})
-                    .update(update_alert_document)
+                    .update(doc! { "$set": set_doc })
                     .build(),
             );
 
@@ -856,5 +875,60 @@ impl ZtfEnrichmentWorker {
         }
 
         Ok(results)
+    }
+
+    /// Compute RTF and mTAN embeddings for a batch of alerts.
+    /// Each model is run independently per alert; failures are logged and produce None.
+    fn compute_embeddings(
+        &self,
+        models: &SharedModels,
+        work_items: &[AlertWork],
+    ) -> Vec<Option<ZtfAlertEmbeddings>> {
+        let mut results = Vec::with_capacity(work_items.len());
+
+        for item in work_items {
+            // RTF embedding
+            let rtf_embedding = match RtfModel::prepare_features(&item.alert, &item.cutouts) {
+                Ok((x, pad_mask, images)) => {
+                    match models.rtf_embed.lock().unwrap().embed(&x, &pad_mask, &images) {
+                        Ok(emb) => Some(emb),
+                        Err(e) => {
+                            warn!("RTF inference failed for candid {}: {}", item.candid, e);
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("RTF feature prep failed for candid {}: {}", item.candid, e);
+                    None
+                }
+            };
+
+            // mTAN embedding
+            let mtan_embedding = match MtanModel::prepare_features(&item.alert) {
+                Ok((x, time_steps, query_times)) => {
+                    match models
+                        .mtan_embed
+                        .lock()
+                        .unwrap()
+                        .embed_raw(&x, &time_steps, &query_times)
+                    {
+                        Ok(raw) => Some(MtanModel::pool_embedding(&raw, 50)),
+                        Err(e) => {
+                            warn!("mTAN inference failed for candid {}: {}", item.candid, e);
+                            None
+                        }
+                    }
+                }
+                Err(_) => None, // Insufficient photometry, silently skip
+            };
+
+            results.push(Some(ZtfAlertEmbeddings {
+                rtf: rtf_embedding,
+                mtan: mtan_embedding,
+            }));
+        }
+
+        results
     }
 }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -259,10 +259,13 @@ pub trait AlertProducer {
                     topic_name,
                 );
             }
-            // The topic and data directory are inconsistent. Delete the topic
-            // to start fresh:
-            warn!("recreating topic {}", topic_name);
-            delete_topic(&self.server_url(), &topic_name).await?;
+            // The topic and data directory are inconsistent.
+            // NOTE: We intentionally skip delete_topic here because Kafka
+            // deletes topics asynchronously, causing a race condition where
+            // initialize_topic later sees a ghost topic with 0 partitions.
+            // Instead, we let initialize_topic handle it after downloading.
+            // warn!("recreating topic {}", topic_name);
+            // delete_topic(&self.server_url(), &topic_name).await?;
         }
 
         match self.download_alerts_from_archive().await {


### PR DESCRIPTION
Adds RTF and mTAN encoder inference to the ZTF enrichment pipeline. When a ZTF alert is processed, BOOM now computes a 128D RTF embedding and a 2D mTAN embedding alongside the existing ACAI/BTSBot classifications, and stores them in the alert document under an `embeddings` field.

### Changes

**`src/enrichment/models/rtf.rs`** — `prepare_features()` constructs the (1, 257, 37) photometry tensor, (1, 257) padding mask, and (1, 3, 63, 63) CHW cutout tensor from raw alert data. The 37 channels match the training pipeline: log time deltas, logflux, band one-hots, and 30 alert metadata keys.

**`src/enrichment/models/mtan.rs`** — `prepare_features()` filters to g/r bands, merges nearby observations, normalizes magnitudes and time to [0,1], and pads to 200 steps. `pool_embedding()` mean-pools qz0_mean across 50 query times to produce the final 2D vector. Skips alerts with fewer than 3 observations.

**`src/enrichment/ztf.rs`** — Adds `ZtfAlertEmbeddings` struct, `compute_embeddings()` method, and integrates it into `process_alerts()`. Both models fail gracefully (log a warning and store `None` for that embedding).

**`k8s/08-boom-scheduler-ztf.yaml`** — Adds an initContainer that downloads all 8 ONNX model files (5 ACAI, BTSBot, RTF, mTAN) from [boom-astro/boomEncoders](https://huggingface.co/boom-astro/boomEncoders) into an emptyDir volume mounted at `/app/data/models`.

### MongoDB schema after this change

```json
{
  "classifications": { "acai_h": 0.95, ... },
  "embeddings": {
    "rtf": [0.123, -0.456, ...],   // 128 floats
    "mtan": [0.789, -0.012]        // 2 floats
  }
}