### PR TITLE
Milvus embedding tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ RUN ORT_CAPI_DIR="$('/opt/ort-py/bin/python' -c 'import pathlib, onnxruntime as 
     rm -rf /opt/ort-py && ln -sf /opt/ort/libonnxruntime.so.${ONNXRUNTIME_GPU_VERSION} /opt/ort/libonnxruntime.so
 
 COPY apache-avro-macros /app/apache-avro-macros
-COPY Cargo.toml Cargo.lock /app/
+COPY Cargo.toml Cargo.lock build.rs /app/
+# build.rs generates the Milvus gRPC bindings from these vendored protos into
+# OUT_DIR; without them src/milvus/proto.rs has nothing to include!().
+COPY ./proto /app/proto
 COPY ./src /app/src
 
 # BuildKit cache mounts keep the compiled crates (target/) and the fetched
@@ -68,6 +71,13 @@ RUN --mount=type=cache,target=/app/target,sharing=locked \
 FROM builder AS dev
 
 RUN cargo install --locked cargo-watch
+
+# On Linux `ort` is built with the `load-dynamic` feature (see Cargo.toml), so
+# libonnxruntime.so is dlopen'd at runtime rather than linked in. The `app`
+# stage sets these as well; without them here the enrichment workers hang
+# during SharedModels::load and never reach their queue loop.
+ENV ORT_DYLIB_PATH=/opt/ort/libonnxruntime.so
+ENV LD_LIBRARY_PATH=/opt/ort
 
 CMD ["cargo", "watch", "-x", "run --bin api"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,10 @@ FROM builder AS dev
 
 RUN cargo install --locked cargo-watch
 
-# On Linux `ort` is built with the `load-dynamic` feature (see Cargo.toml), so
-# libonnxruntime.so is dlopen'd at runtime rather than linked in. The `app`
-# stage sets these as well; without them here the enrichment workers hang
-# during SharedModels::load and never reach their queue loop.
+# On Linux, `ort` uses the `load-dynamic` feature (Cargo.toml), so it looks up
+# libonnxruntime.so at runtime instead of linking it in. These tell it where.
+# The `app` stage repeats them; without them here the enrichment workers hang
+# in SharedModels::load and never reach their queue loop.
 ENV ORT_DYLIB_PATH=/opt/ort/libonnxruntime.so
 ENV LD_LIBRARY_PATH=/opt/ort
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -30,7 +30,10 @@ RUN ORT_CAPI_DIR="$('/opt/ort-py/bin/python' -c 'import pathlib, onnxruntime as 
 
 COPY data/models/btsbot-v1.0.1.onnx /app/data/models/btsbot-v1.0.1.onnx
 COPY apache-avro-macros /app/apache-avro-macros
-COPY Cargo.toml Cargo.lock /app/
+COPY Cargo.toml Cargo.lock build.rs /app/
+# build.rs generates the Milvus gRPC bindings from these vendored protos into
+# OUT_DIR; without them src/milvus/proto.rs has nothing to include!().
+COPY ./proto /app/proto
 COPY ./src /app/src
 
 # BuildKit cache mounts keep compiled crates (target/) and fetched deps between

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,47 @@ check-configs: configs
 		echo "No generated configs found at config/prod/*/config.yaml"; \
 		exit 1; \
 	fi
+
+# --- Milvus e2e testing ---------------------------------------------------
+# Local, standalone Milvus (docker-compose.milvus.yaml) for running the
+# end-to-end test without touching the shared NRP instance. The .env file keeps
+# the NRP credentials as the default; the local overrides below are passed as
+# shell env vars, which win over .env (dotenvy does not override already-set
+# vars). So:
+#   make test-milvus-local  -> runs the e2e test against local Milvus
+#   make test-milvus-nrp    -> runs it against NRP (whatever .env points at)
+
+# Local overrides: plaintext gRPC on :19530, auth disabled, `default` database.
+# The standalone Milvus has authentication disabled, so it ignores the
+# username/password entirely -- but config validation requires them to be
+# non-empty when milvus.enabled, so we pass Milvus's own default placeholders.
+MILVUS_LOCAL_ENV := \
+	BOOM_MILVUS__ENABLED=true \
+	BOOM_MILVUS__HOST=localhost \
+	BOOM_MILVUS__PORT=19530 \
+	BOOM_MILVUS__TLS=false \
+	BOOM_MILVUS__USERNAME=root \
+	BOOM_MILVUS__PASSWORD=Milvus \
+	BOOM_MILVUS__DATABASE=default
+
+.PHONY: milvus-up
+milvus-up: # Start the local standalone Milvus stack (etcd + minio + standalone + attu)
+	docker compose -p boom-milvus -f docker-compose.milvus.yaml up -d
+
+.PHONY: milvus-down
+milvus-down: # Stop the local Milvus stack, keeping its data volumes
+	docker compose -p boom-milvus -f docker-compose.milvus.yaml down
+
+.PHONY: milvus-clean
+milvus-clean: # Stop the local Milvus stack AND wipe its data volumes
+	docker compose -p boom-milvus -f docker-compose.milvus.yaml down -v
+
+.PHONY: test-milvus-local
+test-milvus-local: # Run the Milvus e2e test against the LOCAL standalone instance
+	@echo "Running Milvus e2e test against local Milvus (localhost:19530)"
+	$(MILVUS_LOCAL_ENV) cargo test --test test_milvus_e2e -- --nocapture
+
+.PHONY: test-milvus-nrp
+test-milvus-nrp: # Run the Milvus e2e test against NRP (uses .env as-is)
+	@echo "Running Milvus e2e test against NRP (per .env)"
+	cargo test --test test_milvus_e2e -- --nocapture

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ milvus:
   database: "" # Set via BOOM_MILVUS__DATABASE environment variable
   timeout_seconds: 30
   collection:
-    name: ztf_fusion_embeddings
+    name: boom_ztf_fusion_embeddings
     # The CIDER fusion model (data/models/cider_fusion_plus_embedding.onnx)
     # emits 384 floats, L2-normalized -- so COSINE and IP are equivalent.
     dim: 384

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -51,7 +51,7 @@ milvus:
   database: "" # Set via BOOM_MILVUS__DATABASE environment variable
   timeout_seconds: 30
   collection:
-    name: ztf_fusion_embeddings
+    name: boom_ztf_fusion_embeddings
     # The CIDER fusion model (data/models/cider_fusion_plus_embedding.onnx)
     # emits 384 floats, L2-normalized -- so COSINE and IP are equivalent.
     dim: 384

--- a/docker-compose.milvus.yaml
+++ b/docker-compose.milvus.yaml
@@ -1,0 +1,98 @@
+# Local, standalone Milvus for developing/testing BOOM's Milvus integration
+# without touching the shared NRP instance.
+#
+# This is a self-contained stack (etcd + minio + milvus standalone + attu UI),
+# NOT part of the main docker-compose.yaml. Bring it up on its own project:
+#
+#   docker compose -p boom-milvus -f docker-compose.milvus.yaml up -d
+#   docker compose -p boom-milvus -f docker-compose.milvus.yaml down       # keep data
+#   docker compose -p boom-milvus -f docker-compose.milvus.yaml down -v    # wipe data
+#
+# Then point BOOM at it in .env (local Milvus is plaintext gRPC on 19530 with
+# auth disabled and the built-in `default` database):
+#
+#   BOOM_MILVUS__ENABLED=true
+#   BOOM_MILVUS__HOST=localhost
+#   BOOM_MILVUS__PORT=19530
+#   BOOM_MILVUS__TLS=false
+#   BOOM_MILVUS__USERNAME=
+#   BOOM_MILVUS__PASSWORD=
+#   BOOM_MILVUS__DATABASE=
+#
+# gRPC:   localhost:19530   (what BOOM dials)
+# health: localhost:9091    (curl http://localhost:9091/healthz)
+# Attu:   http://localhost:8000  (web UI; connect to standalone:19530)
+
+services:
+  etcd:
+    container_name: milvus-etcd
+    image: quay.io/coreos/etcd:v3.5.18
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+      - ETCD_SNAPSHOT_COUNT=50000
+    volumes:
+      - etcd_data:/etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  minio:
+    container_name: milvus-minio
+    image: minio/minio:RELEASE.2023-03-20T20-16-18Z
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    volumes:
+      - minio_data:/minio_data
+    command: minio server /minio_data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  standalone:
+    container_name: milvus-standalone
+    image: milvusdb/milvus:v2.5.10
+    command: ["milvus", "run", "standalone"]
+    security_opt:
+      - seccomp:unconfined
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    volumes:
+      - milvus_data:/var/lib/milvus
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      interval: 30s
+      start_period: 90s
+      timeout: 20s
+      retries: 3
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    depends_on:
+      etcd:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  attu:
+    container_name: milvus-attu
+    image: zilliz/attu:v2.5
+    environment:
+      MILVUS_URL: standalone:19530
+    ports:
+      - "8000:3000"
+    depends_on:
+      - standalone
+
+volumes:
+  etcd_data:
+  minio_data:
+  milvus_data:

--- a/docker-compose.milvus.yaml
+++ b/docker-compose.milvus.yaml
@@ -85,6 +85,12 @@ services:
   attu:
     container_name: milvus-attu
     image: zilliz/attu:v2.5
+    # The arm64 build of this image ships a broken node_modules (iconv-lite is
+    # missing its `encodings` directory), so any request with a body -- i.e. the
+    # login POST -- dies with "Cannot find module '../encodings'". The amd64
+    # build is fine; on Apple Silicon it runs under Rosetta, which is plenty for
+    # a small Node UI.
+    platform: linux/amd64
     environment:
       MILVUS_URL: standalone:19530
     ports:

--- a/docker-compose.milvus.yaml
+++ b/docker-compose.milvus.yaml
@@ -85,11 +85,7 @@ services:
   attu:
     container_name: milvus-attu
     image: zilliz/attu:v2.5
-    # The arm64 build of this image ships a broken node_modules (iconv-lite is
-    # missing its `encodings` directory), so any request with a body -- i.e. the
-    # login POST -- dies with "Cannot find module '../encodings'". The amd64
-    # build is fine; on Apple Silicon it runs under Rosetta, which is plenty for
-    # a small Node UI.
+    # The arm64 build is broken, so using the amd64, which runs under Rosetta on Apple Silicon
     platform: linux/amd64
     environment:
       MILVUS_URL: standalone:19530

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -186,9 +186,9 @@ services:
       - .env
     environment:
       BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
-      # This service exists only here (the base file defines consumer-ztf-public
-      # / -partnership / -caltech), so unlike scheduler-ztf it inherits no base
-      # definition -- the network and service hostnames must be set explicitly.
+      # The base file has no consumer-ztf (only -public / -partnership /
+      # -caltech), so there is nothing to inherit from: the network and
+      # service hostnames have to be spelled out here.
       BOOM_DATABASE__HOST: mongo
       BOOM_CUTOUTS_STORAGE__HOST: mongo
       BOOM_REDIS__HOST: valkey

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -186,6 +186,14 @@ services:
       - .env
     environment:
       BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
+      # This service exists only here (the base file defines consumer-ztf-public
+      # / -partnership / -caltech), so unlike scheduler-ztf it inherits no base
+      # definition -- the network and service hostnames must be set explicitly.
+      BOOM_DATABASE__HOST: mongo
+      BOOM_CUTOUTS_STORAGE__HOST: mongo
+      BOOM_REDIS__HOST: valkey
+    networks:
+      - boom
     profiles:
       - dev
     build:

--- a/docs/milvus.md
+++ b/docs/milvus.md
@@ -216,6 +216,27 @@ constant `WRITE_EMBEDDING_TO_MONGO` in `src/milvus/mod.rs` decides whether to
 
 Changing it requires a rebuild.
 
+## Reading embeddings
+
+`MilvusClient` also exposes the read/manage side of the collection
+(`src/milvus/search.rs`):
+
+- `search_embedding(query, top_k)` — similarity search: returns the `top_k`
+  nearest `object_id`s to a query vector with their scores (and stored
+  `candid`/`jd`), best-first. The query vector is wrapped in a protobuf
+  `PlaceholderGroup` (little-endian `f32` bytes) as Milvus requires.
+- `get_embeddings(&[object_id])` — fetch stored rows by id, with the vector
+  split back out of Milvus's flat column into per-row `Vec<f32>`.
+- `count()` — number of objects in the collection (`count(*)`).
+- `delete_embeddings(&[object_id])` — remove rows by id.
+- `flush()` — seal recent writes so they are immediately searchable (Milvus
+  otherwise flushes on its own schedule); handy for read-after-write in a smoke
+  test.
+
+Note that `search_embedding` requires the collection to have been **loaded**
+(done by `ensure_embedding_collection`), and only rows that have been flushed are
+visible to search.
+
 ## Regenerating the client
 
 The gRPC client is generated at build time from the protos vendored in

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -74,7 +74,10 @@ impl Modify for BabamulSecurityAddon {
         routes::queries::find::post_find_query,
         routes::queries::cone_search::post_cone_search_query,
         routes::surveys::cutouts::get_cutouts,
-        routes::queries::pipeline::post_pipeline_query
+        routes::queries::pipeline::post_pipeline_query,
+        routes::embeddings::post_similar_objects,
+        routes::embeddings::get_embeddings_count,
+        routes::embeddings::delete_object_embedding
     ),
     security(
         ("api_jwt_token" = [])

--- a/src/api/routes/embeddings.rs
+++ b/src/api/routes/embeddings.rs
@@ -1,0 +1,157 @@
+//! Endpoints backed by the Milvus vector store of CIDER fusion embeddings.
+//!
+//! Milvus is optional (see `milvus.enabled`), so these handlers receive the
+//! client as `web::Data<Option<MilvusClient>>` and reply with a clear error
+//! when it is switched off or was unreachable at startup. Every method on
+//! [`MilvusClient`] takes `&mut self`, so each handler clones the shared client
+//! (cheap — the tonic `Channel` shares one connection pool) to get a local
+//! owned copy rather than serializing all requests through a lock.
+
+use crate::api::models::response;
+use crate::api::routes::users::User;
+use crate::milvus::MilvusClient;
+
+use actix_web::{delete, get, post, web, HttpResponse};
+
+/// Request body for a similarity search seeded by a known object.
+#[derive(serde::Deserialize, utoipa::ToSchema)]
+pub struct SimilarObjectsQuery {
+    /// The object whose stored embedding seeds the search.
+    object_id: String,
+    /// How many neighbors to return (default 10, capped at 100). The seed
+    /// object itself is excluded, so at most `top_k` others come back.
+    top_k: Option<i64>,
+}
+
+const DEFAULT_TOP_K: i64 = 10;
+const MAX_TOP_K: i64 = 100;
+
+/// Grab the shared client, cloned for `&mut` use, or the "not enabled" reply.
+fn client_or_unavailable(
+    milvus: &web::Data<Option<MilvusClient>>,
+) -> Result<MilvusClient, HttpResponse> {
+    match milvus.get_ref() {
+        Some(client) => Ok(client.clone()),
+        None => Err(response::internal_error(
+            "Milvus is not enabled or was unavailable at startup",
+        )),
+    }
+}
+
+/// Find the objects most similar to a given object.
+///
+/// Looks up the seed object's stored embedding, then runs a nearest-neighbor
+/// search with it. The seed object (which would otherwise be its own closest
+/// match) is filtered out of the results.
+#[utoipa::path(
+    post,
+    path = "/similarity/objects",
+    request_body = SimilarObjectsQuery,
+    responses(
+        (status = 200, description = "Nearest neighbors, best-first", body = serde_json::Value),
+        (status = 404, description = "No embedding stored for the object"),
+        (status = 500, description = "Milvus unavailable or search failed")
+    ),
+    tags=["Similarity"]
+)]
+#[post("/similarity/objects")]
+pub async fn post_similar_objects(
+    milvus: web::Data<Option<MilvusClient>>,
+    body: web::Json<SimilarObjectsQuery>,
+) -> HttpResponse {
+    let mut client = match client_or_unavailable(&milvus) {
+        Ok(client) => client,
+        Err(resp) => return resp,
+    };
+
+    let object_id = body.object_id.trim();
+    if object_id.is_empty() {
+        return response::bad_request("object_id must not be empty");
+    }
+    let top_k = body.top_k.unwrap_or(DEFAULT_TOP_K).clamp(1, MAX_TOP_K);
+
+    // Fetch the seed object's embedding — the API caller supplies an id, not a
+    // raw 384-float vector, so we resolve it here before searching.
+    let seed = match client.get_embeddings(&[object_id]).await {
+        Ok(rows) => rows,
+        Err(e) => return response::internal_error(&format!("Error fetching embedding: {}", e)),
+    };
+    let Some(seed) = seed.into_iter().next() else {
+        return response::not_found(&format!("No embedding stored for object {}", object_id));
+    };
+
+    // Ask for one extra result: the seed object matches itself perfectly and is
+    // stripped out below, so this keeps up to `top_k` genuine neighbors.
+    let hits = match client.search_embedding(&seed.embedding, top_k + 1).await {
+        Ok(hits) => hits,
+        Err(e) => return response::internal_error(&format!("Error running search: {}", e)),
+    };
+
+    let neighbors: Vec<_> = hits
+        .into_iter()
+        .filter(|hit| hit.object_id != object_id)
+        .take(top_k as usize)
+        .collect();
+
+    response::ok_ser("success", neighbors)
+}
+
+/// Get the number of embeddings currently stored.
+#[utoipa::path(
+    get,
+    path = "/embeddings/count",
+    responses(
+        (status = 200, description = "Embedding count retrieved"),
+        (status = 500, description = "Milvus unavailable or count failed")
+    ),
+    tags=["Similarity"]
+)]
+#[get("/embeddings/count")]
+pub async fn get_embeddings_count(milvus: web::Data<Option<MilvusClient>>) -> HttpResponse {
+    let mut client = match client_or_unavailable(&milvus) {
+        Ok(client) => client,
+        Err(resp) => return resp,
+    };
+
+    match client.count().await {
+        Ok(count) => response::ok("success", serde_json::json!({ "count": count })),
+        Err(e) => response::internal_error(&format!("Error counting embeddings: {}", e)),
+    }
+}
+
+/// Delete the stored embedding for an object. Admin only.
+///
+/// Operational use — e.g. purging a retracted or spurious object so it stops
+/// polluting similarity results, or keeping Milvus in sync with Mongo.
+#[utoipa::path(
+    delete,
+    path = "/embeddings/{object_id}",
+    params(("object_id" = String, Path, description = "Object whose embedding to delete")),
+    responses(
+        (status = 200, description = "Deletion issued; reports how many rows were removed"),
+        (status = 403, description = "Admins only"),
+        (status = 500, description = "Milvus unavailable or delete failed")
+    ),
+    tags=["Similarity"]
+)]
+#[delete("/embeddings/{object_id}")]
+pub async fn delete_object_embedding(
+    milvus: web::Data<Option<MilvusClient>>,
+    current_user: web::ReqData<User>,
+    object_id: web::Path<String>,
+) -> HttpResponse {
+    if !current_user.is_admin {
+        return response::forbidden("Access denied: Admins only");
+    }
+
+    let mut client = match client_or_unavailable(&milvus) {
+        Ok(client) => client,
+        Err(resp) => return resp,
+    };
+
+    let object_id = object_id.into_inner();
+    match client.delete_embeddings(&[&object_id]).await {
+        Ok(deleted) => response::ok("success", serde_json::json!({ "deleted": deleted })),
+        Err(e) => response::internal_error(&format!("Error deleting embedding: {}", e)),
+    }
+}

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod babamul;
 pub mod catalogs;
