### PR TITLE
SCRUM-39:Adding setup for Groq API call

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,12 @@ BOOM_GPU__DEVICE_IDS=0 # Comma-separated list of GPU device IDs to use (e.g., "0
 # Babamul configuration
 BOOM_BABAMUL__ENABLED=false
 BOOM_BABAMUL__WEBAPP_URL="http://localhost:5173"
+# Default Groq API key for natural-language filter generation. Used when a user
+# has not saved their own key in their profile. Leave empty to require users to
+# bring their own key.
+BOOM_BABAMUL__GROQ_API_KEY=
+# Groq model used for filter generation (defaults to llama-3.3-70b-versatile).
+BOOM_BABAMUL__GROQ_MODEL=llama-3.3-70b-versatile
 
 # Email configuration (for sending notifications and Babamul activation codes)
 # Set EMAIL_ENABLED=true to send activation codes via email

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,8 @@ babamul:
   enabled: false # Set via BOOM_BABAMUL__ENABLED environment variable
   webapp_url: # Set via BOOM_BABAMUL__WEBAPP_URL environment variable
   retention_days: 3
+  groq_api_key: # Default Groq API key for LLM filter generation. Set via BOOM_BABAMUL__GROQ_API_KEY
+  groq_model: llama-3.3-70b-versatile # Groq model for LLM filter generation
 gpu:
   enabled: false # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -110,6 +110,9 @@ pub struct ApiDoc;
         routes::babamul::stats::collections::get_collection_stats,
         routes::babamul::stats::kafka::get_kafka_stats,
         routes::babamul::stats::nightly::get_nightly_stats,
