### PR TITLE
Add deployment trigger workflow for further securing runner

### DIFF
--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -1,0 +1,25 @@
+# This workflow exists so we can restrict the self-hosted runner to only run the
+# deploy.yaml workflow, i.e., no other workflows are allowed to run on our
+# production deployment machine.
+# These need to be separate because GitHub requires a ref for the workflow
+# restriction, and we want to be able to deploy on published releases,
+# which are tag refs.
+name: Trigger deployment to production
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to deploy/rollback to (e.g., v1.0.4)"
+        required: true
+        type: string
+
+jobs:
+  trigger-deployment:
+    uses: boom-astro/boom/.github/workflows/deploy.yaml@refs/heads/main
+    with:
+      # If triggered manually, use the input version. If triggered by a release, use the release tag ref.
+      tag_ref: ${{ github.event.inputs.version || github.ref }}

--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -20,6 +20,9 @@ on:
 jobs:
   trigger-deployment:
     uses: boom-astro/boom/.github/workflows/deploy.yaml@refs/heads/main
+    # Reusable workflows don't receive the caller's repository/org secrets unless
+    # passed. The deploy job references many secrets.* values, so inherit them.
+    secrets: inherit
     with:
       # If triggered manually, use the input version. If triggered by a release, use the release tag ref.
       tag_ref: ${{ github.event.inputs.version || github.ref }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,15 +3,10 @@ name: Deploy to production
 concurrency: production
 
 on:
-  release:
-    types:
-      - published
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      version:
-        description: "Version tag to deploy (must match 'v*')"
+      tag_ref:
         required: true
-        default: "v0.0.0"
         type: string
 
 jobs:
@@ -123,7 +118,7 @@ jobs:
       - name: Validate and normalize deployment tag
         id: deploy_tag
         env:
-          RAW_DEPLOY_REF: ${{ github.event.inputs.version || github.ref }}
+          RAW_DEPLOY_REF: ${{ inputs.tag_ref }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
We can lock down the production self-hosted runner further to only allow running certain workflow at certain refs, but we need to split in two since our release trigger will be a new ref (a tag) each time.