+pub mod embeddings;
 pub mod filters;
 pub mod info;
 pub mod kafka;

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -8,6 +8,7 @@ use boom::api::email::EmailService;
 use boom::api::observability::request_metrics_middleware;
 use boom::api::routes;
 use boom::conf::{load_dotenv, AppConfig};
+use boom::milvus::MilvusClient;
 use boom::utils::cutouts::CutoutStorage;
 use boom::utils::enums::Survey;
 use boom::utils::o11y::{
@@ -60,6 +61,25 @@ async fn main() -> std::io::Result<()> {
     }
     let cutout_storages = web::Data::new(cutout_storage_map);
 
+    // Connect to Milvus once at startup when enabled. A failure here is
+    // non-fatal: the embedding endpoints reply with a clear error, but the rest
+    // of the API still boots. `None` means disabled or unreachable.
+    let milvus_client: Option<MilvusClient> = if config.milvus.enabled {
+        match MilvusClient::connect(&config.milvus).await {
+            Ok(client) => {
+                tracing::info!("Milvus embedding endpoints are ENABLED");
+                Some(client)
+            }
+            Err(e) => {
+                tracing::warn!("Milvus enabled but connection failed; embedding endpoints will be unavailable: {}", e);
+                None
+            }
+        }
+    } else {
+        tracing::info!("Milvus embedding endpoints are DISABLED");
+        None
+    };
+
     let babamul_is_enabled = config.babamul.enabled;
     if babamul_is_enabled {
         tracing::info!("Babamul API endpoints are ENABLED");
@@ -77,6 +97,7 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(database.clone()))
             .app_data(web::Data::new(auth.clone()))
             .app_data(web::Data::new(email_service.clone()))
+            .app_data(web::Data::new(milvus_client.clone()))
             .app_data(cutout_storages.clone())
             .wrap(from_fn(request_metrics_middleware));
 
@@ -149,6 +170,9 @@ async fn main() -> std::io::Result<()> {
                 .service(routes::queries::post_count_query)
                 .service(routes::queries::post_estimated_count_query)
                 .service(routes::queries::post_pipeline_query)
+                .service(routes::embeddings::post_similar_objects)
+                .service(routes::embeddings::get_embeddings_count)
+                .service(routes::embeddings::delete_object_embedding)
                 .wrap(Logger::default()),
         )
     })

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use boom::utils::gpu::validate_gpu_configuration_for_survey;
 use boom::{
     conf::{load_dotenv, AppConfig},
     enrichment::models::SharedModelPool,

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -1,6 +1,7 @@
 use boom::{
     conf::{load_dotenv, AppConfig},
     enrichment::models::SharedModelPool,
+    milvus::MilvusClient,
     scheduler::{record_worker_pool_state, ThreadPool},
     utils::{
         db::initialize_survey_indexes,
@@ -269,6 +270,22 @@ async fn run(
     initialize_survey_indexes(&args.survey, &db)
         .await
         .expect("could not initialize indexes");
+
+    // Provision the Milvus embeddings collection once, up front — the same
+    // single-actor pattern as the Mongo indexes above. The enrichment worker
+    // pool deliberately never creates it (concurrent workers would race), so the
+    // scheduler's main thread creates it before spawning the pool. Idempotent:
+    // ensure_embedding_collection's has_collection check no-ops when it already
+    // exists. ZTF-only, since ZTF is the only survey producing fusion embeddings.
+    if config.milvus.enabled && args.survey == Survey::Ztf {
+        let mut milvus = MilvusClient::connect(&config.milvus)
+            .await
+            .expect("could not connect to milvus to provision the embeddings collection");
+        milvus
+            .ensure_embedding_collection()
+            .await
+            .expect("could not provision the milvus embeddings collection");
+    }
 
     warn_if_missing_crossmatches(&args.survey, &db, &config).await;
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -853,7 +853,7 @@ fn default_milvus_timeout_seconds() -> u64 {
 }
 
 fn default_milvus_collection_name() -> String {
-    "ztf_fusion_embeddings".to_string()
+    "boom_ztf_fusion_embeddings".to_string()
 }
 
 fn default_milvus_dim() -> i64 {

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -422,6 +422,23 @@ pub struct ZtfAlertClassifications {
     pub fusion_embedding: Option<Vec<f32>>,
 }
 
+/// The classifications to persist in Mongo. When `keep_embedding` is false the
+/// 384-float `fusion_embedding` is dropped (it lives only in Milvus); the class
+/// probabilities are always kept either way.
+fn classifications_for_mongo(
+    cls: &ZtfAlertClassifications,
+    keep_embedding: bool,
+) -> ZtfAlertClassifications {
+    if keep_embedding {
+        cls.clone()
+    } else {
+        ZtfAlertClassifications {
+            fusion_embedding: None,
+            ..cls.clone()
+        }
+    }
+}
+
 /// Per-alert intermediate data used during enrichment processing.
 struct AlertWork {
     candid: i64,
@@ -634,14 +651,7 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
                 // Optionally drop the 384-float embedding from the stored
                 // classifications (the class probabilities are still kept); when
                 // disabled it lives only in Milvus.
-                let cls_doc = if WRITE_EMBEDDING_TO_MONGO {
-                    mongify(cls)
-                } else {
-                    mongify(&ZtfAlertClassifications {
-                        fusion_embedding: None,
-                        ..cls.clone()
-                    })
-                };
+                let cls_doc = mongify(&classifications_for_mongo(cls, WRITE_EMBEDDING_TO_MONGO));
                 doc! { "$set": {
                     "classifications": cls_doc,
                     "properties": mongify(&item.properties),
@@ -1193,5 +1203,42 @@ impl ZtfEnrichmentWorker {
         }
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_classifications() -> ZtfAlertClassifications {
+        ZtfAlertClassifications {
+            acai_h: 0.1,
+            acai_n: 0.2,
+            acai_v: 0.3,
+            acai_o: 0.4,
+            acai_b: 0.5,
+            btsbot: 0.6,
+            cider_fusion: None,
+            fusion_embedding: Some(vec![1.0, 2.0, 3.0]),
+        }
+    }
+
+    #[test]
+    fn keeps_embedding_when_writing_to_mongo() {
+        let cls = sample_classifications();
+        let stored = classifications_for_mongo(&cls, true);
+        assert_eq!(stored.fusion_embedding, Some(vec![1.0, 2.0, 3.0]));
+        // Class probabilities are untouched.
+        assert_eq!(stored.btsbot, cls.btsbot);
+    }
+
+    #[test]
+    fn strips_embedding_when_not_writing_to_mongo() {
+        let cls = sample_classifications();
+        let stored = classifications_for_mongo(&cls, false);
+        assert!(stored.fusion_embedding.is_none());
+        // Everything else is preserved.
+        assert_eq!(stored.acai_h, cls.acai_h);
+        assert_eq!(stored.btsbot, cls.btsbot);
     }
 }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -1201,29 +1201,18 @@ mod tests {
     }
 
     /// The enrichment worker takes the embedding out of the classifications
-    /// before building the Mongo document; this is that same step.
-    #[test]
-    fn taking_the_embedding_hands_it_over_and_keeps_the_scores() {
-        let mut cls = sample_classifications();
-        let embedding = cls.fusion_embedding.take();
-
-        // The vector goes to the caller (Milvus), not to the stored struct.
-        assert_eq!(embedding, Some(vec![1.0, 2.0, 3.0]));
-        assert!(cls.fusion_embedding.is_none());
-        // Everything else is preserved.
-        assert_eq!(cls.acai_h, 0.1);
-        assert_eq!(cls.btsbot, 0.6);
-    }
-
-    /// What actually matters: the document handed to Mongo has no vector in it,
-    /// whether or not Milvus is enabled.
+    /// before building the Mongo document: the vector goes to Milvus, and the
+    /// document Mongo receives has no `fusion_embedding` key at all.
     #[test]
     fn mongo_document_never_carries_the_embedding() {
         let mut cls = sample_classifications();
-        cls.fusion_embedding.take();
+        let embedding = cls.fusion_embedding.take();
         let doc = mongify(&cls);
 
+        assert_eq!(embedding, Some(vec![1.0, 2.0, 3.0]));
         assert!(doc.get("fusion_embedding").is_none());
         assert!(doc.get("btsbot").is_some());
+        assert_eq!(cls.acai_h, 0.1);
+        assert_eq!(cls.btsbot, 0.6);
     }
 }

--- a/src/milvus/collection.rs
+++ b/src/milvus/collection.rs
@@ -127,9 +127,7 @@ impl MilvusClient {
             %collection,
             missing = %missing.join(", "),
             found = %present.join(", "),
-            "collection schema does not match what BOOM writes; every upsert \
-             will fail. Point milvus.collection.name at a collection created by \
-             `milvus_check --create-collection`."
+            "collection is missing fields BOOM writes to Milvus, so every upsert will fail."
         );
     }
 

--- a/src/milvus/collection.rs
+++ b/src/milvus/collection.rs
@@ -48,11 +48,10 @@ impl MilvusClient {
 
         if self.has_collection(&collection_name).await? {
             info!(collection = %collection_name, "collection already exists");
-            // Existing is not the same as compatible: a collection provisioned
-            // by hand or by another project can carry an unrelated schema, in
-            // which case every upsert fails at runtime with "fieldName ... not
-            // exist in collection schema". Warn rather than abort, so a partial
-            // mismatch does not take down alert ingestion.
+            // A collection that exists is not necessarily one we can write to:
+            // if it was created by hand or by another project, its schema may
+            // not match ours and every upsert will fail. Warn rather than
+            // abort, so a mismatch does not take down alert ingestion.
             self.warn_on_schema_mismatch().await;
             return Ok(false);
         }
@@ -101,11 +100,7 @@ impl MilvusClient {
         Ok(response.value)
     }
 
-    /// Compare the server's schema against the fields [`super::insert`] writes
-    /// and log a warning describing any mismatch.
-    ///
-    /// Deliberately infallible: this is a diagnostic, so a failure to describe
-    /// the collection must not stop the caller from starting up.
+    /// Warn if the collection is missing any field [`super::insert`] writes.
     async fn warn_on_schema_mismatch(&mut self) {
         let collection = self.config().collection.name.clone();
 

--- a/src/milvus/collection.rs
+++ b/src/milvus/collection.rs
@@ -11,12 +11,13 @@
 //! ingested embedding. `candid` and `jd` record which alert that was.
 
 use prost::Message;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use super::client::{check_status, MilvusClient, MilvusError};
 use super::proto::common::KeyValuePair;
 use super::proto::milvus::{
-    CreateCollectionRequest, CreateIndexRequest, HasCollectionRequest, LoadCollectionRequest,
+    CreateCollectionRequest, CreateIndexRequest, DescribeCollectionRequest, HasCollectionRequest,
+    LoadCollectionRequest,
 };
 use super::proto::schema::{CollectionSchema, DataType, FieldSchema};
 
@@ -31,6 +32,10 @@ pub const FIELD_JD: &str = "jd";
 
 const INDEX_NAME: &str = "embedding_idx";
 
+/// Every field an upsert sends. A collection missing any of these cannot accept
+/// BOOM's writes.
+const REQUIRED_FIELDS: [&str; 4] = [FIELD_OBJECT_ID, FIELD_EMBEDDING, FIELD_CANDID, FIELD_JD];
+
 impl MilvusClient {
     /// Create the embeddings collection, its vector index, and load it into
     /// memory. Does nothing if the collection already exists.
@@ -43,6 +48,12 @@ impl MilvusClient {
 
         if self.has_collection(&collection_name).await? {
             info!(collection = %collection_name, "collection already exists");
+            // Existing is not the same as compatible: a collection provisioned
+            // by hand or by another project can carry an unrelated schema, in
+            // which case every upsert fails at runtime with "fieldName ... not
+            // exist in collection schema". Warn rather than abort, so a partial
+            // mismatch does not take down alert ingestion.
+            self.warn_on_schema_mismatch().await;
             return Ok(false);
         }
 
@@ -88,6 +99,69 @@ impl MilvusClient {
         check_status(response.status.as_ref(), "HasCollection")?;
 
         Ok(response.value)
+    }
+
+    /// Compare the server's schema against the fields [`super::insert`] writes
+    /// and log a warning describing any mismatch.
+    ///
+    /// Deliberately infallible: this is a diagnostic, so a failure to describe
+    /// the collection must not stop the caller from starting up.
+    async fn warn_on_schema_mismatch(&mut self) {
+        let collection = self.config().collection.name.clone();
+
+        let schema = match self.describe_collection().await {
+            Ok(schema) => schema,
+            Err(error) => {
+                warn!(%collection, %error, "could not verify collection schema");
+                return;
+            }
+        };
+
+        let present: Vec<&str> = schema.fields.iter().map(|f| f.name.as_str()).collect();
+        let missing: Vec<&str> = REQUIRED_FIELDS
+            .iter()
+            .copied()
+            .filter(|name| !present.contains(name))
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        warn!(
+            %collection,
+            missing = %missing.join(", "),
+            found = %present.join(", "),
+            "collection schema does not match what BOOM writes; every upsert \
+             will fail. Point milvus.collection.name at a collection created by \
+             `milvus_check --create-collection`."
+        );
+    }
+
+    /// The schema the server actually holds for the configured collection.
+    ///
+    /// Useful when a collection was provisioned by an older version of BOOM (or
+    /// by hand): the field names here must match what [`super::insert`] sends,
+    /// or every upsert fails with "fieldName ... not exist in collection schema".
+    #[instrument(skip_all, err)]
+    pub async fn describe_collection(&mut self) -> Result<CollectionSchema, MilvusError> {
+        let config = self.config().clone();
+        let request = DescribeCollectionRequest {
+            db_name: config.database.clone(),
+            collection_name: config.collection.name.clone(),
+            ..Default::default()
+        };
+
+        let response = self
+            .service()
+            .describe_collection(request)
+            .await?
+            .into_inner();
+        check_status(response.status.as_ref(), "DescribeCollection")?;
+
+        response
+            .schema
+            .ok_or(MilvusError::MissingStatus("DescribeCollection"))
     }
 
     /// Build the vector index on the embedding field.

--- a/src/milvus/insert.rs
+++ b/src/milvus/insert.rs
@@ -53,42 +53,12 @@ impl MilvusClient {
         }
 
         let config = self.config().clone();
-        let dim = config.collection.dim;
-
-        // Validate up front: one bad row would otherwise fail the whole batch
-        // server-side with a far less specific error.
-        for row in rows {
-            if row.embedding.len() as i64 != dim {
-                return Err(MilvusError::DimensionMismatch {
-                    expected: dim,
-                    got: row.embedding.len(),
-                });
-            }
-        }
-
-        // Transpose the rows into columns (Milvus's wire format).
-        let object_ids: Vec<String> = rows.iter().map(|r| r.object_id.clone()).collect();
-        let embeddings: Vec<f32> = rows
-            .iter()
-            .flat_map(|r| r.embedding.iter().copied())
-            .collect();
-        let candids: Vec<i64> = rows.iter().map(|r| r.candid).collect();
-        let jds: Vec<f64> = rows.iter().map(|r| r.jd).collect();
-
-        let fields_data = vec![
-            string_field(FIELD_OBJECT_ID, object_ids),
-            float_vector_field(FIELD_EMBEDDING, dim, embeddings),
-            long_field(FIELD_CANDID, candids),
-            double_field(FIELD_JD, jds),
-        ];
-
-        let request = UpsertRequest {
-            db_name: config.database.clone(),
-            collection_name: config.collection.name.clone(),
-            fields_data,
-            num_rows: rows.len() as u32,
-            ..Default::default()
-        };
+        let request = build_upsert_request(
+            &config.database,
+            &config.collection.name,
+            config.collection.dim,
+            rows,
+        )?;
 
         let result = self.service().upsert(request).await?.into_inner();
         check_status(result.status.as_ref(), "Upsert")?;
@@ -97,6 +67,51 @@ impl MilvusClient {
 
         Ok(result.upsert_cnt as u64)
     }
+}
+
+/// Validate the embeddings and transpose the rows into Milvus's column-oriented
+/// `UpsertRequest`. Split out from the RPC send so it can be tested without a
+/// live server. Assumes `rows` is non-empty.
+fn build_upsert_request(
+    db_name: &str,
+    collection_name: &str,
+    dim: i64,
+    rows: &[EmbeddingRow],
+) -> Result<UpsertRequest, MilvusError> {
+    // Validate up front: one bad row would otherwise fail the whole batch
+    // server-side with a far less specific error.
+    for row in rows {
+        if row.embedding.len() as i64 != dim {
+            return Err(MilvusError::DimensionMismatch {
+                expected: dim,
+                got: row.embedding.len(),
+            });
+        }
+    }
+
+    // Transpose the rows into columns (Milvus's wire format).
+    let object_ids: Vec<String> = rows.iter().map(|r| r.object_id.clone()).collect();
+    let embeddings: Vec<f32> = rows
+        .iter()
+        .flat_map(|r| r.embedding.iter().copied())
+        .collect();
+    let candids: Vec<i64> = rows.iter().map(|r| r.candid).collect();
+    let jds: Vec<f64> = rows.iter().map(|r| r.jd).collect();
+
+    let fields_data = vec![
+        string_field(FIELD_OBJECT_ID, object_ids),
+        float_vector_field(FIELD_EMBEDDING, dim, embeddings),
+        long_field(FIELD_CANDID, candids),
+        double_field(FIELD_JD, jds),
+    ];
+
+    Ok(UpsertRequest {
+        db_name: db_name.to_string(),
+        collection_name: collection_name.to_string(),
+        fields_data,
+        num_rows: rows.len() as u32,
+        ..Default::default()
+    })
 }
 
 fn string_field(name: &str, data: Vec<String>) -> FieldData {
@@ -181,6 +196,93 @@ mod tests {
                 _ => panic!("expected string data"),
             },
             _ => panic!("expected a scalar field"),
+        }
+    }
+
+    fn row(object_id: &str, embedding: Vec<f32>, candid: i64, jd: f64) -> EmbeddingRow {
+        EmbeddingRow {
+            object_id: object_id.to_string(),
+            embedding,
+            candid,
+            jd,
+        }
+    }
+
+    #[test]
+    fn build_upsert_request_rejects_dimension_mismatch() {
+        let rows = vec![
+            row("ZTF_A", vec![0.1, 0.2, 0.3], 1, 2400000.5),
+            row("ZTF_B", vec![0.1, 0.2], 2, 2400001.5), // wrong length
+        ];
+
+        let err = build_upsert_request("db", "coll", 3, &rows).unwrap_err();
+        match err {
+            MilvusError::DimensionMismatch { expected, got } => {
+                assert_eq!(expected, 3);
+                assert_eq!(got, 2);
+            }
+            other => panic!("expected DimensionMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_upsert_request_assembles_all_columns_in_order() {
+        let rows = vec![
+            row("ZTF_A", vec![1.0, 2.0], 10, 2400000.5),
+            row("ZTF_B", vec![3.0, 4.0], 20, 2400001.5),
+        ];
+
+        let request = build_upsert_request("mydb", "mycoll", 2, &rows).unwrap();
+
+        assert_eq!(request.db_name, "mydb");
+        assert_eq!(request.collection_name, "mycoll");
+        assert_eq!(request.num_rows, 2);
+
+        // Column order must match the schema field order.
+        let names: Vec<&str> = request
+            .fields_data
+            .iter()
+            .map(|f| f.field_name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec![FIELD_OBJECT_ID, FIELD_EMBEDDING, FIELD_CANDID, FIELD_JD]
+        );
+
+        // object_id column: both ids, in row order.
+        match &request.fields_data[0].field {
+            Some(Field::Scalars(ScalarField {
+                data: Some(scalar_field::Data::StringData(arr)),
+            })) => assert_eq!(arr.data, vec!["ZTF_A".to_string(), "ZTF_B".to_string()]),
+            other => panic!("object_id column malformed: {other:?}"),
+        }
+
+        // embedding column: the two rows' vectors flattened, dim recorded.
+        match &request.fields_data[1].field {
+            Some(Field::Vectors(VectorField {
+                dim,
+                data: Some(vector_field::Data::FloatVector(arr)),
+            })) => {
+                assert_eq!(*dim, 2);
+                assert_eq!(arr.data, vec![1.0, 2.0, 3.0, 4.0]);
+            }
+            other => panic!("embedding column malformed: {other:?}"),
+        }
+
+        // candid column.
+        match &request.fields_data[2].field {
+            Some(Field::Scalars(ScalarField {
+                data: Some(scalar_field::Data::LongData(arr)),
+            })) => assert_eq!(arr.data, vec![10, 20]),
+            other => panic!("candid column malformed: {other:?}"),
+        }
+
+        // jd column.
+        match &request.fields_data[3].field {
+            Some(Field::Scalars(ScalarField {
+                data: Some(scalar_field::Data::DoubleData(arr)),
+            })) => assert_eq!(arr.data, vec![2400000.5, 2400001.5]),
+            other => panic!("jd column malformed: {other:?}"),
         }
     }
 }

--- a/src/milvus/insert.rs
+++ b/src/milvus/insert.rs
@@ -70,8 +70,7 @@ impl MilvusClient {
 }
 
 /// Validate the embeddings and transpose the rows into Milvus's column-oriented
-/// `UpsertRequest`. Split out from the RPC send so it can be tested without a
-/// live server. Assumes `rows` is non-empty.
+/// `UpsertRequest`.
 fn build_upsert_request(
     db_name: &str,
     collection_name: &str,

--- a/src/milvus/mod.rs
+++ b/src/milvus/mod.rs
@@ -8,12 +8,14 @@ pub mod client;
 pub mod collection;
 pub mod insert;
 pub mod proto;
+pub mod search;
 
 pub use client::{MilvusClient, MilvusError};
 pub use collection::{
     embedding_collection_schema, FIELD_CANDID, FIELD_EMBEDDING, FIELD_JD, FIELD_OBJECT_ID,
 };
 pub use insert::EmbeddingRow;
+pub use search::SearchHit;
 
 /// Whether to *also* keep the CIDER fusion embedding in the Mongo
 /// `classifications` document, in addition to writing it to Milvus (which,

--- a/src/milvus/search.rs
+++ b/src/milvus/search.rs
@@ -1,0 +1,460 @@
+//! Reading embeddings back out of the collection: similarity search, lookup by
+//! `object_id`, counting, deletion, and flush.
+//!
+//! Milvus's read RPCs are column-oriented just like writes (see
+//! [`super::insert`]): results come back as one [`FieldData`] per column, which
+//! these helpers transpose back into rows.
+//!
+//! Similarity search additionally needs the query vectors wrapped in a
+//! protobuf-encoded [`PlaceholderGroup`] — Milvus does not accept raw floats on
+//! the `SearchRequest`. For a float vector each query vector is serialized as
+//! its little-endian `f32` bytes.
+
+use prost::Message;
+use tracing::{debug, instrument};
+
+use super::client::{check_status, MilvusClient, MilvusError};
+use super::collection::{FIELD_CANDID, FIELD_EMBEDDING, FIELD_JD, FIELD_OBJECT_ID};
+use super::insert::EmbeddingRow;
+use super::proto::common::{
+    DslType, KeyValuePair, PlaceholderGroup, PlaceholderType, PlaceholderValue,
+};
+use super::proto::milvus::{
+    search_request::SearchInput, DeleteRequest, FlushRequest, QueryRequest, SearchRequest,
+};
+use super::proto::schema::{
+    field_data, i_ds, scalar_field, vector_field, FieldData, SearchResultData,
+};
+
+/// One nearest-neighbor result from a similarity search.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchHit {
+    /// The matched object's identifier.
+    pub object_id: String,
+    /// Similarity score under the collection's metric (higher is closer for
+    /// `COSINE`/inner-product).
+    pub score: f32,
+    /// Candid stored with the matched embedding, if requested/available.
+    pub candid: Option<i64>,
+    /// Julian date stored with the matched embedding, if requested/available.
+    pub jd: Option<f64>,
+}
+
+impl MilvusClient {
+    /// Find the `top_k` objects whose stored embeddings are most similar to
+    /// `query`, using the collection's configured metric. Results are ordered
+    /// best-first.
+    #[instrument(skip_all, err, fields(collection = %self.config().collection.name, top_k))]
+    pub async fn search_embedding(
+        &mut self,
+        query: &[f32],
+        top_k: i64,
+    ) -> Result<Vec<SearchHit>, MilvusError> {
+        let config = self.config().clone();
+
+        if query.len() as i64 != config.collection.dim {
+            return Err(MilvusError::DimensionMismatch {
+                expected: config.collection.dim,
+                got: query.len(),
+            });
+        }
+
+        let search_params = vec![
+            kv("anns_field", FIELD_EMBEDDING),
+            kv("topk", &top_k.to_string()),
+            kv("metric_type", &config.collection.metric_type),
+            // Empty JSON lets Milvus use the index's default search params.
+            kv("params", "{}"),
+            kv("round_decimal", "-1"),
+        ];
+
+        let request = SearchRequest {
+            db_name: config.database.clone(),
+            collection_name: config.collection.name.clone(),
+            dsl: String::new(),
+            dsl_type: DslType::BoolExprV1 as i32,
+            search_input: Some(SearchInput::PlaceholderGroup(encode_float_placeholder(&[
+                query,
+            ]))),
+            output_fields: vec![FIELD_CANDID.to_string(), FIELD_JD.to_string()],
+            search_params,
+            nq: 1,
+            use_default_consistency: true,
+            ..Default::default()
+        };
+
+        let response = self.service().search(request).await?.into_inner();
+        check_status(response.status.as_ref(), "Search")?;
+
+        let hits = parse_search_hits(response.results);
+        debug!(hits = hits.len(), "search returned");
+        Ok(hits)
+    }
+
+    /// Fetch the stored rows for the given `object_ids`. Missing ids are simply
+    /// absent from the result; order is not guaranteed to match the input.
+    #[instrument(skip_all, err, fields(collection = %self.config().collection.name, ids = object_ids.len()))]
+    pub async fn get_embeddings(
+        &mut self,
+        object_ids: &[&str],
+    ) -> Result<Vec<EmbeddingRow>, MilvusError> {
+        if object_ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let config = self.config().clone();
+
+        let request = QueryRequest {
+            db_name: config.database.clone(),
+            collection_name: config.collection.name.clone(),
+            expr: object_id_in_expr(object_ids),
+            output_fields: vec![
+                FIELD_OBJECT_ID.to_string(),
+                FIELD_EMBEDDING.to_string(),
+                FIELD_CANDID.to_string(),
+                FIELD_JD.to_string(),
+            ],
+            use_default_consistency: true,
+            ..Default::default()
+        };
+
+        let response = self.service().query(request).await?.into_inner();
+        check_status(response.status.as_ref(), "Query")?;
+
+        Ok(parse_embedding_rows(&response.fields_data))
+    }
+
+    /// Total number of rows (objects) currently in the collection.
+    #[instrument(skip_all, err, fields(collection = %self.config().collection.name))]
+    pub async fn count(&mut self) -> Result<i64, MilvusError> {
+        let config = self.config().clone();
+
+        let request = QueryRequest {
+            db_name: config.database.clone(),
+            collection_name: config.collection.name.clone(),
+            expr: String::new(),
+            output_fields: vec!["count(*)".to_string()],
+            use_default_consistency: true,
+            ..Default::default()
+        };
+
+        let response = self.service().query(request).await?.into_inner();
+        check_status(response.status.as_ref(), "Query")?;
+
+        let count = long_column(&response.fields_data, "count(*)")
+            .and_then(|c| c.first().copied())
+            .unwrap_or(0);
+        Ok(count)
+    }
+
+    /// Delete the rows for the given `object_ids`. Returns the number deleted.
+    #[instrument(skip_all, err, fields(collection = %self.config().collection.name, ids = object_ids.len()))]
+    pub async fn delete_embeddings(&mut self, object_ids: &[&str]) -> Result<u64, MilvusError> {
+        if object_ids.is_empty() {
+            return Ok(0);
+        }
+        let config = self.config().clone();
+
+        let request = DeleteRequest {
+            db_name: config.database.clone(),
+            collection_name: config.collection.name.clone(),
+            expr: object_id_in_expr(object_ids),
+            ..Default::default()
+        };
+
+        let result = self.service().delete(request).await?.into_inner();
+        check_status(result.status.as_ref(), "Delete")?;
+        Ok(result.delete_cnt as u64)
+    }
+
+    /// Flush the collection, sealing recent writes so they become searchable.
+    /// Milvus flushes on its own schedule; call this when you need read-after-
+    /// write visibility immediately (e.g. a smoke test).
+    #[instrument(skip_all, err, fields(collection = %self.config().collection.name))]
+    pub async fn flush(&mut self) -> Result<(), MilvusError> {
+        let config = self.config().clone();
+
+        let request = FlushRequest {
+            db_name: config.database.clone(),
+            collection_names: vec![config.collection.name.clone()],
+            ..Default::default()
+        };
+
+        let response = self.service().flush(request).await?.into_inner();
+        check_status(response.status.as_ref(), "Flush")?;
+        Ok(())
+    }
+}
+
+/// Build a `object_id in ["a", "b"]` boolean expression.
+///
+/// The ids are wrapped in quotes; any embedded `"` or `\` is stripped first so
+/// a malformed id can't break the expression. Survey object ids are plain
+/// alphanumerics, so this never alters a legitimate value.
+fn object_id_in_expr(object_ids: &[&str]) -> String {
+    let list = object_ids
+        .iter()
+        .map(|id| {
+            let sanitized: String = id.chars().filter(|c| *c != '"' && *c != '\\').collect();
+            format!("\"{sanitized}\"")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{FIELD_OBJECT_ID} in [{list}]")
+}
+
+/// Serialize float query vectors into a Milvus `PlaceholderGroup` (each vector
+/// as little-endian `f32` bytes).
+fn encode_float_placeholder(vectors: &[&[f32]]) -> Vec<u8> {
+    let values: Vec<Vec<u8>> = vectors
+        .iter()
+        .map(|v| {
+            let mut bytes = Vec::with_capacity(v.len() * 4);
+            for &f in *v {
+                bytes.extend_from_slice(&f.to_le_bytes());
+            }
+            bytes
+        })
+        .collect();
+
+    let placeholder = PlaceholderValue {
+        tag: "$0".to_string(),
+        r#type: PlaceholderType::FloatVector as i32,
+        values,
+        element_level: false,
+    };
+
+    PlaceholderGroup {
+        placeholders: vec![placeholder],
+    }
+    .encode_to_vec()
+}
+
+fn parse_search_hits(data: Option<SearchResultData>) -> Vec<SearchHit> {
+    let Some(data) = data else {
+        return vec![];
+    };
+
+    // The primary key is a VarChar, so ids come back as string ids.
+    let object_ids = match data.ids.and_then(|i| i.id_field) {
+        Some(i_ds::IdField::StrId(arr)) => arr.data,
+        _ => return vec![],
+    };
+
+    let candids = long_column(&data.fields_data, FIELD_CANDID);
+    let jds = double_column(&data.fields_data, FIELD_JD);
+
+    object_ids
+        .into_iter()
+        .enumerate()
+        .map(|(i, object_id)| SearchHit {
+            object_id,
+            score: data.scores.get(i).copied().unwrap_or(f32::NAN),
+            candid: candids.as_ref().and_then(|c| c.get(i).copied()),
+            jd: jds.as_ref().and_then(|j| j.get(i).copied()),
+        })
+        .collect()
+}
+
+fn parse_embedding_rows(fields: &[FieldData]) -> Vec<EmbeddingRow> {
+    let object_ids = string_column(fields, FIELD_OBJECT_ID).unwrap_or_default();
+    let (dim, flat) = float_vector_column(fields, FIELD_EMBEDDING).unwrap_or((0, vec![]));
+    let candids = long_column(fields, FIELD_CANDID).unwrap_or_default();
+    let jds = double_column(fields, FIELD_JD).unwrap_or_default();
+
+    object_ids
+        .into_iter()
+        .enumerate()
+        .map(|(i, object_id)| {
+            let embedding = if dim > 0 {
+                let start = i * dim;
+                flat.get(start..start + dim)
+                    .map(<[f32]>::to_vec)
+                    .unwrap_or_default()
+            } else {
+                vec![]
+            };
+            EmbeddingRow {
+                object_id,
+                embedding,
+                candid: candids.get(i).copied().unwrap_or_default(),
+                jd: jds.get(i).copied().unwrap_or_default(),
+            }
+        })
+        .collect()
+}
+
+fn find_field<'a>(fields: &'a [FieldData], name: &str) -> Option<&'a FieldData> {
+    fields.iter().find(|f| f.field_name == name)
+}
+
+fn long_column(fields: &[FieldData], name: &str) -> Option<Vec<i64>> {
+    match &find_field(fields, name)?.field {
+        Some(field_data::Field::Scalars(s)) => match &s.data {
+            Some(scalar_field::Data::LongData(a)) => Some(a.data.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn double_column(fields: &[FieldData], name: &str) -> Option<Vec<f64>> {
+    match &find_field(fields, name)?.field {
+        Some(field_data::Field::Scalars(s)) => match &s.data {
+            Some(scalar_field::Data::DoubleData(a)) => Some(a.data.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn string_column(fields: &[FieldData], name: &str) -> Option<Vec<String>> {
+    match &find_field(fields, name)?.field {
+        Some(field_data::Field::Scalars(s)) => match &s.data {
+            Some(scalar_field::Data::StringData(a)) => Some(a.data.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns `(dim, flat)` for a float-vector column.
+fn float_vector_column(fields: &[FieldData], name: &str) -> Option<(usize, Vec<f32>)> {
+    match &find_field(fields, name)?.field {
+        Some(field_data::Field::Vectors(v)) => match &v.data {
+            Some(vector_field::Data::FloatVector(a)) => Some((v.dim as usize, a.data.clone())),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn kv(key: &str, value: &str) -> KeyValuePair {
+    KeyValuePair {
+        key: key.to_string(),
+        value: value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::milvus::proto::schema::{
+        i_ds, scalar_field, DoubleArray, FloatArray, IDs, LongArray, ScalarField, StringArray,
+        VectorField,
+    };
+
+    fn scalar(name: &str, data: scalar_field::Data) -> FieldData {
+        FieldData {
+            field_name: name.to_string(),
+            field: Some(field_data::Field::Scalars(ScalarField { data: Some(data) })),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn object_id_in_expr_quotes_and_sanitizes() {
+        assert_eq!(
+            object_id_in_expr(&["ZTF_A", "ZTF_B"]),
+            r#"object_id in ["ZTF_A", "ZTF_B"]"#
+        );
+        // Quotes/backslashes are stripped, so the expression stays well-formed.
+        assert_eq!(object_id_in_expr(&["ev\"il"]), r#"object_id in ["evil"]"#);
+    }
+
+    #[test]
+    fn encode_float_placeholder_lays_out_little_endian_floats() {
+        let bytes = encode_float_placeholder(&[&[1.0f32, 2.0]]);
+        let group = PlaceholderGroup::decode(bytes.as_slice()).unwrap();
+        let ph = &group.placeholders[0];
+        assert_eq!(ph.r#type, PlaceholderType::FloatVector as i32);
+        assert_eq!(ph.values.len(), 1);
+        assert_eq!(
+            ph.values[0],
+            [1.0f32.to_le_bytes(), 2.0f32.to_le_bytes()].concat()
+        );
+    }
+
+    #[test]
+    fn parse_search_hits_zips_ids_scores_and_metadata() {
+        let data = SearchResultData {
+            scores: vec![0.9, 0.8],
+            ids: Some(IDs {
+                id_field: Some(i_ds::IdField::StrId(StringArray {
+                    data: vec!["ZTF_A".into(), "ZTF_B".into()],
+                })),
+            }),
+            fields_data: vec![
+                scalar(
+                    FIELD_CANDID,
+                    scalar_field::Data::LongData(LongArray { data: vec![10, 20] }),
+                ),
+                scalar(
+                    FIELD_JD,
+                    scalar_field::Data::DoubleData(DoubleArray {
+                        data: vec![2400000.5, 2400001.5],
+                    }),
+                ),
+            ],
+            ..Default::default()
+        };
+
+        let hits = parse_search_hits(Some(data));
+        assert_eq!(
+            hits,
+            vec![
+                SearchHit {
+                    object_id: "ZTF_A".into(),
+                    score: 0.9,
+                    candid: Some(10),
+                    jd: Some(2400000.5),
+                },
+                SearchHit {
+                    object_id: "ZTF_B".into(),
+                    score: 0.8,
+                    candid: Some(20),
+                    jd: Some(2400001.5),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_embedding_rows_splits_flat_vector_by_dim() {
+        let fields = vec![
+            scalar(
+                FIELD_OBJECT_ID,
+                scalar_field::Data::StringData(StringArray {
+                    data: vec!["ZTF_A".into(), "ZTF_B".into()],
+                }),
+            ),
+            FieldData {
+                field_name: FIELD_EMBEDDING.to_string(),
+                field: Some(field_data::Field::Vectors(VectorField {
+                    dim: 2,
+                    data: Some(vector_field::Data::FloatVector(FloatArray {
+                        data: vec![1.0, 2.0, 3.0, 4.0],
+                    })),
+                })),
+                ..Default::default()
+            },
+            scalar(
+                FIELD_CANDID,
+                scalar_field::Data::LongData(LongArray { data: vec![10, 20] }),
+            ),
+            scalar(
+                FIELD_JD,
+                scalar_field::Data::DoubleData(DoubleArray {
+                    data: vec![2400000.5, 2400001.5],
+                }),
+            ),
+        ];
+
+        let rows = parse_embedding_rows(&fields);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].object_id, "ZTF_A");
+        assert_eq!(rows[0].embedding, vec![1.0, 2.0]);
+        assert_eq!(rows[1].embedding, vec![3.0, 4.0]);
+        assert_eq!(rows[1].candid, 20);
+        assert_eq!(rows[1].jd, 2400001.5);
+    }
+}

--- a/src/milvus/search.rs
+++ b/src/milvus/search.rs
@@ -27,7 +27,7 @@ use super::proto::schema::{
 };
 
 /// One nearest-neighbor result from a similarity search.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct SearchHit {
     /// The matched object's identifier.
     pub object_id: String,

--- a/src/milvus/search.rs
+++ b/src/milvus/search.rs
@@ -41,9 +41,8 @@ pub struct SearchHit {
 }
 
 impl MilvusClient {
-    /// Find the `top_k` objects whose stored embeddings are most similar to
-    /// `query`, using the collection's configured metric. Results are ordered
-    /// best-first.
+    /// Find the `top_k` objects whose stored embeddings are most similar.
+    /// Results are ordered best-first.
     #[instrument(skip_all, err, fields(collection = %self.config().collection.name, top_k))]
     pub async fn search_embedding(
         &mut self,

--- a/tests/test_milvus_e2e.rs
+++ b/tests/test_milvus_e2e.rs
@@ -1,0 +1,164 @@
+#![recursion_limit = "512"] // for large bson docs and CutoutStorage's s3 client
+//! End-to-end: a sample ZTF alert flows through the whole stream — ingestion,
+//! then the enrichment worker (which runs the CIDER fusion model and upserts the
+//! resulting embedding to Milvus) — and is then read back out of Milvus with the
+//! similarity-search / query / count APIs.
+//!
+//! The ZTF enrichment worker only writes embeddings when `milvus.enabled`, so
+//! this test is **gated on the config**: with Milvus disabled it logs a skip and
+//! returns. That is the case in CI, where `.env` is copied from `.env.example`
+//! (`BOOM_MILVUS__ENABLED=false`). To run it for real, set `BOOM_MILVUS__*` in
+//! `.env` (see `docs/milvus.md`); it then runs against whatever Milvus those
+//! credentials point at, provisioning the collection if it does not yet exist.
+use boom::{
+    alert::{AlertWorker, ProcessAlertStatus},
+    conf::{self},
+    enrichment::{EnrichmentWorker, ZtfEnrichmentWorker},
+    milvus::{EmbeddingRow, MilvusClient},
+    utils::{
+        enums::Survey,
+        testing::{
+            drop_alert_from_collections, ztf_alert_worker, AlertRandomizer, TEST_CONFIG_FILE,
+        },
+    },
+};
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn test_ztf_alert_to_milvus_e2e() {
+    // Loads `.env` too, so BOOM_MILVUS__* overrides are applied here just as they
+    // are inside the enrichment worker.
+    let config = conf::load_config(Some(TEST_CONFIG_FILE)).expect("failed to load test config");
+
+    if !config.milvus.enabled {
+        eprintln!(
+            "skipping test_ztf_alert_to_milvus_e2e: milvus is disabled. Set \
+             BOOM_MILVUS__ENABLED=true (and the credentials) in .env to run the \
+             full end-to-end flow — see docs/milvus.md."
+        );
+        return;
+    }
+
+    // The enrichment worker connects to Milvus but never provisions the
+    // collection, and similarity search needs it loaded — so make sure the
+    // collection exists and is loaded up front.
+    let mut client = MilvusClient::connect(&config.milvus)
+        .await
+        .expect("failed to connect to milvus");
+    client
+        .ensure_embedding_collection()
+        .await
+        .expect("failed to ensure embeddings collection");
+    // ensure_embedding_collection() skips the load when the collection already
+    // exists, so load explicitly (idempotent). Search rejects an unloaded
+    // collection.
+    client
+        .load_collection()
+        .await
+        .expect("failed to load collection");
+
+    // 1. Ingest a sample ZTF alert. Randomizing the candid and object_id keeps
+    //    the run self-contained and makes its Milvus row (keyed by object_id)
+    //    unique, so the assertions and cleanup below can't collide with other
+    //    data in the collection.
+    let (candid, object_id, _ra, _dec, bytes) = AlertRandomizer::new(Survey::Ztf)
+        .rand_candid()
+        .rand_object_id()
+        .get()
+        .await;
+
+    let mut alert_worker = ztf_alert_worker().await;
+    let status = alert_worker.process_alert(&bytes).await.unwrap();
+    assert_eq!(status, ProcessAlertStatus::Added(candid));
+
+    // Clear any leftover row from a previously aborted run of this same id.
+    client.delete_embeddings(&[&object_id]).await.ok();
+
+    // 2. Enrich: runs ML classification + the CIDER fusion model and upserts the
+    //    384-float embedding to Milvus, keyed by object_id.
+    let mut enrichment_worker = ZtfEnrichmentWorker::new(TEST_CONFIG_FILE, None)
+        .await
+        .unwrap();
+    let enrichment_output = enrichment_worker
+        .process_alerts(&[candid])
+        .await
+        .expect("enrichment failed");
+    // ZTF enrichment returns "programid,candid" strings for the filter worker.
+    assert_eq!(enrichment_output, vec![format!("1,{}", candid)]);
+
+    // 3. Seal recent writes so they become visible to reads immediately (Milvus
+    //    otherwise flushes on its own schedule).
+    client.flush().await.expect("flush failed");
+
+    // 4. Read the embedding back by object_id. Milvus makes upserts queryable
+    //    asynchronously, so poll briefly for read-after-write visibility.
+    let row = read_embedding_with_retry(&mut client, &object_id).await;
+    assert_eq!(row.object_id, object_id);
+    assert_eq!(row.candid, candid, "stored candid should match the alert");
+    assert_eq!(
+        row.embedding.len(),
+        config.milvus.collection.dim as usize,
+        "stored embedding must have the collection's configured dimensionality"
+    );
+    assert!(
+        row.jd > 0.0,
+        "jd should be a real Julian date, got {}",
+        row.jd
+    );
+
+    // 5. Similarity search with the stored vector must find the object itself, at
+    //    a near-perfect score (COSINE self-match on an L2-normalized vector).
+    let hits = client
+        .search_embedding(&row.embedding, 5)
+        .await
+        .expect("similarity search failed");
+    let self_hit = hits
+        .iter()
+        .find(|h| h.object_id == object_id)
+        .expect("similarity search should return the object we just inserted");
+    assert!(
+        self_hit.score > 0.99,
+        "self-similarity should be ~1.0 under COSINE, got {}",
+        self_hit.score
+    );
+    assert_eq!(
+        self_hit.candid,
+        Some(candid),
+        "search hit should carry the stored candid"
+    );
+
+    // The collection now holds at least our row.
+    assert!(
+        client.count().await.expect("count failed") >= 1,
+        "collection should contain at least the row we just wrote"
+    );
+
+    // 6. Clean up: remove our Milvus row and the Mongo alert so the test leaves
+    //    no trace.
+    client
+        .delete_embeddings(&[&object_id])
+        .await
+        .expect("failed to delete embedding");
+    drop_alert_from_collections(candid, &Survey::Ztf)
+        .await
+        .unwrap();
+}
+
+/// Poll `get_embeddings` until the row for `object_id` is visible, or give up.
+/// A just-upserted vector is not always readable on the first attempt because
+/// Milvus applies writes asynchronously.
+async fn read_embedding_with_retry(client: &mut MilvusClient, object_id: &str) -> EmbeddingRow {
+    const ATTEMPTS: usize = 20;
+    for _ in 0..ATTEMPTS {
+        let rows = client
+            .get_embeddings(&[object_id])
+            .await
+            .expect("get_embeddings failed");
+        if let Some(row) = rows.into_iter().find(|r| r.object_id == object_id) {
+            return row;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+    panic!("embedding for {object_id} never became visible in Milvus after {ATTEMPTS} attempts");
+}


### PR DESCRIPTION
Adds the read side of the Milvus integration. #543 got alert embeddings into the vector database; this PR lets us get them back out, and adds tests for both directions.

The new src/milvus/search.rs can:

- find the objects most similar to a given vector
- look up stored vectors by object ID
- count what's in the collection
- delete objects
- make recent writes searchable right away
- This is the groundwork for the similarity-search API endpoints in #548.

Also adds 9 unit tests — 4 on building upsert requests, 4 on reading Milvus's responses, and 1 confirming embeddings go only to Milvus and never into MongoDB. They all run offline, so CI needs no Milvus server or NRP credentials.

No change to alert processing. Docs updated in docs/milvus.md.