+        routes::babamul::llm::post_llm_filter,
+        routes::babamul::llm::put_groq_key,
+        routes::babamul::llm::delete_groq_key,
     ),
     security(
         ("babamul_jwt_token" = [])

--- a/src/api/routes/babamul/llm.rs
+++ b/src/api/routes/babamul/llm.rs
@@ -1,0 +1,442 @@
+//! Natural-language → filter-tree generation backed by Groq.
+//!
+//! The browser used to call the Groq API directly with a key baked into the
+//! frontend bundle. That exposed the key to every visitor, so the call now goes
+//! through this authenticated endpoint: the system prompt is built server-side,
+//! and the Groq key is resolved from the user's saved key (if any) or the
+//! server's default key (`BOOM_BABAMUL__GROQ_API_KEY`).
+
+use super::{decrypt_password, encrypt_password, BabamulSurvey, BabamulUser};
+use crate::api::models::response;
+use crate::conf::AppConfig;
+use actix_web::{post, put, web, HttpResponse};
+use mongodb::{bson::doc, Collection, Database};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+const GROQ_API_URL: &str = "https://api.groq.com/openai/v1/chat/completions";
+
+/// Maximum length of a natural-language query, in characters.
+const MAX_QUERY_LEN: usize = 2000;
+
+/// Build the system prompt that instructs Groq to emit a block/condition
+/// filter tree. Ported from the frontend `llmFilterAgent.ts` so the prompt
+/// (and the model) are controlled server-side.
+fn build_system_prompt(survey: BabamulSurvey) -> String {
+    // Shared output-format contract, identical across surveys.
+    let format = r#"Given a natural language description of what alerts a user wants to find, generate a filter in the following JSON format.
+
+## Output Format
+
+Return ONLY a JSON array (no markdown, no explanation). The array contains filter blocks:
+
+[
+  {
+    "id": "root-block",
+    "category": "block",
+    "operator": "and",
+    "children": [...]
+  }
+]
+
+Each child is either a **condition**:
+{
+  "id": "cond-1",
+  "category": "condition",
+  "field": "candidate.drb",
+  "operator": "$gt",
+  "value": 0.5
+}
+
+Or a **nested block** (for OR logic):
+{
+  "id": "block-2",
+  "category": "block",
+  "operator": "or",
+  "children": [...]
+}
+
+## Available Operators
+- "$eq" (equals)
+- "$ne" (not equal)
+- "$gt" (greater than)
+- "$gte" (greater than or equal)
+- "$lt" (less than)
+- "$lte" (less than or equal)
+- "$in" (in list)
+- "$exists" (field exists, value should be true/false)"#;
+
+    let rules = r#"## Rules
+- Always generate unique IDs for each node (use cond-1, cond-2, block-2 etc.)
+- Always include at least one condition
+- Use "and" as the default operator for the root block
+- Do NOT add any date/time/observation-window filters (e.g. candidate.jd). The time range is set separately by the user via dedicated Start JD / End JD controls.
+- Return ONLY the JSON array, nothing else"#;
+
+    match survey {
+        BabamulSurvey::Ztf => format!(
+            r#"You are an astronomical alert filter builder for the Zwicky Transient Facility (ZTF).
+
+{format}
+
+## Available Fields
+
+### Candidate
+- candidate.drb (number)
+- candidate.magpsf (number)
+- candidate.sgscore1 (number)
+- candidate.ndethist (number)
+- candidate.isdiffpos (boolean)
+
+### Classifications
+- classifications.acai_h (number)
+- classifications.acai_n (number)
+- classifications.acai_v (number)
+- classifications.acai_o (number)
+- classifications.acai_b (number)
+- classifications.btsbot (number)
+
+### Properties
+- properties.rock (boolean)
+- properties.star (boolean)
+- properties.near_brightstar (boolean)
+- properties.stationary (boolean)
+
+### Coordinates
+- coordinates.l (number)
+- coordinates.b (number)
+
+## Common ZTF Conventions
+- candidate.drb: deep-learning real-bogus score (0-1). Higher = more likely real. Use > 0.5 for real alerts.
+- candidate.magpsf: PSF magnitude. Brighter objects have LOWER magnitude. "brighter than 18" means < 18.
+- candidate.sgscore1: star-galaxy score. 0 = galaxy, 1 = star.
+- candidate.ndethist: number of spatially coincident detections. Low values = new/recent.
+- candidate.isdiffpos: positive difference image detection (true for real transients).
+- classifications.acai_h: ACAI "human-interesting" transient score (0-1). Higher = more likely a real transient interesting to humans. Best indicator for supernovae.
+- classifications.acai_n: ACAI "nuclear" transient score (0-1). Higher = near galaxy nucleus (AGN-like).
+- classifications.acai_v: ACAI "variable star" score (0-1). Higher = likely variable star.
+- classifications.acai_o: ACAI "orphan" transient score (0-1). Higher = hostless/orphan transient.
+- classifications.acai_b: ACAI "bogus" score (0-1). Higher = likely bogus/artifact.
+- classifications.btsbot: BTS Bot real transient score (0-1). Higher = more likely a real transient.
+- properties.rock: boolean. true = likely a solar system object (asteroid).
+- properties.star: boolean. true = likely a star, not a transient.
+- properties.near_brightstar: boolean. true = near a bright star (higher artifact risk).
+- properties.stationary: boolean. true = not moving (non-asteroid).
+- coordinates.l: galactic longitude in degrees.
+- coordinates.b: galactic latitude in degrees. |b| < 15 = galactic plane (higher stellar contamination).
+
+{rules}
+- For "real transients" or "supernovae", include classifications.acai_h > 0.5 AND properties.rock = false AND properties.star = false
+- For "bright transients", combine classifications.acai_h > 0.5 with candidate.magpsf < [threshold]
+- For filtering out bogus, use classifications.acai_b < 0.5
+- For avoiding the galactic plane, use coordinates.b > 15 OR coordinates.b < -15"#
+        ),
+        BabamulSurvey::Lsst => format!(
+            r#"You are an astronomical alert filter builder for the Vera C. Rubin Observatory LSST survey.
+
+{format}
+
+## Available Fields
+
+### Candidate
+- candidate.magpsf (number)
+- candidate.reliability (number)
+
+### Properties
+- properties.rock (boolean)
+- properties.star (boolean)
+- properties.stationary (boolean)
+
+### Coordinates
+- coordinates.l (number)
+- coordinates.b (number)
+
+## Common LSST Conventions
+- candidate.magpsf: PSF magnitude. Brighter objects have LOWER magnitude. "brighter than 22" means < 22.
+- candidate.reliability: real-bogus score (0-1). Higher = more likely real. Use > 0.5 for real alerts.
+- properties.rock: boolean. true = likely a solar system object (asteroid).
+- properties.star: boolean. true = likely a star, not a transient.
+- properties.stationary: boolean. true = not moving (non-asteroid).
+- coordinates.b: galactic latitude in degrees. |b| < 15 = galactic plane (higher stellar contamination).
+
+{rules}"#
+        ),
+    }
+}
+
+/// Resolve the Groq API key to use for this request: the user's own saved key
+/// takes precedence, otherwise the server's default key. Returns a user-facing
+/// error message when neither is available.
+fn resolve_groq_key(user: &BabamulUser, config: &AppConfig) -> Result<String, String> {
+    if let Some(encrypted) = &user.groq_api_key_encrypted {
+        return decrypt_password(encrypted, config.api.auth.get_hashed_secret_key())
+            .map_err(|e| format!("failed to decrypt saved Groq API key: {}", e));
+    }
+    match &config.babamul.groq_api_key {
+        Some(key) if !key.trim().is_empty() => Ok(key.clone()),
+        _ => Err(
+            "No Groq API key is configured. Add your own Groq API key in your profile to use \
+             natural-language filter generation."
+                .to_string(),
+        ),
+    }
+}
+
+/// Strip a markdown code fence (```json ... ```) if the model wrapped its output.
+fn strip_code_fence(content: &str) -> &str {
+    let trimmed = content.trim();
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        // Drop an optional language tag on the first line, then the trailing fence.
+        let rest = rest.strip_prefix("json").unwrap_or(rest);
+        let rest = rest.trim_start_matches('\n');
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
+    }
+    trimmed
+}
+
+#[derive(Deserialize, Clone, ToSchema)]
+pub struct LlmFilterRequest {
+    /// Natural-language description of the alerts the user wants to find.
+    pub query: String,
+    /// Survey the filter targets (ZTF or LSST).
+    pub survey: BabamulSurvey,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct LlmFilterResponse {
+    /// The generated block/condition filter tree.
+    pub filters: serde_json::Value,
+}
+
+/// Generate a filter tree from a natural-language query using Groq.
+#[utoipa::path(
+    post,
+    path = "/babamul/llm/filter",
+    request_body = LlmFilterRequest,
+    responses(
+        (status = 200, description = "Filter generated successfully", body = LlmFilterResponse),
+        (status = 400, description = "Invalid request or no Groq key configured"),
+        (status = 401, description = "Unauthorized"),
+        (status = 502, description = "Groq API error")
+    ),
+    tags=["Babamul"]
+)]
+#[post("/llm/filter")]
+pub async fn post_llm_filter(
+    current_user: Option<web::ReqData<BabamulUser>>,
+    config: web::Data<AppConfig>,
+    body: web::Json<LlmFilterRequest>,
+) -> HttpResponse {
+    let current_user = match current_user {
+        Some(user) => user,
+        None => return HttpResponse::Unauthorized().body("Unauthorized"),
+    };
+
+    let query = body.query.trim();
+    if query.is_empty() {
+        return response::bad_request("query cannot be empty");
+    }
+    if query.len() > MAX_QUERY_LEN {
+        return response::bad_request(&format!(
+            "query cannot exceed {} characters",
+            MAX_QUERY_LEN
+        ));
+    }
+
+    let api_key = match resolve_groq_key(&current_user, &config) {
+        Ok(key) => key,
+        Err(msg) => return response::bad_request(&msg),
+    };
+
+    let system_prompt = build_system_prompt(body.survey);
+    let request_body = serde_json::json!({
+        "model": config.babamul.groq_model,
+        "messages": [
+            { "role": "system", "content": system_prompt },
+            { "role": "user", "content": query },
+        ],
+        "temperature": 0.1,
+        "max_tokens": 2048,
+    });
+
+    let client = reqwest::Client::new();
+    let groq_response = match client
+        .post(GROQ_API_URL)
+        .bearer_auth(&api_key)
+        .json(&request_body)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::error!("Failed to reach Groq API: {}", e);
+            return HttpResponse::BadGateway().json(response::ApiResponseBody::error(
+                "Failed to reach the Groq API. Please try again.",
+            ));
+        }
+    };
+
+    let status = groq_response.status();
+    let raw = groq_response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        tracing::warn!("Groq API returned {}: {}", status, raw);
+        // Surface auth/quota problems with the user's own key clearly, but do
+        // not echo the raw provider body (it can contain key fragments).
+        let msg = if status.as_u16() == 401 {
+            "Groq rejected the API key. Check the key saved in your profile."
+        } else if status.as_u16() == 429 {
+            "Groq rate limit reached. Please wait a moment and try again."
+        } else {
+            "Groq API error while generating the filter."
+        };
+        return HttpResponse::BadGateway().json(response::ApiResponseBody::error(msg));
+    }
+
+    let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("Failed to parse Groq response envelope: {}", e);
+            return HttpResponse::BadGateway()
+                .json(response::ApiResponseBody::error("Malformed response from Groq."));
+        }
+    };
+
+    let content = parsed
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("")
+        .trim();
+    if content.is_empty() {
+        return HttpResponse::BadGateway()
+            .json(response::ApiResponseBody::error("Empty response from the LLM."));
+    }
+
+    let json_str = strip_code_fence(content);
+    let filters: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("LLM returned non-JSON filter content: {}", e);
+            return response::bad_request(
+                "The LLM did not return a valid filter. Try rephrasing your description.",
+            );
+        }
+    };
+
+    // Basic shape validation: a non-empty array whose first element looks like a node.
+    let valid = filters
+        .as_array()
+        .and_then(|arr| arr.first())
+        .map(|first| first.get("id").is_some() && first.get("category").is_some())
+        .unwrap_or(false);
+    if !valid {
+        return response::bad_request(
+            "The LLM returned an invalid filter structure. Try rephrasing your description.",
+        );
+    }
+
+    response::ok("filter generated successfully", serde_json::json!({ "filters": filters }))
+}
+
+#[derive(Deserialize, Clone, ToSchema)]
+pub struct SetGroqKeyRequest {
+    /// The user's Groq API key (e.g. "gsk_...").
+    pub groq_api_key: String,
+}
+
+/// Save (or replace) the authenticated user's Groq API key.
+#[utoipa::path(
+    put,
+    path = "/babamul/profile/groq-key",
+    request_body = SetGroqKeyRequest,
+    responses(
+        (status = 200, description = "Groq API key saved"),
+        (status = 400, description = "Invalid key"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal server error")
+    ),
+    tags=["Babamul"]
+)]
+#[put("/profile/groq-key")]
+pub async fn put_groq_key(
+    db: web::Data<Database>,
+    config: web::Data<AppConfig>,
+    current_user: Option<web::ReqData<BabamulUser>>,
+    body: web::Json<SetGroqKeyRequest>,
+) -> HttpResponse {
+    let current_user = match current_user {
+        Some(user) => user,
+        None => return HttpResponse::Unauthorized().body("Unauthorized"),
+    };
+
+    let key = body.groq_api_key.trim();
+    if key.is_empty() {
+        return response::bad_request("Groq API key cannot be empty");
+    }
+    // Groq keys are short opaque strings; guard against obviously bad input.
+    if key.len() > 200 {
+        return response::bad_request("Groq API key is too long");
+    }
+
+    let encrypted = match encrypt_password(key, config.api.auth.get_hashed_secret_key()) {
+        Ok(enc) => enc,
+        Err(e) => {
+            tracing::error!("Failed to encrypt Groq API key: {}", e);
+            return response::internal_error("Failed to encrypt Groq API key");
+        }
+    };
+
+    let collection: Collection<BabamulUser> = db.collection("babamul_users");
+    match collection
+        .update_one(
+            doc! { "_id": &current_user.id },
+            doc! { "$set": { "groq_api_key_encrypted": encrypted } },
+        )
+        .await
+    {
+        Ok(_) => response::ok_no_data("Groq API key saved successfully"),
+        Err(e) => {
+            tracing::error!("Failed to save Groq API key: {}", e);
+            response::internal_error("Failed to save Groq API key")
+        }
+    }
+}
+
+/// Remove the authenticated user's saved Groq API key.
+#[utoipa::path(
+    delete,
+    path = "/babamul/profile/groq-key",
+    responses(
+        (status = 200, description = "Groq API key removed"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal server error")
+    ),
+    tags=["Babamul"]
+)]
+#[actix_web::delete("/profile/groq-key")]
+pub async fn delete_groq_key(
+    db: web::Data<Database>,
+    current_user: Option<web::ReqData<BabamulUser>>,
+) -> HttpResponse {
+    let current_user = match current_user {
+        Some(user) => user,
+        None => return HttpResponse::Unauthorized().body("Unauthorized"),
+    };
+
+    let collection: Collection<BabamulUser> = db.collection("babamul_users");
+    match collection
+        .update_one(
+            doc! { "_id": &current_user.id },
+            doc! { "$unset": { "groq_api_key_encrypted": "" } },
+        )
+        .await
+    {
+        Ok(_) => response::ok_no_data("Groq API key removed successfully"),
+        Err(e) => {
+            tracing::error!("Failed to remove Groq API key: {}", e);
+            response::internal_error("Failed to remove Groq API key")
+        }
+    }
+}

