### PR TITLE
Update alerting for queue not draining

### DIFF
--- a/config/grafana/provisioning/alerting/rules.yaml
+++ b/config/grafana/provisioning/alerting/rules.yaml
@@ -210,12 +210,29 @@ groups:
             datasourceUid: prometheus
             model:
               refId: A
-              # min_over_time means the queue's low-water mark over the last 30m is
-              # still above the threshold: even at its emptiest it never drained,
-              # i.e. a consumer is absent or can't keep up. A transient spike that
-              # drains within 30m won't trip this.
+              # Two conditions, both required:
+              #
+              #   1. min_over_time > 50k -- the queue's low-water mark over the last
+              #      30m is still above the threshold: even at its emptiest it never
+              #      drained. A transient spike that clears within 30m won't trip this.
+              #   2. deriv(...) >= 0 -- the queue is flat or growing. This is the
+              #      actual fault signal. Do NOT reintroduce a rate/ETA test here: a
+              #      backlog that legitimately takes weeks to chew through is still
+              #      draining and must stay silent, so we ask only whether the number
+              #      is moving down at all, never how fast.
+              #
+              # deriv is a least-squares slope (items/sec) over the window, not an
+              # endpoint diff, so a single scrape blip can't flip its sign. 15m is
+              # deliberate: at a 15s scrape that is ~60 samples for the regression,
+              # and it tolerates batchy consumers that can sit still for a minute or
+              # two between chunks. Shortening it toward 1m makes the alert flap on
+              # exactly those slow-but-healthy queues.
               expr: |
-                max by (key) (min_over_time(redis_key_size{key=~".*_queue.*"}[30m])) > 50000
+                max by (key) (
+                    (min_over_time(redis_key_size{key=~".*_queue.*"}[30m]) > 50000)
+                  and
+                    (deriv(redis_key_size{key=~".*_queue.*"}[15m]) >= 0)
+                )
               instant: true
               intervalMs: 1000
               maxDataPoints: 43200
@@ -248,8 +265,8 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: 'Valkey queue {{ $labels.key }} stayed above 50k for 30m (not draining)'
-          description: 'A worker pool is not draining its upstream queue. Check scheduler logs/traces and worker health.'
+          summary: 'Valkey queue {{ $labels.key }} stayed above 50k for 30m and stopped moving'
+          description: 'A worker pool is making no headway on its upstream queue: the queue never dipped below 50k in the last 30m, and its depth has been flat or growing for the last 15m. Check scheduler logs/traces and worker health. A backlog that is draining slowly -- even one that will take days or weeks -- will not fire this; only one that has stopped going down.'
 
       - uid: scheduler-worker-pool-degraded
         title: Scheduler worker pool degraded (dead workers)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -162,7 +162,7 @@ Alert rules, contact points, and notification policies are provisioned from
 | `container-restart-flapping` | Container restarted >3 times in 1h |
 | `cpu-throttling` | >25% of CFS periods throttled for 15m |
 | `otel-collector-dropped-metrics` | OTel exporter is failing to send metric points |
-| `valkey-queue-backed-up` | Any worker queue >50k entries for 15m |
+| `valkey-queue-backed-up` | Any worker queue >50k entries for 30m *and* flat or growing for 15m (slow drain is fine) |
 
 All alerts route to a single **Slack** contact point. Set
 `SLACK_WEBHOOK_URL` in your environment / `.env` to a Slack incoming-webhook


### PR DESCRIPTION
Existing alarm fires for a queue that's draining, but will take a very long time, like the current reprocessing.