### PR TITLE
filter validation endpoint and skip_validation flag on patch

### DIFF
--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -62,6 +62,7 @@ impl Modify for BabamulSecurityAddon {
         routes::catalogs::get_catalog_sample,
         routes::filters::post_filter,
         routes::filters::patch_filter,
+        routes::filters::validate_filter,
         routes::filters::get_filters,
         routes::filters::get_filter,
         routes::filters::post_filter_version,

--- a/src/api/routes/filters.rs
+++ b/src/api/routes/filters.rs
@@ -463,6 +463,8 @@ struct FilterPatch {
     active: Option<bool>,
     active_fid: Option<String>,
     permissions: Option<HashMap<Survey, Vec<i32>>>,
+    #[serde(default)]
+    skip_validation: bool,
 }
 /// Update a filter's metadata
 #[utoipa::path(
@@ -557,7 +559,7 @@ pub async fn patch_filter(
     let exec_changed = (body.active == Some(true) && !filter.active)
         || new_active_fid.is_some()
         || body.permissions.is_some();
-    if will_be_active && exec_changed {
+    if will_be_active && exec_changed && !body.skip_validation {
         let active_fid = new_active_fid
             .as_deref()
             .unwrap_or(filter.active_fid.as_str());
@@ -608,6 +610,108 @@ pub async fn patch_filter(
     match update_result {
         Ok(_) => response::ok_no_data(&format!("successfully updated filter id: {}", &filter_id)),
         Err(e) => response::internal_error(&format!("failed to update filter. error: {}", e)),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct ValidateFilterQuery {
+    fid: Option<String>,
+}
+
+/// Validate a filter version for activation without changing state
+#[utoipa::path(
+    post,
+    path = "/filters/{filter_id}/validate",
+    params(
+        ("filter_id" = String, Path, description = "ID of the filter to validate"),
+        ("fid" = Option<String>, Query, description = "Version to validate (defaults to the active_fid)")
+    ),
+    responses(
+        (status = 200, description = "Validation result (passed true/false)", body = serde_json::Value),
+        (status = 400, description = "Invalid request"),
+        (status = 500, description = "Internal server error")
+    ),
+    tags=["Filters"]
+)]
+#[post("/filters/{filter_id}/validate")]
+pub async fn validate_filter(
+    db: web::Data<Database>,
+    config: web::Data<AppConfig>,
+    filter_id: web::Path<String>,
+    query: web::Query<ValidateFilterQuery>,
+    current_user: Option<web::ReqData<User>>,
+) -> HttpResponse {
+    let current_user = match current_user {
+        Some(user) => user,
+        None => return HttpResponse::Unauthorized().body("Unauthorized"),
+    };
+    let filter_id = filter_id.into_inner();
+    let collection: Collection<Filter> = db.collection("filters");
+    let filter = match collection.find_one(doc! {"_id": filter_id.clone()}).await {
+        Ok(Some(filter)) => filter,
+        Ok(None) => {
+            return response::not_found(&format!("filter with id {} does not exist", filter_id));
+        }
+        Err(e) => {
+            return response::internal_error(&format!(
+                "failed to find filter with id {}. error: {}",
+                &filter_id, e
+            ));
+        }
+    };
+    if filter.user_id != current_user.id && !current_user.is_admin {
+        return response::forbidden("only the filter owner or an admin can validate a filter");
+    }
+
+    let fid = query
+        .fid
+        .clone()
+        .unwrap_or_else(|| filter.active_fid.clone());
+    let version = match filter.fv.iter().find(|fv| fv.fid == fid) {
+        Some(v) => v,
+        None => {
+            return response::bad_request(&format!(
+                "filter {} has no version matching fid {}",
+                filter_id, fid
+            ));
+        }
+    };
+    let pipeline = match serde_json::from_str::<Vec<serde_json::Value>>(&version.pipeline) {
+        Ok(p) => p,
+        Err(e) => {
+            return response::internal_error(&format!(
+                "failed to parse stored filter pipeline: {}",
+                e
+            ));
+        }
+    };
+    let filter_config = match config.workers.get(&filter.survey).map(|w| &w.filter) {
+        Some(c) => c,
+        None => {
+            return response::internal_error(&format!(
+                "no worker config defined for survey {}",
+                filter.survey
+            ));
+        }
+    };
+
+    match validate_filter_activation(
+        &db,
+        filter_config,
+        &filter.survey,
+        &pipeline,
+        &filter.permissions,
+    )
+    .await
+    {
+        Ok(()) => response::ok(
+            &format!("filter version {} passed activation validation", fid),
+            serde_json::json!({ "fid": fid, "passed": true }),
+        ),
+        Err(message) => response::ok(
+            &format!("filter version {} did not pass activation validation", fid),
+            serde_json::json!({ "fid": fid, "passed": false, "message": message }),
+        ),
     }
 }
 

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -130,6 +130,7 @@ async fn main() -> std::io::Result<()> {
                 .service(routes::kafka::delete_kafka_credentials)
                 .service(routes::filters::post_filter)
                 .service(routes::filters::patch_filter)
+                .service(routes::filters::validate_filter)
                 .service(routes::filters::get_filters)
                 .service(routes::filters::get_filter)
                 .service(routes::filters::post_filter_version)


### PR DESCRIPTION
This PR adds a filter validation endpoint and skip_validation flag on patch, to streamline SkyPortal interactions.