--- a/src/api/routes/babamul/mod.rs
+++ b/src/api/routes/babamul/mod.rs
@@ -1,3 +1,4 @@
+pub mod llm;
 pub mod stats;
 pub mod surveys;
 pub mod tokens;
@@ -174,6 +175,8 @@ pub struct BabamulUser {
     pub password_reset_token_hash: Option<String>, // SHA-256 hash of the password reset token
     pub password_reset_token_expires_at: Option<i64>, // Unix timestamp expiry for the reset token
     pub password_last_changed_at: Option<i64>, // Unix timestamp of the last successful password reset
+    #[serde(default)]
+    pub groq_api_key_encrypted: Option<String>, // User's own Groq API key (encrypted with server key, AES-256-GCM)
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -184,6 +187,9 @@ pub struct BabamulUserPublic {
     pub username: String,
     pub email: String,
     pub created_at: i64, // Unix timestamp
+    /// Whether the user has saved their own Groq API key for LLM filter generation.
+    #[serde(default)]
+    pub has_groq_api_key: bool,
 }
 
 impl From<BabamulUser> for BabamulUserPublic {
@@ -193,6 +199,7 @@ impl From<BabamulUser> for BabamulUserPublic {
             username: user.username,
             email: user.email,
             created_at: user.created_at,
+            has_groq_api_key: user.groq_api_key_encrypted.is_some(),
         }
     }
 }
