### PR TITLE
adding DESI DR1 and LS DR10 PHOTOZ catalog crossmatches

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -204,6 +204,38 @@ crossmatch:
         tMASSphot: 1
         Mstar: 1
         Mstar_unc: 1
+    - catalog: DESI_DR1
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z"
+      distance_max: 30.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        z: 1
+        zerr: 1
+        zwarn: 1
+        chi2: 1
+        deltachi2: 1
+        spectype: 1
+        zcat_nspec: 1
+    - catalog: LS_DR10_PHOTOZ
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z_phot"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        ra_err: 1
+        dec_err: 1
+        z_phot: 1
+        z_phot_err: 1
+        photo_z_type: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0 # 30 arcseconds
@@ -238,6 +270,38 @@ crossmatch:
         tMASSphot: 1
         Mstar: 1
         Mstar_unc: 1
+    - catalog: DESI_DR1
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z"
+      distance_max: 30.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        z: 1
+        zerr: 1
+        zwarn: 1
+        chi2: 1
+        deltachi2: 1
+        spectype: 1
+        zcat_nspec: 1
+    - catalog: LS_DR10_PHOTOZ
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z_phot"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        ra_err: 1
+        dec_err: 1
+        z_phot: 1
+        z_phot_err: 1
+        photo_z_type: 1
   decam: []
   winter:
     - catalog: PS1_DR1
@@ -302,3 +366,35 @@ crossmatch:
         tMASSphot: 1
         Mstar: 1
         Mstar_unc: 1
+    - catalog: DESI_DR1
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z"
+      distance_max: 30.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        z: 1
+        zerr: 1
+        zwarn: 1
+        chi2: 1
+        deltachi2: 1
+        spectype: 1
+        zcat_nspec: 1
+    - catalog: LS_DR10_PHOTOZ
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z_phot"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        ra_err: 1
+        dec_err: 1
+        z_phot: 1
+        z_phot_err: 1
+        photo_z_type: 1

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -500,3 +500,35 @@ crossmatch:
         tMASSphot: 1
         Mstar: 1
         Mstar_unc: 1
+    - catalog: DESI_DR1
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z"
+      distance_max: 30.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        z: 1
+        zerr: 1
+        zwarn: 1
+        chi2: 1
+        deltachi2: 1
+        spectype: 1
+        zcat_nspec: 1
+    - catalog: LS_DR10_PHOTOZ
+      radius: 30.0 # 30 arcseconds
+      use_distance: true
+      distance_key: "z_phot"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        ra_err: 1
+        dec_err: 1
+        z_phot: 1
+        z_phot_err: 1
+        photo_z_type: 1


### PR DESCRIPTION
These are simple config changes to allow for cross-match with DESI_DR1 and Legacy Survey DR10 Photo-z catalogs.

https://github.com/boom-astro/boom-catalogs has instruction on how these catalogs can be fetched and ultimately ingested in MongoDB. This was initially done on the UMN instance and the MongoDB dump was transferred to Caltech instance where it was added to the Caltech MongoDB.