### PR TITLE
Ingest ssSource designation data from the LSST alert stream

### DIFF
--- a/src/alert/base.rs
+++ b/src/alert/base.rs
@@ -1254,17 +1254,19 @@ pub trait AlertWorker {
         survey_matches: &Option<T>,
         current_version: Option<i32>,
         now: f64,
+        extra_set: Document,
     ) -> Document
     where
         T: Serialize,
     {
-        let mut update_doc = doc! {
-            "$set": {
-                "aliases": mongify(survey_matches),
-                "updated_at": now,
-                "version": current_version.unwrap_or(0) + 1,
-            }
+        let mut set_doc = doc! {
+            "aliases": mongify(survey_matches),
+            "updated_at": now,
+            "version": current_version.unwrap_or(0) + 1,
         };
+        set_doc.extend(extra_set);
+
+        let mut update_doc = doc! { "$set": set_doc };
 
         if !push_updates.is_empty() {
             update_doc.insert("$push", push_updates);
@@ -1275,6 +1277,8 @@ pub trait AlertWorker {
     /// Finalize the auxiliary update by performing an update_one with a filter that includes a
     /// version check for concurrency control. If the update fails due to a concurrent modification
     /// (matched_count == 0), an error is returned to trigger a fallback to a DB-only update.
+    /// `extra_set` lets a survey-specific caller fold additional field updates into the same
+    /// version-checked write instead of issuing a second, unguarded update_one.
     async fn finalize_aux_update<T, K>(
         object_id: &str,
         push_updates: Document,
@@ -1282,13 +1286,19 @@ pub trait AlertWorker {
         current_version: Option<i32>,
         now: f64,
         alert_aux_collection: &mongodb::Collection<K>,
+        extra_set: Document,
     ) -> Result<(), AlertError>
     where
         T: Serialize + Sync,
         K: Serialize + Unpin + Send + Sync,
     {
-        let update_doc =
-            Self::make_filter_doc_aux_update(push_updates, survey_matches, current_version, now);
+        let update_doc = Self::make_filter_doc_aux_update(
+            push_updates,
+            survey_matches,
+            current_version,
+            now,
+            extra_set,
+        );
 
         let find_doc = Self::make_find_doc_aux_update(object_id, current_version);
 

--- a/src/alert/decam.rs
+++ b/src/alert/decam.rs
@@ -344,6 +344,7 @@ impl DecamAlertWorker {
             current_version,
             now,
             &self.alert_aux_collection,
+            Document::new(),
         )
         .await
     }

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -1127,13 +1127,18 @@ impl LsstAlertWorker {
         fp_hists: &Vec<LsstForcedPhot>,
         survey_matches: &Option<LsstAliases>,
         now: f64,
+        designation: Option<&str>,
     ) -> Result<(), AlertError> {
+        let mut lc_set_update = doc! {
+            "prv_candidates": update_timeseries_op("prv_candidates", "jd", &mongify_vec(prv_candidates)),
+            "fp_hists": update_timeseries_op("fp_hists", "jd", &mongify_vec(fp_hists)),
+        };
+        if let Some(designation) = designation {
+            lc_set_update.insert("designation", designation);
+        }
         Self::db_only_aux_update(
             object_id,
-            doc! {
-                "prv_candidates": update_timeseries_op("prv_candidates", "jd", &mongify_vec(prv_candidates)),
-                "fp_hists": update_timeseries_op("fp_hists", "jd", &mongify_vec(fp_hists)),
-            },
+            lc_set_update,
             survey_matches,
             now,
             &self.alert_aux_collection,
@@ -1150,6 +1155,7 @@ impl LsstAlertWorker {
         survey_matches: &Option<LsstAliases>,
         now: f64,
         existing_alert_aux: &AlertAuxForUpdate,
+        designation: Option<&str>,
     ) -> Result<(), AlertError> {
         let current_version = existing_alert_aux.version;
 
@@ -1169,15 +1175,28 @@ impl LsstAlertWorker {
         Self::add_to_push_aux_update(&mut push_updates, "prv_candidates", prepared_prv_candidates);
         Self::add_to_push_aux_update(&mut push_updates, "fp_hists", prepared_fp_hists);
 
-        Self::finalize_aux_update(
-            object_id,
-            push_updates,
-            survey_matches,
-            current_version,
-            now,
-            &self.alert_aux_collection,
-        )
-        .await
+        // finalize_aux_update always builds a document shaped like `{ "$set": {...} }`
+        // (see make_filter_doc_aux_update in base.rs), so it's safe to reach in and add
+        // the LSST-only `designation` field to that same $set instead of doing a second
+        // update_one just for it.
+        let mut update_doc =
+            Self::make_filter_doc_aux_update(push_updates, survey_matches, current_version, now);
+        if let Some(designation) = designation {
+            update_doc
+                .get_document_mut("$set")
+                .expect("make_filter_doc_aux_update always includes $set")
+                .insert("designation", designation);
+        }
+
+        let find_doc = Self::make_find_doc_aux_update(object_id, current_version);
+        let update_result = self
+            .alert_aux_collection
+            .update_one(find_doc, update_doc)
+            .await?;
+        if update_result.matched_count == 0 {
+            return Err(AlertError::ConcurrentAuxUpdate(object_id.to_string()));
+        }
+        Ok(())
     }
 
     #[instrument(
@@ -1192,6 +1211,7 @@ impl LsstAlertWorker {
         survey_matches: &Option<LsstAliases>,
         now: f64,
         existing_alert_aux: &AlertAuxForUpdate,
+        designation: Option<&str>,
     ) -> Result<(), AlertError> {
         match self
             .update_aux_inner(
@@ -1201,6 +1221,7 @@ impl LsstAlertWorker {
                 survey_matches,
                 now,
                 existing_alert_aux,
+                designation,
             )
             .await
         {
@@ -1212,8 +1233,15 @@ impl LsstAlertWorker {
                     AlertError::ConcurrentAuxUpdate(_) => debug!(error = %e),
                     _ => error!(error = %e),
                 }
-                self.update_aux_fallback(object_id, prv_candidates, fp_hists, survey_matches, now)
-                    .await
+                self.update_aux_fallback(
+                    object_id,
+                    prv_candidates,
+                    fp_hists,
+                    survey_matches,
+                    now,
+                    designation,
+                )
+                .await
             }
         }
     }
@@ -1359,7 +1387,14 @@ impl AlertWorker for LsstAlertWorker {
                 .inspect_err(as_error!())?,
         );
 
+        // The designation is only known once a diaSource is linked to an ssObject; keep it
+        // current independent of whichever branch below runs, and regardless of any ZTF
+        // cross-match (an LSST-only or ZTF-only ssObject is a normal outcome). Fold the $set
+        // into the aux insert/update itself rather than issuing a separate round trip: a fresh
+        // insert already carries the designation, and an existing-doc update can carry it in
+        // the same `$set` as the lightcurve/aliases update.
         let existing_alert_aux = self.get_existing_aux(&object_id).await?;
+        let existing_alert_aux_present = existing_alert_aux.is_some();
 
         if let Some(existing) = existing_alert_aux {
             self.update_aux(
@@ -1369,6 +1404,7 @@ impl AlertWorker for LsstAlertWorker {
                 &survey_matches,
                 now,
                 &existing,
+                designation.as_deref(),
             )
             .await
             .inspect_err(as_error!())?;
@@ -1407,6 +1443,7 @@ impl AlertWorker for LsstAlertWorker {
                     &obj.fp_hists,
                     &obj.aliases,
                     now,
+                    designation.as_deref(),
                 )
                 .await
                 .inspect_err(as_error!())?;
@@ -1415,17 +1452,15 @@ impl AlertWorker for LsstAlertWorker {
             }
         }
 
-        // The designation is only known once a diaSource is linked to an ssObject; keep it
-        // current on the aux doc independent of whichever branch above ran, and regardless of
-        // any ZTF cross-match (an LSST-only or ZTF-only ssObject is a normal outcome).
-        if ss_source_present {
+        // The only case not covered by the folded-in `$set` above is clearing a designation
+        // (no designation on this alert's ss_source) on a doc that already existed before this
+        // alert: a fresh insert never has the field set in the first place, so there's nothing
+        // to unset there.
+        if ss_source_present && designation.is_none() && existing_alert_aux_present {
             self.alert_aux_collection
                 .update_one(
                     doc! { "_id": &object_id },
-                    match &designation {
-                        Some(designation) => doc! { "$set": { "designation": designation } },
-                        None => doc! { "$unset": { "designation": "" } },
-                    },
+                    doc! { "$unset": { "designation": "" } },
                 )
                 .await
                 .inspect_err(as_error!())?;
@@ -1516,6 +1551,7 @@ mod tests {
                 survey_matches,
                 Time::now().to_jd(),
                 existing_aux,
+                None,
             )
             .await
             .unwrap();
@@ -1890,6 +1926,68 @@ mod tests {
 
         let second = worker.process_alert(&bytes_content).await.unwrap();
         assert_eq!(second, ProcessAlertStatus::Exists(candid));
+
+        drop_alert_from_collections(candid, &Survey::Lsst)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_aux_folds_in_designation() {
+        let mut worker = lsst_alert_worker().await;
+        let (candid, object_id, _bytes_content) = seed_lsst_alert(&mut worker).await;
+
+        let existing_aux = load_aux(&worker, &object_id).await;
+        worker
+            .update_aux(
+                &object_id,
+                &vec![],
+                &vec![],
+                &Some(LsstAliases::default()),
+                Time::now().to_jd(),
+                &existing_aux,
+                Some("2008 AB"),
+            )
+            .await
+            .unwrap();
+
+        let aux = worker
+            .alert_aux_collection
+            .find_one(doc! { "_id": &object_id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(aux.designation, Some("2008 AB".to_string()));
+
+        drop_alert_from_collections(candid, &Survey::Lsst)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_aux_fallback_folds_in_designation() {
+        let mut worker = lsst_alert_worker().await;
+        let (candid, object_id, _bytes_content) = seed_lsst_alert(&mut worker).await;
+
+        worker
+            .update_aux_fallback(
+                &object_id,
+                &vec![],
+                &vec![],
+                &Some(LsstAliases::default()),
+                Time::now().to_jd(),
+                Some("2010 XY"),
+            )
+            .await
+            .unwrap();
+
+        let aux = worker
+            .alert_aux_collection
+            .find_one(doc! { "_id": &object_id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(aux.designation, Some("2010 XY".to_string()));
 
         drop_alert_from_collections(candid, &Survey::Lsst)
             .await

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -1417,11 +1417,14 @@ impl AlertWorker for LsstAlertWorker {
         // The designation is only known once a diaSource is linked to an ssObject; keep it
         // current on the aux doc independent of whichever branch above ran, and regardless of
         // any ZTF cross-match (an LSST-only or ZTF-only ssObject is a normal outcome).
-        if let Some(designation) = &designation {
+        if ss_object_id.is_some() {
             self.alert_aux_collection
                 .update_one(
                     doc! { "_id": &object_id },
-                    doc! { "$set": { "designation": designation } },
+                    match &designation {
+                        Some(designation) => doc! { "$set": { "designation": designation } },
+                        None => doc! { "$unset": { "designation": "" } },
+                    },
                 )
                 .await
                 .inspect_err(as_error!())?;
@@ -1691,12 +1694,18 @@ mod tests {
             ("eclBeta".to_string(), Value::Double(20.0)),
             ("galLon".to_string(), Value::Double(30.0)),
             ("galLat".to_string(), Value::Double(40.0)),
-            ("elongation".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "elongation".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
             (
                 "phaseAngle".to_string(),
                 Value::Union(1, Box::new(Value::Float(12.5))),
             ),
-            ("topoRange".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "topoRange".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
             (
                 "topoRangeRate".to_string(),
                 Value::Union(0, Box::new(Value::Null)),
@@ -1717,8 +1726,14 @@ mod tests {
                 "ephDec".to_string(),
                 Value::Union(1, Box::new(Value::Double(5.0))),
             ),
-            ("ephVmag".to_string(), Value::Union(0, Box::new(Value::Null))),
-            ("ephRate".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "ephVmag".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "ephRate".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
             (
                 "ephRateRa".to_string(),
                 Value::Union(0, Box::new(Value::Null)),
@@ -1727,7 +1742,10 @@ mod tests {
                 "ephRateDec".to_string(),
                 Value::Union(0, Box::new(Value::Null)),
             ),
-            ("ephOffset".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "ephOffset".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
             (
                 "ephOffsetRa".to_string(),
                 Value::Union(0, Box::new(Value::Null)),
@@ -1744,9 +1762,18 @@ mod tests {
                 "ephOffsetCrossTrack".to_string(),
                 Value::Union(0, Box::new(Value::Null)),
             ),
-            ("helio_x".to_string(), Value::Union(0, Box::new(Value::Null))),
-            ("helio_y".to_string(), Value::Union(0, Box::new(Value::Null))),
-            ("helio_z".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "helio_x".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "helio_y".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "helio_z".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
             (
                 "helio_vx".to_string(),
                 Value::Union(0, Box::new(Value::Null)),
@@ -1766,9 +1793,18 @@ mod tests {
             ("topo_x".to_string(), Value::Union(0, Box::new(Value::Null))),
             ("topo_y".to_string(), Value::Union(0, Box::new(Value::Null))),
             ("topo_z".to_string(), Value::Union(0, Box::new(Value::Null))),
-            ("topo_vx".to_string(), Value::Union(0, Box::new(Value::Null))),
-            ("topo_vy".to_string(), Value::Union(0, Box::new(Value::Null))),
-            ("topo_vz".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "topo_vx".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "topo_vy".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "topo_vz".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
             (
                 "topo_vtot".to_string(),
                 Value::Union(0, Box::new(Value::Null)),

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -1024,6 +1024,7 @@ pub struct LsstAliases {
     pub decam: Vec<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LsstObject {
     #[serde(rename = "_id")]
@@ -1056,6 +1057,7 @@ pub struct LsstAlert {
     pub updated_at: f64,
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize)]
 struct AlertAuxForUpdate {
     #[serde(default)]
@@ -1119,6 +1121,10 @@ impl LsstAlertWorker {
         Ok(result)
     }
 
+    /// Designation is sticky: once an MPC association has been made for an object, a later
+    /// alert with no designation is never allowed to clear it (that alert may simply lack the
+    /// association for unrelated reasons, e.g. a transient gap in Rubin's own pipeline). Only a
+    /// `Some` designation is ever written here.
     #[instrument(skip(self, prv_candidates, fp_hists, survey_matches), err)]
     async fn update_aux_fallback(
         &mut self,
@@ -1146,6 +1152,7 @@ impl LsstAlertWorker {
         .await
     }
 
+    /// See `update_aux_fallback` for why designation is only ever set, never cleared.
     #[instrument(skip(self, prv_candidates, fp_hists, survey_matches, existing_alert_aux))]
     async fn update_aux_inner(
         &mut self,
@@ -1175,28 +1182,21 @@ impl LsstAlertWorker {
         Self::add_to_push_aux_update(&mut push_updates, "prv_candidates", prepared_prv_candidates);
         Self::add_to_push_aux_update(&mut push_updates, "fp_hists", prepared_fp_hists);
 
-        // finalize_aux_update always builds a document shaped like `{ "$set": {...} }`
-        // (see make_filter_doc_aux_update in base.rs), so it's safe to reach in and add
-        // the LSST-only `designation` field to that same $set instead of doing a second
-        // update_one just for it.
-        let mut update_doc =
-            Self::make_filter_doc_aux_update(push_updates, survey_matches, current_version, now);
+        let mut extra_set = Document::new();
         if let Some(designation) = designation {
-            update_doc
-                .get_document_mut("$set")
-                .expect("make_filter_doc_aux_update always includes $set")
-                .insert("designation", designation);
+            extra_set.insert("designation", designation);
         }
 
-        let find_doc = Self::make_find_doc_aux_update(object_id, current_version);
-        let update_result = self
-            .alert_aux_collection
-            .update_one(find_doc, update_doc)
-            .await?;
-        if update_result.matched_count == 0 {
-            return Err(AlertError::ConcurrentAuxUpdate(object_id.to_string()));
-        }
-        Ok(())
+        Self::finalize_aux_update(
+            object_id,
+            push_updates,
+            survey_matches,
+            current_version,
+            now,
+            &self.alert_aux_collection,
+            extra_set,
+        )
+        .await
     }
 
     #[instrument(
@@ -1346,7 +1346,6 @@ impl AlertWorker for LsstAlertWorker {
         let dec = candidate.dia_source.dec;
 
         let ss_source = avro_alert.ss_source.take();
-        let ss_source_present = ss_source.is_some();
         let designation = ss_source.as_ref().and_then(|s| s.designation.clone());
 
         let mut prv_candidates = avro_alert.prv_candidates.take().unwrap_or_default();
@@ -1389,12 +1388,12 @@ impl AlertWorker for LsstAlertWorker {
 
         // The designation is only known once a diaSource is linked to an ssObject; keep it
         // current independent of whichever branch below runs, and regardless of any ZTF
-        // cross-match (an LSST-only or ZTF-only ssObject is a normal outcome). Fold the $set
-        // into the aux insert/update itself rather than issuing a separate round trip: a fresh
-        // insert already carries the designation, and an existing-doc update can carry it in
-        // the same `$set` as the lightcurve/aliases update.
+        // cross-match (an LSST-only or ZTF-only ssObject is a normal outcome). It's sticky:
+        // once set, a later alert with no designation never clears it (see update_aux_fallback),
+        // so this only ever folds a `Some` designation into the same write as the
+        // lightcurve/aliases update, in every branch below (fresh insert, versioned update, and
+        // both DB-only fallbacks) instead of issuing a separate round trip.
         let existing_alert_aux = self.get_existing_aux(&object_id).await?;
-        let existing_alert_aux_present = existing_alert_aux.is_some();
 
         if let Some(existing) = existing_alert_aux {
             self.update_aux(
@@ -1450,20 +1449,6 @@ impl AlertWorker for LsstAlertWorker {
             } else {
                 result.inspect_err(as_error!())?;
             }
-        }
-
-        // The only case not covered by the folded-in `$set` above is clearing a designation
-        // (no designation on this alert's ss_source) on a doc that already existed before this
-        // alert: a fresh insert never has the field set in the first place, so there's nothing
-        // to unset there.
-        if ss_source_present && designation.is_none() && existing_alert_aux_present {
-            self.alert_aux_collection
-                .update_one(
-                    doc! { "_id": &object_id },
-                    doc! { "$unset": { "designation": "" } },
-                )
-                .await
-                .inspect_err(as_error!())?;
         }
 
         let status = self
@@ -1965,6 +1950,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_aux_preserves_designation_when_absent() {
+        let mut worker = lsst_alert_worker().await;
+        let (candid, object_id, _bytes_content) = seed_lsst_alert(&mut worker).await;
+        set_aux_fields(&worker, &object_id, doc! { "designation": "2008 AB" }).await;
+
+        let existing_aux = load_aux(&worker, &object_id).await;
+        worker
+            .update_aux(
+                &object_id,
+                &vec![],
+                &vec![],
+                &Some(LsstAliases::default()),
+                Time::now().to_jd(),
+                &existing_aux,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let aux = worker
+            .alert_aux_collection
+            .find_one(doc! { "_id": &object_id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(aux.designation, Some("2008 AB".to_string()));
+
+        drop_alert_from_collections(candid, &Survey::Lsst)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_update_aux_fallback_folds_in_designation() {
         let mut worker = lsst_alert_worker().await;
         let (candid, object_id, _bytes_content) = seed_lsst_alert(&mut worker).await;
@@ -1977,6 +1995,37 @@ mod tests {
                 &Some(LsstAliases::default()),
                 Time::now().to_jd(),
                 Some("2010 XY"),
+            )
+            .await
+            .unwrap();
+
+        let aux = worker
+            .alert_aux_collection
+            .find_one(doc! { "_id": &object_id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(aux.designation, Some("2010 XY".to_string()));
+
+        drop_alert_from_collections(candid, &Survey::Lsst)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_aux_fallback_preserves_designation_when_absent() {
+        let mut worker = lsst_alert_worker().await;
+        let (candid, object_id, _bytes_content) = seed_lsst_alert(&mut worker).await;
+        set_aux_fields(&worker, &object_id, doc! { "designation": "2010 XY" }).await;
+
+        worker
+            .update_aux_fallback(
+                &object_id,
+                &vec![],
+                &vec![],
+                &Some(LsstAliases::default()),
+                Time::now().to_jd(),
+                None,
             )
             .await
             .unwrap();

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -822,7 +822,120 @@ impl TimeSeries for LsstForcedPhot {
     }
 }
 
-/// Rubin Avro alert schema v10.0 (minus SSO metadata, which we do not use here yet)
+/// Rubin's per-detection Solar System ephemeris and designation record (`ssSource`), present
+/// only when a diaSource was linked to a known Solar System object (ssObject) instead of a
+/// diaObject. `mpc_orbits` (the orbital elements record) is intentionally not parsed here yet.
+#[serde_as]
+#[skip_serializing_none]
+#[serdavro]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default, ToSchema)]
+#[serde(default)]
+pub struct SsSource {
+    /// Unique identifier of the observation (matching DiaSource.diaSourceId).
+    #[serde(rename = "diaSourceId")]
+    pub dia_source_id: i64,
+    /// Unique LSST identifier of the Solar System object.
+    #[serde(rename = "ssObjectId")]
+    pub ss_object_id: i64,
+    /// The unpacked primary provisional designation for this object.
+    pub designation: Option<String>,
+    /// Ecliptic longitude, converted from the observed coordinates.
+    #[serde(rename = "eclLambda")]
+    pub ecl_lambda: f64,
+    /// Ecliptic latitude, converted from the observed coordinates.
+    #[serde(rename = "eclBeta")]
+    pub ecl_beta: f64,
+    /// Galactic longitude, converted from the observed coordinates.
+    #[serde(rename = "galLon")]
+    pub gal_lon: f64,
+    /// Galactic latitude, converted from the observed coordinates.
+    #[serde(rename = "galLat")]
+    pub gal_lat: f64,
+    /// Solar elongation of the object at the time of observation.
+    pub elongation: Option<f32>,
+    /// Phase angle between the Sun, object, and observer.
+    #[serde(rename = "phaseAngle")]
+    pub phase_angle: Option<f32>,
+    /// Topocentric distance (delta) at light-emission time.
+    #[serde(rename = "topoRange")]
+    pub topo_range: Option<f32>,
+    /// Topocentric radial (line-of-sight) velocity (deldot); positive values indicate motion away from the observer.
+    #[serde(rename = "topoRangeRate")]
+    pub topo_range_rate: Option<f32>,
+    /// Heliocentric distance (r) at light-emission time.
+    #[serde(rename = "helioRange")]
+    pub helio_range: Option<f32>,
+    /// Heliocentric radial velocity (rdot); positive values indicate motion away from the Sun.
+    #[serde(rename = "helioRangeRate")]
+    pub helio_range_rate: Option<f32>,
+    /// Predicted ICRS right ascension from the orbit in mpc_orbits.
+    #[serde(rename = "ephRa")]
+    pub eph_ra: Option<f64>,
+    /// Predicted ICRS declination from the orbit in mpc_orbits.
+    #[serde(rename = "ephDec")]
+    pub eph_dec: Option<f64>,
+    /// Predicted magnitude in V band, computed from mpc_orbits data including the mpc_orbits-provided (H, G) estimates.
+    #[serde(rename = "ephVmag")]
+    pub eph_vmag: Option<f32>,
+    /// Total predicted on-sky angular rate of motion.
+    #[serde(rename = "ephRate")]
+    pub eph_rate: Option<f32>,
+    /// Predicted on-sky angular rate in the R.A. direction (includes the cos(dec) factor).
+    #[serde(rename = "ephRateRa")]
+    pub eph_rate_ra: Option<f32>,
+    /// Predicted on-sky angular rate in the declination direction.
+    #[serde(rename = "ephRateDec")]
+    pub eph_rate_dec: Option<f32>,
+    /// Total observed versus predicted angular separation on the sky.
+    #[serde(rename = "ephOffset")]
+    pub eph_offset: Option<f32>,
+    /// Offset between observed and predicted position in the R.A. direction (includes cos(dec) term).
+    #[serde(rename = "ephOffsetRa")]
+    pub eph_offset_ra: Option<f64>,
+    /// Offset between observed and predicted position in declination.
+    #[serde(rename = "ephOffsetDec")]
+    pub eph_offset_dec: Option<f64>,
+    /// Offset between observed and predicted position in the along-track direction on the sky.
+    #[serde(rename = "ephOffsetAlongTrack")]
+    pub eph_offset_along_track: Option<f32>,
+    /// Offset between observed and predicted position in the cross-track direction on the sky.
+    #[serde(rename = "ephOffsetCrossTrack")]
+    pub eph_offset_cross_track: Option<f32>,
+    /// Cartesian heliocentric X coordinate at light-emission time (ICRS).
+    pub helio_x: Option<f32>,
+    /// Cartesian heliocentric Y coordinate at light-emission time (ICRS).
+    pub helio_y: Option<f32>,
+    /// Cartesian heliocentric Z coordinate at light-emission time (ICRS).
+    pub helio_z: Option<f32>,
+    /// Cartesian heliocentric X velocity at light-emission time (ICRS).
+    pub helio_vx: Option<f32>,
+    /// Cartesian heliocentric Y velocity at light-emission time (ICRS).
+    pub helio_vy: Option<f32>,
+    /// Cartesian heliocentric Z velocity at light-emission time (ICRS).
+    pub helio_vz: Option<f32>,
+    /// The magnitude of the heliocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz).
+    pub helio_vtot: Option<f32>,
+    /// Cartesian topocentric X coordinate at light-emission time (ICRS).
+    pub topo_x: Option<f32>,
+    /// Cartesian topocentric Y coordinate at light-emission time (ICRS).
+    pub topo_y: Option<f32>,
+    /// Cartesian topocentric Z coordinate at light-emission time (ICRS).
+    pub topo_z: Option<f32>,
+    /// Cartesian topocentric X velocity at light-emission time (ICRS).
+    pub topo_vx: Option<f32>,
+    /// Cartesian topocentric Y velocity at light-emission time (ICRS).
+    pub topo_vy: Option<f32>,
+    /// Cartesian topocentric Z velocity at light-emission time (ICRS).
+    pub topo_vz: Option<f32>,
+    /// The magnitude of the topocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz).
+    pub topo_vtot: Option<f32>,
+    /// The rank of the diaSourceId-identified source in terms of its closeness to the predicted SSO position.
+    #[serde(rename = "diaDistanceRank")]
+    pub dia_distance_rank: Option<i32>,
+}
+
+/// Rubin Avro alert schema v11.0 (minus the `mpc_orbits` orbital-elements record, which we do
+/// not use here yet)
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct LsstRawAvroAlert {
     #[serde(rename(deserialize = "diaSourceId"))]
@@ -837,6 +950,8 @@ pub struct LsstRawAvroAlert {
     pub fp_hists: Option<Vec<LsstForcedPhot>>,
     #[serde(rename = "diaObject")]
     pub dia_object: Option<DiaObject>,
+    #[serde(rename = "ssSource")]
+    pub ss_source: Option<SsSource>,
     #[serde(rename = "cutoutDifference")]
     #[serde(deserialize_with = "deserialize_cutout")]
     pub cutout_difference: Vec<u8>,
@@ -916,6 +1031,9 @@ pub struct LsstObject {
     pub prv_candidates: Vec<LsstPrvCandidate>,
     pub fp_hists: Vec<LsstForcedPhot>,
     pub is_sso: bool,
+    /// The MPC provisional/permanent designation for this Solar System object, if any.
+    /// Persists regardless of whether a ZTF cross-match is ever found.
+    pub designation: Option<String>,
     pub cross_matches: Option<HashMap<String, Vec<Document>>>,
     pub aliases: Option<LsstAliases>,
     pub coordinates: Coordinates,
@@ -931,6 +1049,7 @@ pub struct LsstAlert {
     pub object_id: String,
     #[serde(rename = "ssObjectId")]
     pub ss_object_id: Option<String>,
+    pub ss_source: Option<SsSource>,
     pub candidate: LsstCandidate,
     pub coordinates: Coordinates,
     pub created_at: f64,
@@ -1198,6 +1317,9 @@ impl AlertWorker for LsstAlertWorker {
         let ra = candidate.dia_source.ra;
         let dec = candidate.dia_source.dec;
 
+        let ss_source = avro_alert.ss_source.take();
+        let designation = ss_source.as_ref().and_then(|s| s.designation.clone());
+
         let mut prv_candidates = avro_alert.prv_candidates.take().unwrap_or_default();
         let mut fp_hists = avro_alert.fp_hists.take().unwrap_or_default();
 
@@ -1214,6 +1336,7 @@ impl AlertWorker for LsstAlertWorker {
             candid,
             object_id: object_id.clone(),
             ss_object_id: ss_object_id.clone(),
+            ss_source,
             candidate,
             coordinates: Coordinates::new(ra, dec),
             created_at: now,
@@ -1263,6 +1386,7 @@ impl AlertWorker for LsstAlertWorker {
                 prv_candidates,
                 fp_hists,
                 is_sso: ss_object_id.is_some(),
+                designation: designation.clone(),
                 cross_matches: Some(xmatches),
                 aliases: survey_matches,
                 coordinates: Coordinates::new(ra, dec),
@@ -1288,6 +1412,19 @@ impl AlertWorker for LsstAlertWorker {
             } else {
                 result.inspect_err(as_error!())?;
             }
+        }
+
+        // The designation is only known once a diaSource is linked to an ssObject; keep it
+        // current on the aux doc independent of whichever branch above ran, and regardless of
+        // any ZTF cross-match (an LSST-only or ZTF-only ssObject is a normal outcome).
+        if let Some(designation) = &designation {
+            self.alert_aux_collection
+                .update_one(
+                    doc! { "_id": &object_id },
+                    doc! { "$set": { "designation": designation } },
+                )
+                .await
+                .inspect_err(as_error!())?;
         }
 
         let status = self
@@ -1533,6 +1670,126 @@ mod tests {
         // TODO: check prv_candidates and forced photometry once we have alerts
         //       where they aren't empty
         // TODO: check non detections once these are available in the schema
+
+        // the real fixture alert is not a Solar System object, so ssSource should
+        // deserialize cleanly as None rather than erroring out
+        assert!(alert.ss_source.is_none());
+    }
+
+    #[test]
+    fn test_ss_source_from_avro_value() {
+        use apache_avro::{from_value, types::Value};
+
+        let value = Value::Record(vec![
+            ("diaSourceId".to_string(), Value::Long(123456789)),
+            ("ssObjectId".to_string(), Value::Long(987654321)),
+            (
+                "designation".to_string(),
+                Value::Union(1, Box::new(Value::String("2008 AB".to_string()))),
+            ),
+            ("eclLambda".to_string(), Value::Double(10.0)),
+            ("eclBeta".to_string(), Value::Double(20.0)),
+            ("galLon".to_string(), Value::Double(30.0)),
+            ("galLat".to_string(), Value::Double(40.0)),
+            ("elongation".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "phaseAngle".to_string(),
+                Value::Union(1, Box::new(Value::Float(12.5))),
+            ),
+            ("topoRange".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "topoRangeRate".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "helioRange".to_string(),
+                Value::Union(1, Box::new(Value::Float(2.5))),
+            ),
+            (
+                "helioRangeRate".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "ephRa".to_string(),
+                Value::Union(1, Box::new(Value::Double(100.0))),
+            ),
+            (
+                "ephDec".to_string(),
+                Value::Union(1, Box::new(Value::Double(5.0))),
+            ),
+            ("ephVmag".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("ephRate".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "ephRateRa".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "ephRateDec".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            ("ephOffset".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "ephOffsetRa".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "ephOffsetDec".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "ephOffsetAlongTrack".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "ephOffsetCrossTrack".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            ("helio_x".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("helio_y".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("helio_z".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "helio_vx".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "helio_vy".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "helio_vz".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "helio_vtot".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            ("topo_x".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("topo_y".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("topo_z".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("topo_vx".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("topo_vy".to_string(), Value::Union(0, Box::new(Value::Null))),
+            ("topo_vz".to_string(), Value::Union(0, Box::new(Value::Null))),
+            (
+                "topo_vtot".to_string(),
+                Value::Union(0, Box::new(Value::Null)),
+            ),
+            (
+                "diaDistanceRank".to_string(),
+                Value::Union(1, Box::new(Value::Int(1))),
+            ),
+        ]);
+
+        let ss_source: SsSource = from_value(&value).expect("failed to deserialize SsSource");
+        assert_eq!(ss_source.dia_source_id, 123456789);
+        assert_eq!(ss_source.ss_object_id, 987654321);
+        assert_eq!(ss_source.designation, Some("2008 AB".to_string()));
+        assert_eq!(ss_source.ecl_lambda, 10.0);
+        assert_eq!(ss_source.phase_angle, Some(12.5));
+        assert_eq!(ss_source.eph_ra, Some(100.0));
+        assert_eq!(ss_source.eph_dec, Some(5.0));
+        assert_eq!(ss_source.helio_range, Some(2.5));
+        assert_eq!(ss_source.topo_range, None);
+        assert_eq!(ss_source.dia_distance_rank, Some(1));
     }
 
     #[tokio::test]

--- a/src/alert/lsst.rs
+++ b/src/alert/lsst.rs
@@ -1318,6 +1318,7 @@ impl AlertWorker for LsstAlertWorker {
         let dec = candidate.dia_source.dec;
 
         let ss_source = avro_alert.ss_source.take();
+        let ss_source_present = ss_source.is_some();
         let designation = ss_source.as_ref().and_then(|s| s.designation.clone());
 
         let mut prv_candidates = avro_alert.prv_candidates.take().unwrap_or_default();
@@ -1417,7 +1418,7 @@ impl AlertWorker for LsstAlertWorker {
         // The designation is only known once a diaSource is linked to an ssObject; keep it
         // current on the aux doc independent of whichever branch above ran, and regardless of
         // any ZTF cross-match (an LSST-only or ZTF-only ssObject is a normal outcome).
-        if ss_object_id.is_some() {
+        if ss_source_present {
             self.alert_aux_collection
                 .update_one(
                     doc! { "_id": &object_id },

--- a/src/alert/mod.rs
+++ b/src/alert/mod.rs
@@ -14,7 +14,7 @@ pub use decam::{
 };
 pub use lsst::{
     DiaForcedSource, DiaSource, LsstAlert, LsstAlertWorker, LsstAliases, LsstCandidate,
-    LsstForcedPhot, LsstObject, LsstPrvCandidate, LsstRawAvroAlert, LSST_DEC_RANGE,
+    LsstForcedPhot, LsstObject, LsstPrvCandidate, LsstRawAvroAlert, SsSource, LSST_DEC_RANGE,
     LSST_SCHEMA_REGISTRY_GITHUB_FALLBACK_URL, LSST_SCHEMA_REGISTRY_URL, LSST_ZTF_XMATCH_RADIUS,
 };
 pub use winter::{

--- a/src/alert/winter.rs
+++ b/src/alert/winter.rs
@@ -576,6 +576,7 @@ impl WinterAlertWorker {
             current_version,
             now,
             &self.alert_aux_collection,
+            Document::new(),
         )
         .await
     }

--- a/src/alert/ztf.rs
+++ b/src/alert/ztf.rs
@@ -851,6 +851,7 @@ impl ZtfAlertWorker {
             current_version,
             now,
             &self.alert_aux_collection,
+            Document::new(),
         )
         .await
     }

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -1,4 +1,4 @@
-use crate::alert::LsstCandidate;
+use crate::alert::{LsstCandidate, SsSource};
 use crate::conf::AppConfig;
 use crate::enrichment::{
     babamul::{Babamul, BabamulLsstAlert},
@@ -130,6 +130,7 @@ pub fn create_lsst_alert_pipeline() -> Vec<Document> {
             "$project": {
                 "objectId": 1,
                 "ssObjectId": 1,
+                "ss_source": 1,
                 "candidate": 1,
                 "prv_candidates": "$aux.prv_candidates",
                 "fp_hists": "$aux.fp_hists",
@@ -185,6 +186,7 @@ pub struct LsstAlertForEnrichment {
     pub object_id: String,
     #[serde(rename = "ssObjectId")]
     pub ss_object_id: Option<String>,
+    pub ss_source: Option<SsSource>,
     pub candidate: LsstCandidate,
     pub prv_candidates: Vec<LsstPhotometry>,
     pub fp_hists: Vec<LsstPhotometry>,

--- a/src/filter/lsst.rs
+++ b/src/filter/lsst.rs
@@ -386,6 +386,7 @@ pub async fn build_lsst_filter_pipeline(
             "$project": doc! {
                 "objectId": 1,
                 "candidate": 1,
+                "ss_source": 1,
                 "properties": 1,
                 "coordinates": 1,
             }

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -103,12 +103,12 @@ pub async fn initialize_survey_indexes(
     };
     create_index(&alerts_collection, index, false).await?;
 
-    // if survey is LSST, create an index on the ss_object_id field of the alerts collection,
+    // if survey is LSST, create an index on the ssObjectId field of the alerts collection,
     // and on the designation field of the aux collection (used to look up a moving object by
     // its MPC designation, independent of any cross-survey position match)
     if survey == &Survey::Lsst {
         let index = doc! {
-            "ss_object_id": 1,
+            "ssObjectId": 1,
         };
         create_index(&alerts_collection, index, false).await?;
 

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -19,9 +19,28 @@ pub async fn create_index(
     index: Document,
     unique: bool,
 ) -> Result<(), CreateIndexError> {
+    create_partial_index(collection, index, unique, None).await
+}
+
+#[instrument(
+    skip(collection, index, partial_filter),
+    fields(collection = collection.name()),
+    err
+)]
+pub async fn create_partial_index(
+    collection: &Collection<Document>,
+    index: Document,
+    unique: bool,
+    partial_filter: Option<Document>,
+) -> Result<(), CreateIndexError> {
     let index_model = IndexModel::builder()
         .keys(index)
-        .options(IndexOptions::builder().unique(unique).build())
+        .options(
+            IndexOptions::builder()
+                .unique(unique)
+                .partial_filter_expression(partial_filter)
+                .build(),
+        )
         .build();
     collection.create_index(index_model).await?;
     Ok(())
@@ -115,7 +134,13 @@ pub async fn initialize_survey_indexes(
         let index = doc! {
             "designation": 1,
         };
-        create_index(&alerts_aux_collection, index, false).await?;
+        create_partial_index(
+            &alerts_aux_collection,
+            index,
+            false,
+            Some(doc! { "designation": { "$exists": true } }),
+        )
+        .await?;
     }
 
     Ok(())

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -103,12 +103,19 @@ pub async fn initialize_survey_indexes(
     };
     create_index(&alerts_collection, index, false).await?;
 
-    // if survey is LSST, create an index on the ss_object_id field of the alerts collection
+    // if survey is LSST, create an index on the ss_object_id field of the alerts collection,
+    // and on the designation field of the aux collection (used to look up a moving object by
+    // its MPC designation, independent of any cross-survey position match)
     if survey == &Survey::Lsst {
         let index = doc! {
             "ss_object_id": 1,
         };
         create_index(&alerts_collection, index, false).await?;
+
+        let index = doc! {
+            "designation": 1,
+        };
+        create_index(&alerts_aux_collection, index, false).await?;
     }
 
     Ok(())

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -1002,6 +1002,7 @@ mod tests {
                 prv_candidates: vec![],
                 fp_hists: vec![],
                 is_sso: false,
+                designation: None,
                 aliases: None,
                 created_at: 0.0,
                 updated_at: 0.0,

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -277,6 +277,7 @@ async fn create_mock_enriched_lsst_alert_with_matches(
         candid,
         object_id: object_id.to_string(),
         ss_object_id: ss_object_id.map(|id| id.to_string()),
+        ss_source: None,
         candidate,
         prv_candidates: vec![prv_candidate],
         fp_hists: vec![],
@@ -1200,6 +1201,7 @@ async fn test_babamul_lsst_with_ztf_match() {
         candid: lsst_alert_id,
         object_id: lsst_object_id.clone(),
         ss_object_id: None,
+        ss_source: None,
         candidate: lsst_candidate.clone(),
         coordinates: Coordinates::new(180.0, 0.0),
         created_at: now,
@@ -1258,6 +1260,7 @@ async fn test_babamul_lsst_with_ztf_match() {
         prv_candidates: vec![LsstPrvCandidate::try_from(lsst_candidate).unwrap()],
         fp_hists: vec![lsst_forced_phot],
         is_sso: false,
+        designation: None,
         cross_matches: None,
         aliases: Some(LsstAliases {
             ztf: vec![ztf_match_id.clone()],
@@ -1497,6 +1500,7 @@ async fn test_babamul_ztf_with_lsst_match() {
         prv_candidates: vec![LsstPrvCandidate::try_from(lsst_dia_source).unwrap()],
         fp_hists: vec![lsst_forced_phot],
         is_sso: false,
+        designation: None,
         cross_matches: None,
         aliases: Some(LsstAliases {
             ztf: Vec::new(),


### PR DESCRIPTION
This pull request adds support for Rubin/LSST Solar System object (SSO) metadata in alert handling, specifically by introducing the `SsSource` struct to represent per-detection SSO ephemeris and designation information. The changes ensure that SSO data is parsed, stored, indexed, and exposed throughout the alert ingestion, enrichment, and filtering pipelines, and are accompanied by new tests for correct deserialization and handling of SSO fields.

**Support for Solar System Object metadata:**

- Added the new `SsSource` struct to represent Solar System object ephemeris and designation data, with full parsing and (de)serialization support in `src/alert/lsst.rs`. This struct is now included in the `LsstRawAvroAlert`, `LsstAlert`, and `LsstObject` types, and is handled during alert ingestion and enrichment. 
- The SSO designation is now persisted in the auxiliary collection for each object, updated independently of cross-survey matches, and indexed for efficient lookup by designation. 

**Pipeline and API changes:**

- The alert enrichment and filtering pipelines have been updated to propagate the new `ss_source` field, making SSO metadata available for downstream consumers and APIs. 

**Testing and validation:**

- Added tests to verify correct deserialization of the new `SsSource` struct, including edge cases where the field is absent. Existing tests and fixtures were updated to include or expect the new fields where appropriate. 

These changes collectively enable robust handling and querying of Solar System object information in LSST alert data, paving the way for more advanced moving object science use cases.

The idea behind this PR is to query by `ssObjectId` in the future