### PR TITLE
bump kafka version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
         echo "Installed ONNX Runtime at: ${ORT_LIB}"
     - name: Install Kafka CLI tools
       run: |
-        KAFKA_VERSION=4.1.2
+        KAFKA_VERSION=4.3.1
         SCALA_VERSION=2.13
         sudo apt-get update && sudo apt-get install -y --no-install-recommends \
             libsasl2-2 ca-certificates openjdk-25-jre-headless curl bash tar

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
         echo "Installed ONNX Runtime at: ${ORT_LIB}"
     - name: Install Kafka CLI tools
       run: |
-        KAFKA_VERSION=4.1.1
+        KAFKA_VERSION=4.1.2
         SCALA_VERSION=2.13
         sudo apt-get update && sudo apt-get install -y --no-install-recommends \
             libsasl2-2 ca-certificates openjdk-25-jre-headless curl bash tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG KAFKA_VERSION=4.1.1
+ARG KAFKA_VERSION=4.1.2
 ARG SCALA_VERSION=2.13
 
 FROM rust:slim-trixie AS base
@@ -53,7 +53,7 @@ CMD ["cargo", "watch", "-x", "run --bin api"]
 
 FROM debian:trixie-slim AS app
 
-ARG KAFKA_VERSION=4.1.1
+ARG KAFKA_VERSION=4.1.2
 ARG SCALA_VERSION=2.13
 
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG KAFKA_VERSION=4.1.2
+ARG KAFKA_VERSION=4.3.1
 ARG SCALA_VERSION=2.13
 
 FROM rust:slim-trixie AS base
@@ -53,7 +53,7 @@ CMD ["cargo", "watch", "-x", "run --bin api"]
 
 FROM debian:trixie-slim AS app
 
-ARG KAFKA_VERSION=4.1.2
+ARG KAFKA_VERSION=4.3.1
 ARG SCALA_VERSION=2.13
 
 RUN apt-get update && \


### PR DESCRIPTION
This PR bumps the version of Kafka (our current one is now in the archive).