### PR TITLE
Allow running throughput test on workflow dispatch

### DIFF
--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -115,20 +115,18 @@ jobs:
             echo "link=_no successful main run found_" >> "$GITHUB_OUTPUT"
           fi
       - name: Download Mongo baseline logs
+        if: steps.baseline.outputs.run_id != ''
         uses: dawidd6/action-download-artifact@v11
         with:
-          workflow: test-throughput.yaml
-          branch: main
           run_id: ${{ steps.baseline.outputs.run_id }}
           name: throughput-logs-mongo
           path: ./mongo/baseline
           if_no_artifact_found: warn
         continue-on-error: true
       - name: Download S3 baseline logs
+        if: steps.baseline.outputs.run_id != ''
         uses: dawidd6/action-download-artifact@v11
         with:
-          workflow: test-throughput.yaml
-          branch: main
           run_id: ${{ steps.baseline.outputs.run_id }}
           name: throughput-logs-s3
           path: ./s3/baseline

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -95,11 +95,31 @@ jobs:
         with:
           name: throughput-logs-s3
           path: ./s3/current
+      - name: Resolve baseline run
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The baseline is the artifacts from the most recent *successful* run
+          # of this workflow on main (the same selection dawidd6 makes by
+          # default). Resolve it explicitly so we can both pin the downloads
+          # below to it and link to it from the PR comment, guaranteeing the
+          # link matches the artifacts actually used.
+          run_id=$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow test-throughput.yaml --branch main --status success \
+            --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          if [ -n "$run_id" ]; then
+            echo "link=[\`$run_id\`](https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id)" >> "$GITHUB_OUTPUT"
+          else
+            echo "link=_no successful main run found_" >> "$GITHUB_OUTPUT"
+          fi
       - name: Download Mongo baseline logs
         uses: dawidd6/action-download-artifact@v11
         with:
           workflow: test-throughput.yaml
           branch: main
+          run_id: ${{ steps.baseline.outputs.run_id }}
           name: throughput-logs-mongo
           path: ./mongo/baseline
           if_no_artifact_found: warn
@@ -109,6 +129,7 @@ jobs:
         with:
           workflow: test-throughput.yaml
           branch: main
+          run_id: ${{ steps.baseline.outputs.run_id }}
           name: throughput-logs-s3
           path: ./s3/baseline
           if_no_artifact_found: warn
@@ -159,6 +180,8 @@ jobs:
           body: |
             Throughput results (`${{ github.sha }}`):
             ${{ steps.aggregate.outputs.table }}
+
+            Baseline: ${{ steps.baseline.outputs.link }}
           edit-mode: replace
       - name: Fail if wall time increased too much (PR only)
         run: |

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -179,7 +179,7 @@ jobs:
             Throughput results (`${{ github.sha }}`):
             ${{ steps.aggregate.outputs.table }}
 
-            Baseline: ${{ steps.baseline.outputs.link }}
+            Baseline run: ${{ steps.baseline.outputs.link }}
           edit-mode: replace
       - name: Fail if wall time increased too much (PR only)
         run: |


### PR DESCRIPTION
We seem to be failing on a bunch of branches. I want to test that something with the runners hasn't changed, and this will allow us to update the baseline via the GitHub website if necessary.