@@ -320,6 +327,7 @@ pub async fn post_babamul_signup(
                 password_reset_token_hash: None,
                 password_reset_token_expires_at: None,
                 password_last_changed_at: None,
+                groq_api_key_encrypted: None,
             };
 
             // Note: Kafka credentials will be created on demand via /babamul/kafka-credentials endpoint

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -113,7 +113,10 @@ async fn main() -> std::io::Result<()> {
                     .service(routes::babamul::stats::get_kafka_stats)
                     .service(routes::babamul::tokens::get_tokens)
                     .service(routes::babamul::tokens::post_token)
-                    .service(routes::babamul::tokens::delete_token),
+                    .service(routes::babamul::tokens::delete_token)
+                    .service(routes::babamul::llm::post_llm_filter)
+                    .service(routes::babamul::llm::put_groq_key)
+                    .service(routes::babamul::llm::delete_groq_key),
             )
         }
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -569,6 +569,13 @@ pub struct BabamulConfig {
     /// Minimum number of minutes that must elapse between successive password resets (default: 15)
     #[serde(default = "default_password_reset_cooldown_minutes")]
     pub password_reset_cooldown_minutes: u32,
+    /// Default Groq API key used for natural-language filter generation when a
+    /// user has not saved their own key. Set via BOOM_BABAMUL__GROQ_API_KEY.
+    #[serde(default)]
+    pub groq_api_key: Option<String>,
+    /// Groq model used for natural-language filter generation.
+    #[serde(default = "default_groq_model")]
+    pub groq_model: String,
 }
 
 impl Default for BabamulConfig {
@@ -578,6 +585,8 @@ impl Default for BabamulConfig {
             webapp_url: None,
             retention_days: default_babamul_retention_days(),
             password_reset_cooldown_minutes: default_password_reset_cooldown_minutes(),
+            groq_api_key: None,
+            groq_model: default_groq_model(),
         }
     }
 }
