### PR TITLE
Make Kafka consumers self-roll over via topic-pattern subscription

### DIFF
--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -402,10 +402,8 @@ pub trait AlertConsumer: Sized {
     /// `^` are interpreted by librdkafka as regular expressions, so the consumer
     /// auto-discovers each new day's topic (e.g. `ztf_20260629_programid1`) and
     /// rolls over on its own without restarting. Surveys with a single static
-    /// topic (e.g. LSST) return literal topic names instead.
-    ///
-    /// Defaults to the regex form `^<survey>_<8 digits>...$`; overridden per
-    /// survey where the topic layout differs.
+    /// topic (e.g. LSST) return literal topic names instead. Each survey
+    /// implements this per its topic layout.
     fn topic_patterns(&self) -> Vec<String>;
     fn output_queue(&self) -> String;
     fn survey(&self) -> &'static str;
@@ -564,20 +562,22 @@ fn seek_to_timestamp(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResult<
     Ok(())
 }
 
-// Position freshly-assigned partitions for the long-running consumer: those with
-// a committed offset resume from it; the rest are resolved by `timestamp_ms`
+// Position the given `targets` partitions for the long-running consumer: those
+// with a committed offset resume from it; the rest are resolved by `timestamp_ms`
 // (an old day's topic has nothing at/after it -> seek to end/skip; today's and
-// any newly-created daily topic -> its start). Committed partitions are never
-// re-sought, so this is safe to run on every (re)assignment.
-fn seek_resume_or_skip(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResult<()> {
-    let assignment = consumer.assignment()?;
-    if assignment.count() == 0 {
+// any newly-created daily topic -> its start).
+fn position_partitions(
+    consumer: &BaseConsumer,
+    targets: &TopicPartitionList,
+    timestamp_ms: i64,
+) -> KafkaResult<()> {
+    if targets.count() == 0 {
         return Ok(());
     }
     let committed = consumer.committed(KAFKA_TIMEOUT_SECS)?;
 
     let mut to_resolve = TopicPartitionList::new();
-    for elem in assignment.elements() {
+    for elem in targets.elements() {
         match committed
             .find_partition(elem.topic(), elem.partition())
             .map(|c| c.offset())
@@ -610,6 +610,36 @@ fn seek_resume_or_skip(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResul
             _ => rdkafka::Offset::End,
         };
         consumer.seek(elem.topic(), elem.partition(), offset, KAFKA_TIMEOUT_SECS)?;
+    }
+    Ok(())
+}
+
+// Position only partitions that have appeared in the assignment since the last
+// call, recording them in `positioned`. Positioning each partition exactly once
+// (rather than re-seeking the whole assignment whenever it changes) means a
+// still-active partition is never rewound to its lagging committed offset, and a
+// same-size membership swap (which a count check would miss) is still handled.
+// A genuinely-new daily topic is correctly picked up here; an old retained topic
+// re-assigned mid-run is skipped. (A brand-new partition consumed between poll
+// and this check would be rewound once here — a bounded, idempotent replay.)
+fn reposition_new_partitions(
+    consumer: &BaseConsumer,
+    timestamp_ms: i64,
+    positioned: &mut std::collections::HashSet<(String, i32)>,
+) -> KafkaResult<()> {
+    let assignment = consumer.assignment()?;
+    let mut fresh = TopicPartitionList::new();
+    for elem in assignment.elements() {
+        if !positioned.contains(&(elem.topic().to_string(), elem.partition())) {
+            fresh.add_partition_offset(elem.topic(), elem.partition(), rdkafka::Offset::Invalid)?;
+        }
+    }
+    if fresh.count() == 0 {
+        return Ok(());
+    }
+    position_partitions(consumer, &fresh, timestamp_ms)?;
+    for elem in fresh.elements() {
+        positioned.insert((elem.topic().to_string(), elem.partition()));
     }
     Ok(())
 }
@@ -715,6 +745,9 @@ pub async fn consumer(
     // Wait for initial assignment
     debug!("Waiting for partition assignment...");
 
+    // Partitions already positioned (prod path only); see reposition_new_partitions.
+    let mut positioned: std::collections::HashSet<(String, i32)> = std::collections::HashSet::new();
+
     // Poll once to trigger rebalance and get assignment
     loop {
         match consumer.poll(KAFKA_TIMEOUT_SECS) {
@@ -725,7 +758,7 @@ pub async fn consumer(
                     seek_to_timestamp(&consumer, timestamp * 1000)?;
                 } else {
                     // Resume committed partitions; skip old / start today otherwise.
-                    seek_resume_or_skip(&consumer, timestamp * 1000)?;
+                    reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
                 }
                 break;
             }
@@ -794,24 +827,14 @@ pub async fn consumer(
 
     debug!("Starting Kafka consumer loop...");
 
-    // Track the assignment size so we reposition when it grows: discovering the
-    // next day's topic (or a late cooperative assignment) brings in new
-    // partitions, and seek_resume_or_skip skips any old retained topic among them
-    // while leaving committed partitions in place.
-    let mut assignment_count = consumer.assignment().map(|a| a.count()).unwrap_or(0);
-
     // Process the rest normally
     loop {
-        if !exit_on_eof {
-            let count = consumer
-                .assignment()
-                .map(|a| a.count())
-                .unwrap_or(assignment_count);
-            if count != assignment_count {
-                debug!("assignment changed ({assignment_count} -> {count}), repositioning");
-                seek_resume_or_skip(&consumer, timestamp * 1000)?;
-                assignment_count = count;
-            }
+        // Pick up newly-assigned partitions (e.g. the next day's topic rolling
+        // over). Kept off the per-message hot path: checked once per 1000
+        // messages and whenever the poll goes idle (rollover happens in the
+        // quiet gap between nights, so the idle check catches it promptly).
+        if !exit_on_eof && total % 1000 == 0 {
+            reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
         }
         if max_in_queue > 0 && total % 1000 == 0 {
             loop {
@@ -873,6 +896,8 @@ pub async fn consumer(
                     info!("No more messages, exiting consumer {}", id);
                     break;
                 }
+                // Idle: catch a topic that has just rolled over.
+                reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
             }
         }
     }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -395,7 +395,18 @@ pub enum ConsumerError {
 
 #[async_trait::async_trait]
 pub trait AlertConsumer: Sized {
+    /// Concrete topic name(s) for a specific date. Used by the producer side and
+    /// by the one-shot (`exit_on_eof`) drain path.
     fn topic_names(&self, timestamp: i64) -> Vec<String>;
+    /// Subscription entries for the long-running consumer. Entries beginning with
+    /// `^` are interpreted by librdkafka as regular expressions, so the consumer
+    /// auto-discovers each new day's topic (e.g. `ztf_20260629_programid1`) and
+    /// rolls over on its own without restarting. Surveys with a single static
+    /// topic (e.g. LSST) return literal topic names instead.
+    ///
+    /// Defaults to the regex form `^<survey>_<8 digits>...$`; overridden per
+    /// survey where the topic layout differs.
+    fn topic_patterns(&self) -> Vec<String>;
     fn output_queue(&self) -> String;
     fn survey(&self) -> &'static str;
     #[instrument(skip(self))]
@@ -432,7 +443,15 @@ pub trait AlertConsumer: Sized {
         let config = AppConfig::from_path(config_path)?;
         let survey = self.survey();
 
-        let topics = topics.unwrap_or_else(|| self.topic_names(timestamp));
+        // Prod: subscribe to topic pattern(s) so new daily topics auto-roll over.
+        // exit_on_eof (tests/dev): target the concrete topic for the date.
+        let subscription = topics.unwrap_or_else(|| {
+            if exit_on_eof {
+                self.topic_names(timestamp)
+            } else {
+                self.topic_patterns()
+            }
+        });
         let kafka_config = match kafka_config {
             Some(cfg) => cfg,
             None => config
@@ -454,14 +473,14 @@ pub trait AlertConsumer: Sized {
 
         let mut handles = vec![];
         for i in 0..n_threads {
-            let topics = topics.clone();
+            let subscription = subscription.clone();
             let output_queue = self.output_queue();
             let config = config.clone();
             let kafka_config = kafka_config.clone();
             let handle = tokio::spawn(async move {
                 let result = consumer(
                     &i.to_string(),
-                    topics.iter().map(|s| s.as_str()).collect(),
+                    subscription,
                     &output_queue,
                     max_in_queue,
                     timestamp,
@@ -545,11 +564,61 @@ fn seek_to_timestamp(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResult<
     Ok(())
 }
 
+// Position freshly-assigned partitions for the long-running consumer: those with
+// a committed offset resume from it; the rest are resolved by `timestamp_ms`
+// (an old day's topic has nothing at/after it -> seek to end/skip; today's and
+// any newly-created daily topic -> its start). Committed partitions are never
+// re-sought, so this is safe to run on every (re)assignment.
+fn seek_resume_or_skip(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResult<()> {
+    let assignment = consumer.assignment()?;
+    if assignment.count() == 0 {
+        return Ok(());
+    }
+    let committed = consumer.committed(KAFKA_TIMEOUT_SECS)?;
+
+    let mut to_resolve = TopicPartitionList::new();
+    for elem in assignment.elements() {
+        match committed
+            .find_partition(elem.topic(), elem.partition())
+            .map(|c| c.offset())
+        {
+            Some(rdkafka::Offset::Offset(offset)) => {
+                consumer.seek(
+                    elem.topic(),
+                    elem.partition(),
+                    rdkafka::Offset::Offset(offset),
+                    KAFKA_TIMEOUT_SECS,
+                )?;
+            }
+            _ => {
+                to_resolve.add_partition_offset(
+                    elem.topic(),
+                    elem.partition(),
+                    rdkafka::Offset::Offset(timestamp_ms),
+                )?;
+            }
+        }
+    }
+
+    if to_resolve.count() == 0 {
+        return Ok(());
+    }
+    let resolved = consumer.offsets_for_times(to_resolve, KAFKA_TIMEOUT_SECS)?;
+    for elem in resolved.elements() {
+        let offset = match elem.offset() {
+            rdkafka::Offset::Offset(offset) => rdkafka::Offset::Offset(offset),
+            _ => rdkafka::Offset::End,
+        };
+        consumer.seek(elem.topic(), elem.partition(), offset, KAFKA_TIMEOUT_SECS)?;
+    }
+    Ok(())
+}
+
 // No `#[instrument]` here: this function is the long-lived Kafka poll loop;
 // instrumenting it would funnel every per-message span into one giant trace.
 pub async fn consumer(
     id: &str,
-    topics: Vec<&str>,
+    subscription: Vec<String>,
     output_queue: &str,
     max_in_queue: usize,
     timestamp: i64,
@@ -563,10 +632,10 @@ pub async fn consumer(
     let username = survey_consumer_config.username.clone();
     let password = survey_consumer_config.password.clone();
 
-    let topics = if exit_on_eof {
-        // if exit_on_eof is true, let's only consume from the topics that have messages, and exit if they are all empty
+    let topics: Vec<String> = if exit_on_eof {
+        // One-shot drain: keep only concrete topics that have messages, exit if none.
         let mut non_empty_topics = vec![];
-        for topic in &topics {
+        for topic in &subscription {
             let nb_messages = count_messages(&server, topic)?;
             match nb_messages {
                 Some(0) => {
@@ -580,7 +649,7 @@ pub async fn consumer(
                         "Topic {} has messages, including it for consumer {}",
                         topic, id
                     );
-                    non_empty_topics.push(*topic);
+                    non_empty_topics.push(topic.clone());
                 }
                 None => {
                     info!("Topic {} not found, skipping it for consumer {}", topic, id);
@@ -596,9 +665,9 @@ pub async fn consumer(
         }
         non_empty_topics
     } else {
-        // otherwise, we want to consume from all topics and never exit, even if they are empty at the beginning
-        debug!("exit_on_eof is false, consuming from all topics indefinitely");
-        topics
+        // Long-running: subscribe to the pattern(s); new daily topics roll over automatically.
+        debug!("exit_on_eof is false, consuming indefinitely");
+        subscription
     };
 
     let mut client_config = ClientConfig::new();
@@ -608,9 +677,20 @@ pub async fn consumer(
         .set("bootstrap.servers", &server)
         .set("group.id", &group_id)
         .set("auto.offset.reset", "earliest")
-        // Important: disable automatic offset storage so offsets
-        // can be manually controlled during the seek operation
+        // Manual offset storage so the bootstrap seek isn't clobbered; in the
+        // prod path we store offsets explicitly after each push (see below).
         .set("enable.auto.offset.store", "false");
+
+    if !exit_on_eof {
+        // Long-running consumer: commit stored offsets so restarts/rebalances
+        // resume in place (no replay), and use cooperative-sticky so discovering
+        // the next day's topic only adds its partitions instead of revoking all.
+        client_config
+            .set("enable.auto.commit", "true")
+            .set("partition.assignment.strategy", "cooperative-sticky")
+            // How quickly a newly-created daily topic is discovered and joined.
+            .set("topic.metadata.refresh.interval.ms", "10000");
+    }
 
     if let (Some(username), Some(password)) = (username, password) {
         client_config
@@ -626,9 +706,10 @@ pub async fn consumer(
         .create()
         .inspect_err(as_error!("failed to create consumer"))?;
 
-    // Subscribe to topic(s) - broker will handle partition assignment
+    // Subscribe to topic(s)/pattern(s) - broker handles partition assignment.
+    let topic_refs: Vec<&str> = topics.iter().map(|s| s.as_str()).collect();
     consumer
-        .subscribe(&topics)
+        .subscribe(&topic_refs)
         .inspect_err(as_error!("failed to subscribe to topics"))?;
 
     // Wait for initial assignment
@@ -638,9 +719,14 @@ pub async fn consumer(
     loop {
         match consumer.poll(KAFKA_TIMEOUT_SECS) {
             Some(Ok(_msg)) => {
-                debug!("Received initial message, seeking to timestamp...");
-                // Now seek all assigned partitions to the target timestamp
-                seek_to_timestamp(&consumer, timestamp * 1000)?;
+                debug!("Got initial assignment, positioning partitions...");
+                if exit_on_eof {
+                    // One-shot drain: (re)read from the requested timestamp.
+                    seek_to_timestamp(&consumer, timestamp * 1000)?;
+                } else {
+                    // Resume committed partitions; skip old / start today otherwise.
+                    seek_resume_or_skip(&consumer, timestamp * 1000)?;
+                }
                 break;
             }
             Some(Err(e)) => {
@@ -708,8 +794,25 @@ pub async fn consumer(
 
     debug!("Starting Kafka consumer loop...");
 
+    // Track the assignment size so we reposition when it grows: discovering the
+    // next day's topic (or a late cooperative assignment) brings in new
+    // partitions, and seek_resume_or_skip skips any old retained topic among them
+    // while leaving committed partitions in place.
+    let mut assignment_count = consumer.assignment().map(|a| a.count()).unwrap_or(0);
+
     // Process the rest normally
     loop {
+        if !exit_on_eof {
+            let count = consumer
+                .assignment()
+                .map(|a| a.count())
+                .unwrap_or(assignment_count);
+            if count != assignment_count {
+                debug!("assignment changed ({assignment_count} -> {count}), repositioning");
+                seek_resume_or_skip(&consumer, timestamp * 1000)?;
+                assignment_count = count;
+            }
+        }
         if max_in_queue > 0 && total % 1000 == 0 {
             loop {
                 let nb_in_queue = con
@@ -737,6 +840,13 @@ pub async fn consumer(
                         ALERT_PROCESSED.add(1, &output_error_attrs);
                     })?;
                 trace!("Pushed message to redis");
+                // Mark processed so the periodic auto-commit advances the offset
+                // (only the prod path commits; the drain path never stores).
+                if !exit_on_eof {
+                    if let Err(error) = consumer.store_offset_from_message(&message) {
+                        log_error!(error, "failed to store offset");
+                    }
+                }
                 ALERT_PROCESSED.add(1, &ok_attrs);
                 total += 1;
                 if total % 1000 == 0 {

--- a/src/kafka/decam.rs
+++ b/src/kafka/decam.rs
@@ -26,6 +26,13 @@ impl AlertConsumer for DecamAlertConsumer {
         let date = chrono::DateTime::from_timestamp(timestamp, 0).unwrap();
         vec![format!("decam_{}_programid{}", date.format("%Y%m%d"), 1)]
     }
+    fn topic_patterns(&self) -> Vec<String> {
+        // Regex matching any date and program id — librdkafka auto-joins new
+        // daily topics. (DECAM only produces programid1 today, but this keeps
+        // the consumer from being pinned to it.) librdkafka's matcher is
+        // POSIX/Thompson-NFA: use `[0-9]+`, not `\d`.
+        vec![r"^decam_[0-9]+_programid[0-9]+$".to_string()]
+    }
     fn output_queue(&self) -> String {
         self.output_queue.clone()
     }

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -29,6 +29,11 @@ impl AlertConsumer for LsstAlertConsumer {
             vec!["lsst-alerts-v11".to_string()]
         }
     }
+    fn topic_patterns(&self) -> Vec<String> {
+        // LSST uses a single static topic (not date-partitioned), so there is
+        // nothing to roll over: subscribe to the literal topic name.
+        self.topic_names(0)
+    }
     fn output_queue(&self) -> String {
         self.output_queue.clone()
     }

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -4,7 +4,9 @@ mod lsst;
 mod winter;
 mod ztf;
 
-pub use base::{count_messages, delete_topic, initialize_topic, AlertConsumer, AlertProducer};
+pub use base::{
+    consumer, count_messages, delete_topic, initialize_topic, AlertConsumer, AlertProducer,
+};
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;
 pub use winter::{WinterAlertConsumer, WinterAlertProducer};

--- a/src/kafka/winter.rs
+++ b/src/kafka/winter.rs
@@ -27,6 +27,11 @@ impl AlertConsumer for WinterAlertConsumer {
         let date = chrono::DateTime::from_timestamp(timestamp, 0).unwrap();
         vec![format!("winter_{}", date.format("%Y%m%d"))]
     }
+    fn topic_patterns(&self) -> Vec<String> {
+        // Regex matching any date — librdkafka auto-joins new daily topics.
+        // librdkafka's matcher is POSIX/Thompson-NFA: use `[0-9]+`, not `\d`.
+        vec![r"^winter_[0-9]+$".to_string()]
+    }
     fn output_queue(&self) -> String {
         self.output_queue.clone()
     }

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -39,6 +39,19 @@ impl AlertConsumer for ZtfAlertConsumer {
             .map(|program_id| format!("ztf_{}_programid{}", date.format("%Y%m%d"), program_id))
             .collect()
     }
+    fn topic_patterns(&self) -> Vec<String> {
+        // Regex matching any date for the selected program id(s), e.g.
+        // ^ztf_[0-9]+_programid(1|2)$ — librdkafka auto-joins new daily topics.
+        // NB: librdkafka's matcher is POSIX/Thompson-NFA, so only basic
+        // constructs are used (no `\d`, no `{n}` bounded repetition).
+        let ids = self
+            .program_ids
+            .iter()
+            .map(|program_id| program_id.to_string())
+            .collect::<Vec<_>>()
+            .join("|");
+        vec![format!(r"^ztf_[0-9]+_programid({})$", ids)]
+    }
     fn output_queue(&self) -> String {
         self.output_queue.clone()
     }

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -44,12 +44,17 @@ impl AlertConsumer for ZtfAlertConsumer {
         // ^ztf_[0-9]+_programid(1|2)$ — librdkafka auto-joins new daily topics.
         // NB: librdkafka's matcher is POSIX/Thompson-NFA, so only basic
         // constructs are used (no `\d`, no `{n}` bounded repetition).
-        let ids = self
-            .program_ids
-            .iter()
-            .map(|program_id| program_id.to_string())
-            .collect::<Vec<_>>()
-            .join("|");
+        let ids = if self.program_ids.is_empty() {
+            // Empty selection would otherwise yield `programid()`, matching
+            // nothing; fall back to any program id.
+            "[0-9]+".to_string()
+        } else {
+            self.program_ids
+                .iter()
+                .map(|program_id| program_id.to_string())
+                .collect::<Vec<_>>()
+                .join("|")
+        };
         vec![format!(r"^ztf_[0-9]+_programid({})$", ids)]
     }
     fn output_queue(&self) -> String {

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -316,3 +316,177 @@ async fn test_produce_when_data_does_not_exist() {
         .unwrap();
     assert_eq!(message_count, limit);
 }
+
+/// Poll the redis output queue until every payload in `expected` has been seen,
+/// returning the full set of payloads observed (so callers can also assert that
+/// unwanted payloads are absent). Panics on timeout.
+async fn wait_for_payloads(
+    con: &mut redis::aio::MultiplexedConnection,
+    queue: &str,
+    expected: &[String],
+    timeout: std::time::Duration,
+) -> std::collections::HashSet<String> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let items: Vec<Vec<u8>> = con.lrange(queue, 0, -1).await.unwrap_or_default();
+        let seen: std::collections::HashSet<String> = items
+            .iter()
+            .map(|b| String::from_utf8_lossy(b).to_string())
+            .collect();
+        if expected.iter().all(|e| seen.contains(e)) {
+            return seen;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("timed out waiting for {expected:?}; saw {seen:?}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+}
+
+// End-to-end test of the self-rollover consumer: the long-running consumer
+// subscribes to a topic *pattern* and must (a) skip an old retained topic's
+// messages on cold start, (b) consume the current day's messages, and (c)
+// auto-discover and consume the *next* day's topic created while it is running,
+// all without restarting. Requires a local Kafka broker + redis.
+//
+// The consumer runs on its own dedicated OS thread + runtime (see below) so its
+// blocking rdkafka `poll` can't starve this test driver's runtime.
+#[tokio::test]
+async fn test_consumer_rolls_over_and_skips_old() {
+    use boom::conf::{AppConfig, KafkaConsumerConfig};
+    use boom::kafka::{consumer, delete_topic, initialize_topic};
+    use rdkafka::config::ClientConfig;
+    use rdkafka::producer::{FutureProducer, FutureRecord};
+    use std::time::Duration;
+
+    let server = "localhost:9092";
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    // Unique, regex-safe prefix so the pattern matches only this test's topics.
+    let prefix = format!("rollovertest{now_ms}");
+    let pattern = format!("^{prefix}_[0-9]+$");
+    let output_queue = format!("{prefix}_queue");
+    let group_id = format!("{prefix}_group");
+    let topic_day1 = format!("{prefix}_20260628");
+    let topic_day2 = format!("{prefix}_20260629");
+
+    let app_config = AppConfig::from_path(TEST_CONFIG_FILE).unwrap();
+    let mut con = app_config.build_redis().await.unwrap();
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", server)
+        .create()
+        .unwrap();
+
+    // Day 1 topic: one stale message (10 days old, lowest offset) then fresh ones.
+    initialize_topic(server, &topic_day1, 1).await.unwrap();
+    let stale_ms = now_ms - 10 * 24 * 60 * 60 * 1000;
+    producer
+        .send(
+            FutureRecord::to(topic_day1.as_str())
+                .payload("stale")
+                .key("k")
+                .timestamp(stale_ms),
+            Duration::from_secs(10),
+        )
+        .await
+        .unwrap();
+    let fresh: Vec<String> = (0..5).map(|i| format!("fresh-{i}")).collect();
+    for p in &fresh {
+        producer
+            .send(
+                FutureRecord::to(topic_day1.as_str())
+                    .payload(p.as_str())
+                    .key("k")
+                    .timestamp(now_ms),
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Start the long-running consumer. Cold-start timestamp = 1h ago, so the
+    // 10-day-old "stale" message is skipped while the fresh ones are consumed.
+    let cold_start_ts = now_ms / 1000 - 3600;
+    let kafka_cfg = KafkaConsumerConfig {
+        server: server.to_string(),
+        group_id,
+        schema_registry: None,
+        schema_github_fallback_url: None,
+        username: None,
+        password: None,
+    };
+    // Run the consumer on its own OS thread + runtime so its blocking rdkafka
+    // `poll` doesn't starve the test driver's runtime (this mirrors prod, where
+    // each consumer process owns its runtime). Dropping the runtime when the
+    // stop signal arrives aborts the consumer.
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    let consumer_thread = {
+        let config = app_config.clone();
+        let oq = output_queue.clone();
+        let pat = pattern.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.spawn(async move {
+                let _ = consumer(
+                    "0",
+                    vec![pat],
+                    &oq,
+                    0,
+                    cold_start_ts,
+                    &config,
+                    &kafka_cfg,
+                    false,
+                    "WINTER",
+                )
+                .await;
+            });
+            let _ = stop_rx.recv();
+            // Force shutdown rather than waiting on the consumer's in-flight
+            // blocking `poll` (its worker thread is abandoned and dies with the
+            // process).
+            rt.shutdown_timeout(std::time::Duration::from_secs(1));
+        })
+    };
+
+    // (b)+(a): fresh messages arrive; the stale one is skipped.
+    let seen = wait_for_payloads(&mut con, &output_queue, &fresh, Duration::from_secs(40)).await;
+    assert!(
+        !seen.contains("stale"),
+        "stale (pre-window) message should have been skipped"
+    );
+
+    // (c): create the next day's topic *after* the consumer is running and
+    // produce to it. The consumer must auto-discover it without a restart.
+    initialize_topic(server, &topic_day2, 1).await.unwrap();
+    let newday: Vec<String> = (0..4).map(|i| format!("newday-{i}")).collect();
+    for p in &newday {
+        producer
+            .send(
+                FutureRecord::to(topic_day2.as_str())
+                    .payload(p.as_str())
+                    .key("k")
+                    .timestamp(now_ms),
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+    }
+
+    let expected: Vec<String> = fresh.iter().chain(newday.iter()).cloned().collect();
+    let seen = wait_for_payloads(&mut con, &output_queue, &expected, Duration::from_secs(60)).await;
+    assert!(
+        !seen.contains("stale"),
+        "stale message must never be consumed"
+    );
+
+    let _ = stop_tx.send(());
+    let _ = consumer_thread.join();
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+    let _ = delete_topic(server, &topic_day1).await;
+    let _ = delete_topic(server, &topic_day2).await;
+}


### PR DESCRIPTION
This PR enbles Kafka consumers to self-roll over via topic-pattern subscription.

@petebachant another idea for the rollover stuff. 