### PR TITLE
Updated kafka.rs to include OTel metrics endpoint

### DIFF
--- a/src/api/routes/babamul/stats/kafka.rs
+++ b/src/api/routes/babamul/stats/kafka.rs
@@ -104,6 +104,102 @@ pub async fn get_kafka_stats(
     )
 }
 
+/// Fetch realtime alert metrics from the OTel Collector.
+///
+/// Queries the OTel Collector's Prometheus endpoint and returns current alert
+/// counts per survey with the timestamp when they were gathered. The OTel Collector
+/// endpoint is configured via the `OTEL_COLLECTOR_METRICS_URL` environment variable,
+/// defaulting to `http://localhost:8888/metrics`.
+#[utoipa::path(
+    get,
+    path = "/babamul/stats/kafka",
+    responses(
+        (status = 200, description = "Realtime alert metrics retrieved", body = Vec<RealtimeAlertMetrics>),
+        (status = 500, description = "Internal server error")
+    ),
+    tags = ["Stats"]
+)]
+#[get("/stats/kafka")]
+pub async fn get_realtime_alerts() -> HttpResponse {
+    let collector_url = std::env::var("OTEL_COLLECTOR_METRICS_URL")
+        .unwrap_or_else(|_| "http://localhost:8888/metrics".to_string());
+
+    let gathered_at = Utc::now().timestamp();
+
+    match reqwest::get(&collector_url).await {
+        Ok(resp) => match resp.text().await {
+            Ok(text) => match parse_otel_metrics(&text, gathered_at) {
+                Ok(metrics) => response::ok("realtime alerts", serde_json::json!(metrics)),
+                Err(e) => response::internal_error(&format!("Failed to parse metrics: {}", e)),
+            },
+            Err(e) => response::internal_error(&format!("Failed to read OTel response: {}", e)),
+        },
+        Err(e) => response::internal_error(&format!("Failed to query OTel Collector: {}", e)),
+    }
+}
+
+/// Parse Prometheus-format metrics from OTel Collector and extract alert counts.
+///
+/// Looks for metrics matching the pattern `boom_alerts_total{survey="..."}` and
+/// extracts the survey name and alert count from each line. Attaches the gathered_at
+/// timestamp to each metric.
+fn parse_otel_metrics(text: &str, gathered_at: i64) -> Result<Vec<RealtimeAlertMetrics>, String> {
+    let mut metrics = Vec::new();
+
+    for line in text.lines() {
+        // Skip comments and empty lines
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+
+        // Look for metrics with "alerts" in the name (e.g., boom_alerts_total)
+        if !line.contains("alerts") {
+            continue;
+        }
+
+        // Parse lines like: boom_alerts_total{survey="ztf",instance="..."} 1234
+        if let Some((metric_part, value_part)) = line.split_once(' ') {
+            // Extract survey name from labels
+            if let Some(survey) = extract_survey_label(metric_part) {
+                // Try to parse the numeric value
+                match value_part.trim().parse::<u32>() {
+                    Ok(n_alerts) => {
+                        metrics.push(RealtimeAlertMetrics {
+                            survey,
+                            n_alerts,
+                            gathered_at,
+                        });
+                    }
+                    Err(_) => {
+                        // Skip lines that don't have valid numeric values
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    if metrics.is_empty() {
+        // Return empty list rather than error — OTel may not have metrics yet
+        return Ok(Vec::new());
+    }
+
+    Ok(metrics)
+}
+
+/// Extract the survey label value from a Prometheus metric line.
+///
+/// Parses labels like `metric_name{survey="ztf",other="value"}` and returns "ztf".
+fn extract_survey_label(metric_part: &str) -> Option<String> {
+    if let Some(start) = metric_part.find("survey=\"") {
+        let after_key = &metric_part[start + 8..];
+        if let Some(end) = after_key.find('"') {
+            return Some(after_key[..end].to_string());
+        }
+    }
+    None
+}
+
 fn list_babamul_topics(
     bootstrap_servers: &str,
     retention_days: u32,


### PR DESCRIPTION
Configured src/api/babamul/kafka.rs backend file to make OTel metrics endpoint accessible via HTTP GET request used to access Kafka within babamul-web api