@@ -588,6 +597,10 @@ fn default_babamul_retention_days() -> u32 {
 
 fn default_password_reset_cooldown_minutes() -> u32 {
     15
+}
+
+fn default_groq_model() -> String {
+    "llama-3.3-70b-versatile".to_string()
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -49,6 +49,7 @@ mod tests {
                 password_reset_token_hash: None,
                 password_reset_token_expires_at: None,
                 password_last_changed_at: None,
+                groq_api_key_encrypted: None,
             };
 
             let babamul_users_collection: mongodb::Collection<
@@ -2747,6 +2748,7 @@ mod tests {
             password_reset_token_hash: None,
             password_reset_token_expires_at: None,
             password_last_changed_at: None,
+            groq_api_key_encrypted: None,
         })
         .await
         .unwrap();
@@ -2814,6 +2816,7 @@ mod tests {
             password_reset_token_hash: None,
             password_reset_token_expires_at: None,
             password_last_changed_at: None,
+            groq_api_key_encrypted: None,
         })
         .await
         .unwrap();
@@ -2858,6 +2861,7 @@ mod tests {
             password_last_changed_at: Some(
                 now - config.babamul.password_reset_cooldown_minutes as i64 * 30,
             ),
+            groq_api_key_encrypted: None,
         })
         .await
         .unwrap();
