### PR TITLE
Handle missing fields in WINTER packets

### DIFF
--- a/src/alert/winter.rs
+++ b/src/alert/winter.rs
@@ -79,6 +79,12 @@ pub struct WinterCandidate {
     pub progname: String,
     pub programid: i32,
     pub isdiffpos: bool,
+    // Not all upstream WINTER packets carry `field`; tolerate its absence
+    // rather than failing the whole alert (missing field `field`). It stays a
+    // plain `i32` (not `Option`) because the writer schema types it as a bare
+    // `int` when present — an `Option` would make the deserializer demand a
+    // union and reject that. `#[serde(default)]` fills 0 only when it's absent.
+    #[serde(default)]
     pub field: i32,
     pub ra: f64,
     pub dec: f64,
@@ -194,6 +200,7 @@ pub struct WinterPrvCandidate {
     pub jd: f64,
     pub fid: i32,
     pub isdiffpos: bool,
+    #[serde(default)]
     pub fieldid: i32,
     pub ra: f64,
     pub dec: f64,

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -848,7 +848,7 @@ pub async fn consumer(
         .await
         .inspect_err(as_error!("failed to connect to redis"))?;
 
-    let mut total = 0;
+    let mut total: u64 = 0;
     // start timer
     let start = std::time::Instant::now();
 
@@ -858,7 +858,7 @@ pub async fn consumer(
     // even when idle between nights.
     const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_heartbeat = std::time::Instant::now();
-    let mut total_at_last_heartbeat = 0;
+    let mut total_at_last_heartbeat: u64 = 0;
 
     debug!("Starting Kafka consumer loop...");
 

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -852,10 +852,32 @@ pub async fn consumer(
     // start timer
     let start = std::time::Instant::now();
 
+    // Emit a periodic "still alive" line so low-volume surveys (e.g. WINTER,
+    // which may push far fewer than the every-1000 progress log) visibly report
+    // progress instead of looking stalled. Also confirms the loop is polling
+    // even when idle between nights.
+    const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+    let mut last_heartbeat = std::time::Instant::now();
+    let mut total_at_last_heartbeat = 0;
+
     debug!("Starting Kafka consumer loop...");
 
     // Process the rest normally
     loop {
+        if !exit_on_eof && last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+            let since = total - total_at_last_heartbeat;
+            info!(
+                "Consumer {} alive: {} messages pushed to '{}' ({} in the last {:?}, {:?} total)",
+                id,
+                total,
+                output_queue,
+                since,
+                last_heartbeat.elapsed(),
+                start.elapsed(),
+            );
+            last_heartbeat = std::time::Instant::now();
+            total_at_last_heartbeat = total;
+        }
         // Pick up newly-assigned partitions (e.g. the next day's topic rolling
         // over). Kept off the per-message hot path: checked once per 1000
         // messages and whenever the poll goes idle (rollover happens in the

--- a/tests/test_winter.rs
+++ b/tests/test_winter.rs
@@ -28,6 +28,44 @@ fn test_sanitize_winter_avro_is_readable() {
     assert!(apache_avro::Reader::new(&fixed2[..]).is_ok());
 }
 
+#[test]
+fn test_winter_candidate_missing_field_deserializes() {
+    // Some upstream WINTER packets omit the candidate `field` entirely. That must
+    // deserialize (with `field` defaulting) rather than failing the whole alert
+    // with "missing field `field`". We simulate it by dropping `field` from the
+    // decoded record, which is exactly the shape the strict serde path sees.
+    use apache_avro::types::Value;
+    let raw = std::fs::read("tests/data/alerts/winter/alert.avro").unwrap();
+    let fixed = sanitize_winter_avro(&raw).unwrap();
+    let reader = apache_avro::Reader::new(&fixed[..]).unwrap();
+    let mut value = reader.into_iter().next().unwrap().unwrap();
+
+    // Baseline: with `field` present it must still parse.
+    apache_avro::from_value::<WinterRawAvroAlert>(&value).expect("baseline should parse");
+
+    // Drop `field` from the nested candidate record.
+    if let Value::Record(top) = &mut value {
+        let candidate = top
+            .iter_mut()
+            .find(|(k, _)| k == "candidate")
+            .map(|(_, v)| v)
+            .expect("candidate field");
+        if let Value::Record(fields) = candidate {
+            let before = fields.len();
+            fields.retain(|(k, _)| k != "field");
+            assert_eq!(before - 1, fields.len(), "expected to drop `field`");
+        } else {
+            panic!("candidate is not a record");
+        }
+    } else {
+        panic!("alert is not a record");
+    }
+
+    let alert: WinterRawAvroAlert =
+        apache_avro::from_value(&value).expect("candidate missing `field` should still parse");
+    assert_eq!(alert.candidate.field, 0, "absent `field` defaults to 0");
+}
+
 #[tokio::test]
 async fn test_process_winter_alert() {
     let mut alert_worker = winter_alert_worker().await;


### PR DESCRIPTION
In response to the scheduler logs:

```
2026-07-07 10:49:22.700 | trace_id=2e4432a0c73291c1ee42a8ef351386c7 span_id=204e97b5ff1b0785 2026-07-07T17:49:22.700739Z  WARN handle_process_result: src/alert/base.rs:1365: error processing alert, skipping error=error from avro source=Failed to deserialize Avro value into value: missing field `field` debug=Avro(Error { details: Failed to deserialize Avro value into value: missing field `field` }) |  
-- | -- | --
  |   | 2026-07-07 10:49:22.700 | 2026-07-07T17:49:22.700724Z ERROR src/alert/winter.rs:671: error=error from avro source=Failed to deserialize Avro value into value: missing field `field` debug=Avro(Error { details: Failed to deserialize Avro value into value: missing field `field` }) |  
  |   | 2026-07-07 10:49:22.700 | trace_id=63d3ef9d71e22a94e5bb4d2699835d5c span_id=f0e0a1ee23ef06a7 2026-07-07T17:49:22.700714Z ERROR alert_from_avro_bytes: src/alert/base.rs:571: error=error from avro |  
  |   | 2026-07-07 10:49:22.700 | trace_id=63d3ef9d71e22a94e5bb4d2699835d5c span_id=f0e0a1ee23ef06a7 2026-07-07T17:49:22.700678Z ERROR alert_from_avro_bytes: src/alert/base.rs:620: error=Failed to deserialize Avro value into value: missing field `field` source= debug=Error { details: Failed to deserialize Avro value into value: missing field `field` } |  
  |   | 2026-07-07 10:49:22.198 | trace_id=2e70bc5f8645dddf7e8dd36a0b1447d4 span_id=3866a14c3379c5fb 2026-07-07T17:49:22.198181Z  WARN handle_process_result: src/alert/base.rs:1365: error processing alert, skipping error=error from avro source=Failed to deserialize Avro value into value: missing field `field` debug=Avro(Error { details: Failed to deserialize Avro value into value: missing field `field` }) |  
  |   | 2026-07-07 10:49:22.198 | 2026-07-07T17:49:22.198176Z ERROR src/alert/winter.rs:671: error=error from avro source=Failed to deserialize Avro value into value: missing field `field` debug=Avro(Error { details: Failed to deserialize Avro value into value: missing field `field` }) |  
  |   | 2026-07-07 10:49:22.198 | trace_id=93f7a79a705a50d34cbb372321041b0c span_id=8a04d90667be6e9c 2026-07-07T17:49:22.198173Z ERROR alert_from_avro_bytes: src/alert/base.rs:571: error=error from avro |  
  |   | 2026-07-07 10:49:22.198 | trace_id=93f7a79a705a50d34cbb372321041b0c span_id=8a04d90667be6e9c 2026-07-07T17:49:22.198165Z ERROR alert_from_avro_bytes: src/alert/base.rs:620: error=Failed to deserialize Avro value into value: missing field `field` source= debug=Error { details: Failed to deserialize Avro value into value: missing field `field` } |  
  |   | 2026-07-07 10:49:22.197 | trace_id=c9d99dd897940dd216711f8a680e0c0d span_id=5d9fa132d4b2e4d3 2026-07-07T17:49:22.197919Z  WARN handle_process_result: src/alert/base.rs:1365: error processing alert, skipping error=error from avro source=Failed to deserialize Avro value into value: missing field `field` debug=Avro(Error { det
```

Resolves #526. Actually, the consumer was fine, but the logs were confusing, so I changed the consumer to output more information so we can see what's going on.