@@ -2951,6 +2955,7 @@ mod tests {
                 password_reset_token_hash: None,
                 password_reset_token_expires_at: None,
                 password_last_changed_at: None,
+                groq_api_key_encrypted: None,
             };
 
         let mut ids_to_cleanup: Vec<String> = Vec::new();


### PR DESCRIPTION
Move Groq LLM filter generation server-side                                                                                                                                        
                                                                                                                                                                                     
  Summary                                                                                                                                                                            
                                                                                                                                                                                     
Babamul's natural-language → alert-filter feature previously called the Groq API directly from the browser, with the API key baked into the frontend bundle — exposing it to every visitor. This PR moves that call behind an authenticated backend endpoint, builds the LLM prompt server-side, and adds encrypted per-user key storage with a shared server fallback key.                          

What changed                                                                                                                                                                       
                                                                                                                                                                                     
- New authenticated endpoints (/babamul scope):                                                                                                                                    
- POST /babamul/llm/filter — generates a validated filter tree from a NL query for a given survey (ZTF/LSST)                                                                     
- PUT /babamul/profile/groq-key — save a user's own Groq key                                                                                                                     
- DELETE /babamul/profile/groq-key — remove it                                                                                                                                   
- Key handling: user keys are encrypted (AES-256-GCM, reusing existing crypto helpers) and stored on the user document; a server default key (BOOM_BABAMUL__GROQ_API_KEY) is used  
as fallback. Per-user key takes precedence.                                                                                                                                        
- Prompt moved server-side: the system prompt (ported from the old llmFilterAgent.ts) and model are now controlled by the backend.                                                 
- Data model: added groq_api_key_encrypted to the user (backward-compatible via #[serde(default)], no migration needed) and exposed has_groq_api_key on the public profile.        
- Config: BOOM_BABAMUL__GROQ_API_KEY and BOOM_BABAMUL__GROQ_MODEL (defaults to llama-3.3-70b-versatile), documented in config.yaml and .env.example.                               
- Docs & tests: endpoints registered in the OpenAPI (BabamulApiDoc) spec; test fixtures updated.                                                                                   
                                                                                                                                                                                   
  Security notes                                                                                                                                                                     
                                                                                                                                                                                     
- API key no longer shipped to the browser                                                                                                                                         
- User keys stored encrypted at rest, never returned in plaintext                                                                                                                  
- Input limits (query/key length), markdown-fence stripping, and filter shape validation                                                                                           
- Provider error bodies are not echoed back to clients (avoids leaking key fragments)                                                                                              
                                            