### PR TITLE
Add --date-mode to consume a single night, and fix consumer fencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,6 @@ starts on today's topic(s):
   subscribed at once, each new nightly topic is picked up as it appears, and the
   process never exits. Partitions the consumer group has already read resume
   where they left off.
-  A date more than 30 nights back is refused: that is past what any survey
-  retains, so the extra topics no longer exist.
 - `--on DATE` replays that date's topic(s) alone, never rolling onto new nights.
   It runs in its own consumer group (the configured one suffixed with the date)
   and commits no offsets, so it leaves the long-running consumers alone and the

--- a/README.md
+++ b/README.md
@@ -357,6 +357,23 @@ To continue with the previous example, you can run:
 cargo run --release --bin kafka_consumer ztf 20240617 --programids public
 ```
 
+`DATE` defaults to today (at 00:00:00 UTC), and `--date-mode` controls how it is
+interpreted:
+
+- `from` (the default) consumes that date **and every night after it**. The
+  consumer subscribes to a topic pattern, so each new nightly topic is picked up
+  automatically and the process never exits. The date only acts as a starting
+  point for partitions the consumer group has never read: earlier nights are
+  skipped, and partitions with a committed offset resume where they left off.
+- `single` consumes **only** that date's topic(s) and exits once they are
+  drained. Offsets are not committed and a throwaway consumer group is used, so
+  replaying a night is repeatable and leaves the long-running consumers alone.
+
+```bash
+# Re-ingest a single night, then exit:
+cargo run --release --bin kafka_consumer ztf 20240617 --programids public --date-mode single
+```
+
 ### Alert Processing
 
 Now that alerts have been queued for processing, let's start the workers that will process them. Instead of starting each worker manually, we provide the `scheduler` binary. You can run it with:

--- a/README.md
+++ b/README.md
@@ -359,10 +359,25 @@ cargo run --release --bin kafka_consumer <SURVEY> [DATE] --programids [PROGRAMID
 
 This will start a `Kafka` consumer, which will read the alerts from a given `Kafka` topic and transfer them to `Redis`/`Valkey` in-memory queue that the processing pipeline will read from.
 
+`DATE` defaults to today (at 00:00:00 UTC), and `--date-mode` controls how it is
+interpreted:
+
+- `from` (the default) starts at that date and keeps going: every night since is
+  subscribed at once, each new nightly topic is picked up as it appears, and the
+  process never exits. Partitions the consumer group has already read resume
+  where they left off.
+- `single` consumes **only** that date's topic(s) and exits once they are
+  drained. Offsets are not committed and a throwaway consumer group is used, so
+  replaying a night is repeatable and leaves the long-running consumers alone.
+
 To continue with the previous example, you can run:
 
 ```bash
+# Consume that night and every night after it:
 cargo run --release --bin kafka_consumer ztf 20240617 --programids public
+
+# Re-ingest that single night, then exit:
+cargo run --release --bin kafka_consumer ztf 20240617 --programids public --date-mode single
 ```
 
 ### Alert Processing

--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ interpreted:
   subscribed at once, each new nightly topic is picked up as it appears, and the
   process never exits. Partitions the consumer group has already read resume
   where they left off.
+  A date more than 30 nights back is refused: that is past what any survey
+  retains, so the extra topics no longer exist.
+- `pinned` stays on that date's topic(s), without rolling onto new nights, and
+  keeps running once they are drained.
 - `single` consumes **only** that date's topic(s) and exits once they are
   drained. Offsets are not committed and a throwaway consumer group is used, so
   replaying a night is repeatable and leaves the long-running consumers alone.

--- a/README.md
+++ b/README.md
@@ -354,34 +354,36 @@ docker exec -it broker /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker:
 Next, you can start the `Kafka` consumer with:
 
 ```bash
-cargo run --release --bin kafka_consumer <SURVEY> [DATE] --programids [PROGRAMIDS]
+cargo run --release --bin kafka_consumer <SURVEY> --programids [PROGRAMIDS]
 ```
 
 This will start a `Kafka` consumer, which will read the alerts from a given `Kafka` topic and transfer them to `Redis`/`Valkey` in-memory queue that the processing pipeline will read from.
 
-`DATE` defaults to today (at 00:00:00 UTC), and `--date-mode` controls how it is
-interpreted:
+Which night(s) it reads is set by `--from` or `--on`, both taking a UTC date in
+`YYYYMMDD` format. They are mutually exclusive, and with neither the consumer
+starts on today's topic(s):
 
-- `from` (the default) starts at that date and keeps going: every night since is
+- `--from DATE` starts at that date and keeps going: every night since is
   subscribed at once, each new nightly topic is picked up as it appears, and the
   process never exits. Partitions the consumer group has already read resume
   where they left off.
   A date more than 30 nights back is refused: that is past what any survey
   retains, so the extra topics no longer exist.
-- `pinned` stays on that date's topic(s), without rolling onto new nights, and
-  keeps running once they are drained.
-- `single` consumes **only** that date's topic(s) and exits once they are
-  drained. Offsets are not committed and a throwaway consumer group is used, so
-  replaying a night is repeatable and leaves the long-running consumers alone.
+- `--on DATE` replays that date's topic(s) alone, never rolling onto new nights.
+  It runs in its own consumer group (the configured one suffixed with the date)
+  and commits no offsets, so it leaves the long-running consumers alone and the
+  night can be replayed as often as needed. It keeps running once the topics are
+  drained, unless you add `--exit-on-eof`, which is only accepted alongside
+  `--on`.
 
 To continue with the previous example, you can run:
 
 ```bash
 # Consume that night and every night after it:
-cargo run --release --bin kafka_consumer ztf 20240617 --programids public
+cargo run --release --bin kafka_consumer ztf --from 20240617 --programids public
 
 # Re-ingest that single night, then exit:
-cargo run --release --bin kafka_consumer ztf 20240617 --programids public --date-mode single
+cargo run --release --bin kafka_consumer ztf --on 20240617 --programids public --exit-on-eof
 ```
 
 ### Alert Processing

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -207,7 +207,7 @@ services:
       - --ignore
       - target
       - -x
-      - run --bin kafka_consumer -- ztf 20240617 --programids public --config /app/config.yaml
+      - run --bin kafka_consumer -- ztf --on 20240617 --programids public --config /app/config.yaml
     volumes:
       - ./src:/app/src
       - ./apache-avro-macros:/app/apache-avro-macros

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -21,6 +21,17 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::{error, info};
 use uuid::Uuid;
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq)]
+enum DateMode {
+    /// Consume `date` and every night after it, rolling over to each new
+    /// topic as it appears, and never exit
+    #[default]
+    From,
+    /// Consume only the topic(s) for `date`, then exit. Offsets are not
+    /// committed, so a night can be replayed as often as needed
+    Single,
+}
+
 #[derive(Parser)]
 struct Cli {
     /// Survey to consume alerts from
@@ -31,6 +42,11 @@ struct Cli {
     /// [default: today's date at 00:00:00 UTC]
     #[arg(value_parser = parse_date)]
     date: Option<NaiveDateTime>, // Easier to deal with the default value after clap
+
+    /// Whether `date` is a starting point ("from", the default) or the only
+    /// date to consume ("single")
+    #[arg(long, value_enum, default_value_t = DateMode::From)]
+    date_mode: DateMode,
 
     /// ID(s) of the program(s) to consume the alerts (ZTF-only). Defaults to "public" program if not specified (e.g. --programids public,partnership,caltech).
     #[arg(long, value_enum, value_delimiter = ',', default_value = "public")]
@@ -82,12 +98,8 @@ fn parse_date(s: &str) -> Result<NaiveDateTime, String> {
     Ok(date.and_hms_opt(0, 0, 0).unwrap())
 }
 
-// `run` deliberately is NOT `#[instrument]`'d. It runs for the entire lifetime
-// of the consumer; wrapping it in a single span would make every per-batch /
-// per-alert child span a descendant of the same root span, producing a single
-// trace that grows unboundedly until Tempo rejects it. The survey is already
-// captured in the OTel `service.name` resource attribute, so it doesn't need
-// to be a span field here.
+// No `#[instrument]`: one span for the process lifetime would grow until Tempo
+// rejects the trace. The survey is already in the `service.name` attribute.
 async fn run(
     args: Cli,
     meter_provider: Option<SdkMeterProvider>,
@@ -99,14 +111,19 @@ async fn run(
     });
     let timestamp = date.and_utc().timestamp();
 
-    let exit_on_eof = if args.deployment_env == "dev" {
-        args.exit_on_eof
-    } else {
-        false
+    // `single` reuses the one-shot drain path, ungated on the environment since
+    // it commits nothing.
+    let exit_on_eof = match args.date_mode {
+        DateMode::Single => true,
+        DateMode::From => args.deployment_env == "dev" && args.exit_on_eof,
     };
+    info!(
+        "Consuming {} alerts from {} ({:?} mode)",
+        args.survey,
+        date.format("%Y-%m-%d"),
+        args.date_mode
+    );
 
-    // If topic override is provided, use it. Otherwise, the consumer
-    // will determine the topic based on the survey, program ID, and date.
     let topics = args.topics_override;
 
     match args.survey {
@@ -210,14 +227,12 @@ async fn run(
 
 #[tokio::main]
 async fn main() {
-    // Load environment variables from .env file before anything else
     load_dotenv();
 
     let args = Cli::parse();
 
     let instance_id = args.instance_id.unwrap_or_else(Uuid::new_v4);
-    // Match the Compose service name (consumer-ztf, consumer-lsst, ...) so
-    // Grafana can correlate traces, logs, and metrics on a single label.
+    // Matches the Compose service name so Grafana can correlate on one label.
     let service_name = format!("consumer-{}", args.survey.to_string().to_lowercase());
     let tracer_provider = init_tracing(
         service_name.clone(),

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -2,7 +2,7 @@ use boom::{
     conf::load_dotenv,
     kafka::{
         AlertConsumer, DecamAlertConsumer, LsstAlertConsumer, StartDate, WinterAlertConsumer,
-        ZtfAlertConsumer,
+        ZtfAlertConsumer, MAX_CATCH_UP_DAYS,
     },
     utils::{
         enums::{ProgramId, Survey},
@@ -28,6 +28,9 @@ enum DateMode {
     /// and never exit
     #[default]
     From,
+    /// Consume `date`'s topic(s) only, without rolling onto new nights, and
+    /// never exit
+    Pinned,
     /// Consume only `date`'s topic(s), then exit. Nothing is committed, so the
     /// night can be replayed as often as needed
     Single,
@@ -44,8 +47,8 @@ struct Cli {
     #[arg(value_parser = parse_date)]
     date: Option<NaiveDateTime>, // Easier to deal with the default value after clap
 
-    /// Whether `date` is a starting point ("from", the default) or the only
-    /// date to consume ("single")
+    /// Whether `date` is a starting point to catch up from ("from", the
+    /// default), or the only date to consume ("pinned", "single")
     #[arg(long, value_enum, default_value_t = DateMode::From)]
     date_mode: DateMode,
 
@@ -110,27 +113,39 @@ async fn run(
     meter_provider: Option<SdkMeterProvider>,
     tracer_provider: Option<SdkTracerProvider>,
 ) {
-    let date = args.date.map(|date| date.and_utc().timestamp());
-    let start = match (date, args.date_mode) {
-        (Some(timestamp), DateMode::Single) => StartDate::Pinned(timestamp),
-        (Some(timestamp), DateMode::From) => StartDate::From(timestamp),
-        (None, DateMode::Single) => StartDate::Pinned(StartDate::Current.timestamp()),
-        (None, DateMode::From) => StartDate::Current,
+    let date = args
+        .date
+        .map(|date| date.and_utc().timestamp())
+        .unwrap_or_else(|| StartDate::Current.timestamp());
+    let start = match args.date_mode {
+        DateMode::From if args.date.is_none() => StartDate::Current,
+        DateMode::From => StartDate::From(date),
+        DateMode::Pinned | DateMode::Single => StartDate::Pinned(date),
     };
+
+    let date_label = chrono::DateTime::from_timestamp(start.timestamp(), 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_default();
+    if start.catch_up_days() > MAX_CATCH_UP_DAYS {
+        error!(
+            "Catching up from {} would subscribe to {} nights, over the {}-day limit; \
+             use --date-mode pinned or single to read that night alone",
+            date_label,
+            start.catch_up_days(),
+            MAX_CATCH_UP_DAYS
+        );
+        return;
+    }
 
     // `single` reuses the one-shot drain path, ungated on the environment since
     // it commits nothing and runs in a throwaway consumer group.
     let exit_on_eof = match args.date_mode {
         DateMode::Single => true,
-        DateMode::From => args.deployment_env == "dev" && args.exit_on_eof,
+        DateMode::From | DateMode::Pinned => args.deployment_env == "dev" && args.exit_on_eof,
     };
     info!(
         "Consuming {} alerts ({:?} mode, date {})",
-        args.survey,
-        args.date_mode,
-        chrono::DateTime::from_timestamp(start.timestamp(), 0)
-            .map(|dt| dt.format("%Y-%m-%d").to_string())
-            .unwrap_or_default()
+        args.survey, args.date_mode, date_label
     );
 
     // If topic override is provided, use it. Otherwise, the consumer

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -16,41 +16,29 @@ use boom::{
 };
 
 use chrono::{NaiveDate, NaiveDateTime};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::{error, info};
 use uuid::Uuid;
 
-#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq)]
-enum DateMode {
-    /// Consume `date` and every night after it, rolling onto each new topic,
-    /// and never exit
-    #[default]
-    From,
-    /// Consume `date`'s topic(s) only, without rolling onto new nights, and
-    /// never exit
-    Pinned,
-    /// Consume only `date`'s topic(s), then exit. Nothing is committed, so the
-    /// night can be replayed as often as needed
-    Single,
-}
-
 #[derive(Parser)]
+#[command(group(ArgGroup::new("start")))]
 struct Cli {
     /// Survey to consume alerts from
     #[arg(value_enum)]
     survey: Survey,
 
-    /// UTC date for which we want to consume alerts, with format YYYYMMDD
-    /// [default: today's date at 00:00:00 UTC]
-    #[arg(value_parser = parse_date)]
-    date: Option<NaiveDateTime>, // Easier to deal with the default value after clap
+    /// UTC date (YYYYMMDD) to catch up from, rolling onto each new night's
+    /// topic and never exiting [default: today]
+    #[arg(long, group = "start", value_name = "DATE", value_parser = parse_date)]
+    from: Option<NaiveDateTime>,
 
-    /// Whether `date` is a starting point to catch up from ("from", the
-    /// default), or the only date to consume ("pinned", "single")
-    #[arg(long, value_enum, default_value_t = DateMode::From)]
-    date_mode: DateMode,
+    /// UTC date (YYYYMMDD) to replay on its own, without rolling onto new
+    /// nights. Runs in a per-date consumer group and commits nothing, so
+    /// production consumers are untouched and the night stays replayable
+    #[arg(long, group = "start", value_name = "DATE", value_parser = parse_date)]
+    on: Option<NaiveDateTime>,
 
     /// ID(s) of the program(s) to consume the alerts (ZTF-only). Defaults to "public" program if not specified (e.g. --programids public,partnership,caltech).
     #[arg(long, value_enum, value_delimiter = ',', default_value = "public")]
@@ -82,9 +70,8 @@ struct Cli {
     #[arg(long, env = "BOOM_CONSUMER_INSTANCE_ID")]
     instance_id: Option<Uuid>,
 
-    /// Exit on end of file (for testing purposes)
-    /// Not used in production
-    #[arg(long, default_value_t = false)]
+    /// Exit once the replayed topic(s) are drained, instead of staying up
+    #[arg(long, requires = "on", conflicts_with = "from")]
     exit_on_eof: bool,
 
     /// Override the topic name(s) (useful if data has been produced to a non-default topic)
@@ -113,15 +100,13 @@ async fn run(
     meter_provider: Option<SdkMeterProvider>,
     tracer_provider: Option<SdkTracerProvider>,
 ) {
-    let date = args
-        .date
-        .map(|date| date.and_utc().timestamp())
-        .unwrap_or_else(|| StartDate::Current.timestamp());
-    let start = match args.date_mode {
-        DateMode::From if args.date.is_none() => StartDate::Current,
-        DateMode::From => StartDate::From(date),
-        DateMode::Pinned | DateMode::Single => StartDate::Pinned(date),
+    let start = match (args.from, args.on) {
+        (_, Some(date)) => StartDate::Pinned(date.and_utc().timestamp()),
+        (Some(date), _) => StartDate::From(date.and_utc().timestamp()),
+        _ => StartDate::Current,
     };
+    let replay = args.on.is_some();
+    let exit_on_eof = args.exit_on_eof;
 
     let date_label = chrono::DateTime::from_timestamp(start.timestamp(), 0)
         .map(|dt| dt.format("%Y-%m-%d").to_string())
@@ -129,7 +114,7 @@ async fn run(
     if start.catch_up_days() > MAX_CATCH_UP_DAYS {
         error!(
             "Catching up from {} would subscribe to {} nights, over the {}-day limit; \
-             use --date-mode pinned or single to read that night alone",
+             use --on to read that night alone",
             date_label,
             start.catch_up_days(),
             MAX_CATCH_UP_DAYS
@@ -137,15 +122,9 @@ async fn run(
         return;
     }
 
-    // `single` reuses the one-shot drain path, ungated on the environment since
-    // it commits nothing and runs in a throwaway consumer group.
-    let exit_on_eof = match args.date_mode {
-        DateMode::Single => true,
-        DateMode::From | DateMode::Pinned => args.deployment_env == "dev" && args.exit_on_eof,
-    };
     info!(
-        "Consuming {} alerts ({:?} mode, date {})",
-        args.survey, args.date_mode, date_label
+        "Consuming {} alerts (date {}, replay: {}, exit on EOF: {})",
+        args.survey, date_label, replay, exit_on_eof
     );
 
     // If topic override is provided, use it. Otherwise, the consumer

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -22,6 +22,17 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::{error, info};
 use uuid::Uuid;
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq)]
+enum DateMode {
+    /// Consume `date` and every night after it, rolling onto each new topic,
+    /// and never exit
+    #[default]
+    From,
+    /// Consume only `date`'s topic(s), then exit. Nothing is committed, so the
+    /// night can be replayed as often as needed
+    Single,
+}
+
 #[derive(Parser)]
 struct Cli {
     /// Survey to consume alerts from
@@ -32,6 +43,11 @@ struct Cli {
     /// [default: today's date at 00:00:00 UTC]
     #[arg(value_parser = parse_date)]
     date: Option<NaiveDateTime>, // Easier to deal with the default value after clap
+
+    /// Whether `date` is a starting point ("from", the default) or the only
+    /// date to consume ("single")
+    #[arg(long, value_enum, default_value_t = DateMode::From)]
+    date_mode: DateMode,
 
     /// ID(s) of the program(s) to consume the alerts (ZTF-only). Defaults to "public" program if not specified (e.g. --programids public,partnership,caltech).
     #[arg(long, value_enum, value_delimiter = ',', default_value = "public")]
@@ -94,18 +110,28 @@ async fn run(
     meter_provider: Option<SdkMeterProvider>,
     tracer_provider: Option<SdkTracerProvider>,
 ) {
-    // An explicit date pins the run to that day (replay/backfill); without one
-    // the consumer tracks the current day and rolls over nightly.
-    let start = match args.date {
-        Some(date) => StartDate::Pinned(date.and_utc().timestamp()),
-        None => StartDate::Current,
+    let date = args.date.map(|date| date.and_utc().timestamp());
+    let start = match (date, args.date_mode) {
+        (Some(timestamp), DateMode::Single) => StartDate::Pinned(timestamp),
+        (Some(timestamp), DateMode::From) => StartDate::From(timestamp),
+        (None, DateMode::Single) => StartDate::Pinned(StartDate::Current.timestamp()),
+        (None, DateMode::From) => StartDate::Current,
     };
 
-    let exit_on_eof = if args.deployment_env == "dev" {
-        args.exit_on_eof
-    } else {
-        false
+    // `single` reuses the one-shot drain path, ungated on the environment since
+    // it commits nothing and runs in a throwaway consumer group.
+    let exit_on_eof = match args.date_mode {
+        DateMode::Single => true,
+        DateMode::From => args.deployment_env == "dev" && args.exit_on_eof,
     };
+    info!(
+        "Consuming {} alerts ({:?} mode, date {})",
+        args.survey,
+        args.date_mode,
+        chrono::DateTime::from_timestamp(start.timestamp(), 0)
+            .map(|dt| dt.format("%Y-%m-%d").to_string())
+            .unwrap_or_default()
+    );
 
     // If topic override is provided, use it. Otherwise, the consumer
     // will determine the topic based on the survey, program ID, and date.

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -2,7 +2,7 @@ use boom::{
     conf::load_dotenv,
     kafka::{
         AlertConsumer, DecamAlertConsumer, LsstAlertConsumer, StartDate, WinterAlertConsumer,
-        ZtfAlertConsumer, MAX_CATCH_UP_DAYS,
+        ZtfAlertConsumer,
     },
     utils::{
         enums::{ProgramId, Survey},
@@ -89,12 +89,42 @@ fn parse_date(s: &str) -> Result<NaiveDateTime, String> {
     Ok(date.and_hms_opt(0, 0, 0).unwrap())
 }
 
-// `run` deliberately is NOT `#[instrument]`'d. It runs for the entire lifetime
-// of the consumer; wrapping it in a single span would make every per-batch /
-// per-alert child span a descendant of the same root span, producing a single
-// trace that grows unboundedly until Tempo rejects it. The survey is already
-// captured in the OTel `service.name` resource attribute, so it doesn't need
-// to be a span field here.
+async fn consume_with<C: AlertConsumer>(
+    consumer: C,
+    args: &Cli,
+    start: StartDate,
+    date_label: &str,
+) {
+    info!(
+        "Consuming {} alerts (date {}, replay: {}, exit on EOF: {})",
+        args.survey,
+        date_label,
+        args.on.is_some(),
+        args.exit_on_eof
+    );
+
+    if args.clear {
+        let _ = consumer.clear_output_queue(&args.config).await;
+    }
+    match consumer
+        .consume(
+            args.topics_override.clone(),
+            start,
+            None,
+            Some(args.processes),
+            Some(args.max_in_queue),
+            args.exit_on_eof,
+            &args.config,
+        )
+        .await
+    {
+        Ok(_) => info!("Successfully consumed alerts"),
+        Err(e) => error!("Failed to consume alerts: {}", e),
+    };
+}
+
+// No `#[instrument]`: `run` lives as long as the process, so one wrapping span
+// would grow a single trace until Tempo rejects it.
 async fn run(
     args: Cli,
     meter_provider: Option<SdkMeterProvider>,
@@ -105,116 +135,24 @@ async fn run(
         (Some(date), _) => StartDate::From(date.and_utc().timestamp()),
         _ => StartDate::Current,
     };
-    let replay = args.on.is_some();
-    let exit_on_eof = args.exit_on_eof;
-
     let date_label = chrono::DateTime::from_timestamp(start.timestamp(), 0)
         .map(|dt| dt.format("%Y-%m-%d").to_string())
         .unwrap_or_default();
-    if start.catch_up_days() > MAX_CATCH_UP_DAYS {
-        error!(
-            "Catching up from {} would subscribe to {} nights, over the {}-day limit; \
-             use --on to read that night alone",
-            date_label,
-            start.catch_up_days(),
-            MAX_CATCH_UP_DAYS
-        );
-        return;
-    }
-
-    info!(
-        "Consuming {} alerts (date {}, replay: {}, exit on EOF: {})",
-        args.survey, date_label, replay, exit_on_eof
-    );
-
-    // If topic override is provided, use it. Otherwise, the consumer
-    // will determine the topic based on the survey, program ID, and date.
-    let topics = args.topics_override;
 
     match args.survey {
         Survey::Ztf => {
-            let consumer = ZtfAlertConsumer::new(None, Some(args.programids));
-            if args.clear {
-                let _ = consumer.clear_output_queue(&args.config).await;
-            }
-            match consumer
-                .consume(
-                    topics,
-                    start,
-                    None,
-                    Some(args.processes),
-                    Some(args.max_in_queue),
-                    exit_on_eof,
-                    &args.config,
-                )
-                .await
-            {
-                Ok(_) => info!("Successfully consumed alerts"),
-                Err(e) => error!("Failed to consume alerts: {}", e),
-            };
+            let consumer = ZtfAlertConsumer::new(None, Some(args.programids.clone()));
+            consume_with(consumer, &args, start, &date_label).await
         }
         Survey::Lsst => {
             let consumer = LsstAlertConsumer::new(None, args.simulated);
-            if args.clear {
-                let _ = consumer.clear_output_queue(&args.config).await;
-            }
-            match consumer
-                .consume(
-                    topics,
-                    start,
-                    None,
-                    Some(args.processes),
-                    Some(args.max_in_queue),
-                    exit_on_eof,
-                    &args.config,
-                )
-                .await
-            {
-                Ok(_) => info!("Successfully consumed alerts"),
-                Err(e) => error!("Failed to consume alerts: {}", e),
-            };
+            consume_with(consumer, &args, start, &date_label).await
         }
         Survey::Decam => {
-            let consumer = DecamAlertConsumer::new(None);
-            if args.clear {
-                let _ = consumer.clear_output_queue(&args.config).await;
-            }
-            match consumer
-                .consume(
-                    topics,
-                    start,
-                    None,
-                    Some(args.processes),
-                    Some(args.max_in_queue),
-                    exit_on_eof,
-                    &args.config,
-                )
-                .await
-            {
-                Ok(_) => info!("Successfully consumed alerts"),
-                Err(e) => error!("Failed to consume alerts: {}", e),
-            };
+            consume_with(DecamAlertConsumer::new(None), &args, start, &date_label).await
         }
         Survey::Winter => {
-            let consumer = WinterAlertConsumer::new(None);
-            if args.clear {
-                let _ = consumer.clear_output_queue(&args.config).await;
-            }
-            match consumer
-                .consume(
-                    topics,
-                    start,
-                    None,
-                    Some(args.processes),
-                    Some(args.max_in_queue),
-                    exit_on_eof,
-                    &args.config,
-                )
-                .await
-            {
-                Ok(_) => info!("Successfully consumed alerts"),
-                Err(e) => error!("Failed to consume alerts: {}", e),
-            };
+            consume_with(WinterAlertConsumer::new(None), &args, start, &date_label).await
         }
     }
 

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -393,17 +393,12 @@ pub enum ConsumerError {
     ConfigError(#[from] config::ConfigError),
 }
 
-/// UTC dates a date-partitioned survey should currently be subscribed to,
-/// oldest first: the day containing `timestamp` plus the preceding
-/// `window_days`.
+/// UTC dates a date-partitioned survey should currently be subscribed to, oldest
+/// first: the day containing `timestamp` plus the preceding `window_days`.
 ///
-/// The default of 1 keeps yesterday alongside today, because a survey night
-/// straddles UTC midnight and the tail of it would otherwise be dropped at
-/// rollover. Going wider is a deliberate, temporary act: upstream expires a
-/// topic's partitions while still advertising its name, so every extra day
-/// risks re-adding partitions that fail every poll (survivable — see
-/// `is_expired_partition` — but not free). Its intended use is catching up
-/// after an upstream outage, bounded by upstream retention.
+/// Default 1 keeps yesterday, since a night straddles UTC midnight. Widening is
+/// temporary: upstream advertises names whose partitions it has expired, so each
+/// extra day risks partitions that fail every poll.
 pub fn subscription_window(timestamp: i64, window_days: u64) -> Vec<chrono::NaiveDate> {
     let today = chrono::DateTime::from_timestamp(timestamp, 0)
         .map(|dt| dt.date_naive())
@@ -416,22 +411,15 @@ pub fn subscription_window(timestamp: i64, window_days: u64) -> Vec<chrono::Naiv
 
 #[async_trait::async_trait]
 pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
-    /// Concrete topic name(s) for a specific date. Used by the producer side and
-    /// by the one-shot (`exit_on_eof`) drain path.
+    /// Concrete topic name(s) for a specific date.
     fn topic_names(&self, timestamp: i64) -> Vec<String>;
-    /// Concrete topic names the long-running consumer subscribes to at
-    /// `timestamp`.
+    /// Concrete topic names the long-running consumer subscribes to at `timestamp`:
+    /// a bounded window ([`subscription_window`]) for date-partitioned surveys, the
+    /// literal name for single-topic ones (e.g. LSST). Re-invoked on each UTC date
+    /// change, which is what makes rollover automatic.
     ///
-    /// Date-partitioned surveys return a bounded window (see
-    /// [`subscription_window`]); surveys with a single static topic (e.g. LSST)
-    /// return that literal name and ignore `timestamp`. The consumer re-invokes
-    /// this whenever the UTC date changes and re-subscribes to the result, which
-    /// is what makes rollover automatic.
-    ///
-    /// This deliberately returns literal names rather than a `^…` regex.
-    /// librdkafka expands a regex against every topic the cluster advertises,
-    /// which for a daily-topic survey is the entire history of past nights — a
-    /// set that grows without bound and is almost entirely expired.
+    /// Literal names, not a `^…` regex: librdkafka expands a regex against every
+    /// topic the cluster advertises, i.e. every past night, almost all expired.
     fn subscription_topics(&self, timestamp: i64, window_days: u64) -> Vec<String>;
     fn output_queue(&self) -> String;
     fn survey(&self) -> &'static str;
@@ -452,10 +440,8 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
         );
         Ok(())
     }
-    // No `#[instrument]` here: `consume` runs the consumer loop for the
-    // entire process lifetime, and any wrapping span would make every
-    // per-message child span a descendant of the same root trace, which
-    // grows until Tempo rejects it (TRACE_TOO_LARGE).
+    // No `#[instrument]`: `consume` runs for the process lifetime, so a wrapping
+    // span would grow one trace until Tempo rejects it (TRACE_TOO_LARGE).
     async fn consume(
         &self,
         topics: Option<Vec<String>>,
@@ -469,21 +455,6 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
         let config = AppConfig::from_path(config_path)?;
         let survey = self.survey();
 
-        // Resolves the topics to subscribe to for a given instant. The consumer
-        // loop re-invokes this on every UTC-date rollover and re-subscribes, so
-        // new daily topics are picked up without a restart.
-        // exit_on_eof (tests/dev): target the concrete topic for the date.
-        let subscribe_to: Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync> = match topics {
-            Some(overridden) => Arc::new(move |_, _| overridden.clone()),
-            None if exit_on_eof => {
-                let survey_consumer = self.clone();
-                Arc::new(move |at, _| survey_consumer.topic_names(at))
-            }
-            None => {
-                let survey_consumer = self.clone();
-                Arc::new(move |at, days| survey_consumer.subscription_topics(at, days))
-            }
-        };
         let kafka_config = match kafka_config {
             Some(cfg) => cfg,
             None => config
@@ -503,6 +474,19 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
         let n_threads = n_threads.unwrap_or(1);
         let max_in_queue = max_in_queue.unwrap_or(15000);
         let plan = start.plan(kafka_config.subscription_window_days);
+
+        // A closure, not a Vec: the poll loop re-invokes it on each UTC rollover.
+        let subscribe_to: Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync> = match topics {
+            Some(overridden) => Arc::new(move |_, _| overridden.clone()),
+            None if plan.replay => {
+                let survey_consumer = self.clone();
+                Arc::new(move |at, _| survey_consumer.topic_names(at))
+            }
+            None => {
+                let survey_consumer = self.clone();
+                Arc::new(move |at, days| survey_consumer.subscription_topics(at, days))
+            }
+        };
 
         let mut handles = vec![];
         for i in 0..n_threads {
@@ -597,10 +581,8 @@ fn seek_to_timestamp(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResult<
     Ok(())
 }
 
-// Position the given `targets` partitions for the long-running consumer: those
-// with a committed offset resume from it; the rest are resolved by `timestamp_ms`
-// (an old day's topic has nothing at/after it -> seek to end/skip; today's and
-// any newly-created daily topic -> its start).
+// Position `targets`: partitions with a committed offset resume from it, the rest
+// are resolved by `timestamp_ms` (nothing at/after it -> seek to end and skip).
 fn position_partitions(
     consumer: &BaseConsumer,
     targets: &TopicPartitionList,
@@ -639,11 +621,9 @@ fn position_partitions(
         return Ok(());
     }
     let resolved = consumer.offsets_for_times(to_resolve, KAFKA_TIMEOUT_SECS)?;
-    // Persist the resolved start/skip position for each uncommitted partition.
-    // With the default (eager) assignor, discovering the next day's topic revokes
-    // and reassigns everything; committing here means an old skipped topic resumes
-    // from its end (stays skipped) rather than resetting to `earliest` and
-    // replaying, and today's topic resumes from its start.
+    // Commit the resolved position: with the eager assignor a new daily topic
+    // revokes and reassigns everything, and an uncommitted skipped topic would
+    // reset to `earliest` and replay.
     let mut to_commit = TopicPartitionList::new();
     for elem in resolved.elements() {
         let offset = match elem.offset() {
@@ -674,14 +654,9 @@ fn position_partitions(
     Ok(())
 }
 
-// Position only partitions that have appeared in the assignment since the last
-// call, recording them in `positioned`. Positioning each partition exactly once
-// (rather than re-seeking the whole assignment whenever it changes) means a
-// still-active partition is never rewound to its lagging committed offset, and a
-// same-size membership swap (which a count check would miss) is still handled.
-// A genuinely-new daily topic is correctly picked up here; an old retained topic
-// re-assigned mid-run is skipped. (A brand-new partition consumed between poll
-// and this check would be rewound once here — a bounded, idempotent replay.)
+// Position only partitions new since the last call, recorded in `positioned`.
+// Re-seeking the whole assignment instead would rewind a still-active partition
+// to its lagging committed offset.
 fn reposition_new_partitions(
     consumer: &BaseConsumer,
     timestamp_ms: i64,
@@ -722,10 +697,8 @@ fn position_or_warn(
 
 /// Where a consumer starts reading, and whether it advances with the clock.
 ///
-/// The caller states which it wants rather than having it inferred from the
-/// timestamp. Inferring would get two cases wrong: a pinned run that happens to
-/// name today's date is still a pinned run, and a consumer started moments
-/// before UTC midnight would race the comparison.
+/// Stated by the caller, not inferred: a pinned run naming today's date is still
+/// pinned, and a start just before UTC midnight would race the comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StartDate {
     /// Begin at the current UTC day and roll onto each new daily topic as
@@ -734,9 +707,8 @@ pub enum StartDate {
     /// Begin at a past instant and catch up every night since, then roll like
     /// `Current`.
     From(i64),
-    /// Pinned to one instant — replay, backfill, benchmarks. Never rolls over:
-    /// advancing it would unsubscribe the consumer from the very topic it was
-    /// started to read.
+    /// Pinned to one instant. Never rolls over: advancing would unsubscribe the
+    /// consumer from the very topic it was started to read.
     Pinned(i64),
 }
 
@@ -787,6 +759,7 @@ impl StartDate {
             window_days,
             follows_clock: self.follows_clock(),
             positions_at_rolled_day: matches!(self, StartDate::Current),
+            replay: matches!(self, StartDate::Pinned(_)),
         }
     }
 }
@@ -803,6 +776,8 @@ pub struct StartPlan {
     pub follows_clock: bool,
     /// False while catching up, whose older nights the rolled day would skip.
     pub positions_at_rolled_day: bool,
+    /// Own consumer group, no commits, that night's topics alone, no rollover.
+    pub replay: bool,
 }
 
 /// Beyond this, a catch-up is asking for more nights than any survey retains,
@@ -840,10 +815,9 @@ fn rollover_target(
         .map(|midnight| midnight.and_utc().timestamp())
 }
 
-/// Re-subscribe if the UTC date has rolled onto a new daily topic.
-///
-/// Must be called from both poll loops: a consumer started between nights never
-/// receives a first message, so it never leaves the initial-assignment loop.
+/// Re-subscribe if the UTC date has rolled onto a new daily topic. Called from
+/// both poll loops: a consumer started between nights never receives a first
+/// message, so it never leaves the initial-assignment loop.
 fn roll_subscription_if_needed(
     consumer: &BaseConsumer,
     subscribe_to: &Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync>,
@@ -874,9 +848,8 @@ fn roll_subscription_if_needed(
 }
 
 /// Whether a poll error refers to a partition whose topic no longer exists
-/// upstream — typically an expired daily topic still present in the group's
-/// assignment. Unlike a transient broker error these never recover, so they
-/// must not be retried on the same backoff.
+/// upstream. Unlike a transient broker error these never recover, so they must
+/// not be retried on the same backoff.
 fn is_expired_partition(error: &KafkaError) -> bool {
     matches!(
         error,
@@ -901,12 +874,12 @@ pub async fn consumer(
     exit_on_eof: bool,
     survey: &'static str,
 ) -> Result<(), ConsumerError> {
+    let replay = plan.replay;
     let server = survey_consumer_config.server.clone();
-    // Throwaway group so a one-shot replay never rebalances the long-running
-    // consumers; the timestamp suffix keeps one run's threads together.
-    let group_id = if exit_on_eof {
+    // Own group, per date, so a replay never rebalances the long-running consumers.
+    let group_id = if replay {
         format!(
-            "{}-oneshot-{}",
+            "{}-replay-{}",
             survey_consumer_config.group_id, plan.position_timestamp
         )
     } else {
@@ -917,8 +890,7 @@ pub async fn consumer(
 
     let subscription = subscribe_to(plan.subscription_timestamp, plan.window_days);
 
-    let topics: Vec<String> = if exit_on_eof {
-        // One-shot drain: keep only concrete topics that have messages, exit if none.
+    let topics: Vec<String> = if replay {
         let mut non_empty_topics = vec![];
         for topic in &subscription {
             let nb_messages = count_messages(&server, topic)?;
@@ -942,16 +914,24 @@ pub async fn consumer(
             }
         }
         if non_empty_topics.is_empty() {
+            if exit_on_eof {
+                info!(
+                    "No messages available in any topic, exiting consumer {}",
+                    id
+                );
+                return Ok(());
+            }
             info!(
-                "No messages available in any topic, exiting consumer {}",
+                "No messages available in any topic yet, consumer {} will wait",
                 id
             );
-            return Ok(());
+            subscription
+        } else {
+            non_empty_topics
         }
-        non_empty_topics
     } else {
         // Long-running: subscribe to the pattern(s); new daily topics roll over automatically.
-        debug!("exit_on_eof is false, consuming indefinitely");
+        debug!("Not a replay, consuming indefinitely");
         subscription
     };
 
@@ -966,12 +946,10 @@ pub async fn consumer(
         // prod path we store offsets explicitly after each push (see below).
         .set("enable.auto.offset.store", "false");
 
-    if !exit_on_eof {
-        // Long-running consumer: commit stored offsets so restarts and rebalances
-        // resume in place instead of replaying. We deliberately keep the default
-        // (eager) assignment strategy: switching a live consumer group to
-        // cooperative-sticky is an incompatible rebalance protocol, and members
-        // already in the group on the eager protocol reject the join with
+    if !replay {
+        // Commit stored offsets so restarts resume in place. Keep the default
+        // (eager) assignor: switching a live group to cooperative-sticky is an
+        // incompatible protocol, and members already in it reject the join with
         // InconsistentGroupProtocol.
         client_config
             .set("enable.auto.commit", "true")
@@ -1019,10 +997,8 @@ pub async fn consumer(
     const WAITING_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_waiting_log = std::time::Instant::now();
 
-    // Expired-partition poll errors repeat indefinitely, so they get a short
-    // backoff (enough to keep the loop off a hot spin) and a throttled log.
-    // Both loops below share them: a full second per missing topic adds up to
-    // minutes of startup when a wide window is mostly expired.
+    // Expired-partition errors repeat forever: short backoff and a throttled log.
+    // A full second each adds minutes of startup when the window is mostly expired.
     const EXPIRED_POLL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
     const EXPIRED_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
     let mut last_expired_log = std::time::Instant::now()
@@ -1032,7 +1008,7 @@ pub async fn consumer(
     // Poll once to trigger rebalance and get assignment
     loop {
         // This loop can sit across a UTC midnight; roll while waiting.
-        if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
+        if !replay && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
             last_rollover_check = std::time::Instant::now();
             roll_subscription_if_needed(
                 &consumer,
@@ -1053,8 +1029,8 @@ pub async fn consumer(
         match consumer.poll(KAFKA_TIMEOUT_SECS) {
             Some(Ok(_msg)) => {
                 debug!("Got initial assignment, positioning partitions...");
-                if exit_on_eof {
-                    // One-shot drain: (re)read from the requested timestamp.
+                if replay {
+                    // Replay: (re)read from the timestamp; `position_partitions` commits.
                     seek_to_timestamp(&consumer, plan.position_timestamp * 1000)?;
                 } else if !position_or_warn(&consumer, position_timestamp * 1000, &mut positioned) {
                     // Consuming unpositioned would replay an old night from
@@ -1138,10 +1114,8 @@ pub async fn consumer(
     // start timer
     let start = std::time::Instant::now();
 
-    // Emit a periodic "still alive" line so low-volume surveys (e.g. WINTER,
-    // which may push far fewer than the every-1000 progress log) visibly report
-    // progress instead of looking stalled. Also confirms the loop is polling
-    // even when idle between nights.
+    // Low-volume surveys (WINTER) rarely hit the every-1000 progress log, so a
+    // periodic line distinguishes idle from stalled.
     const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_heartbeat = std::time::Instant::now();
     let mut total_at_last_heartbeat: u64 = 0;
@@ -1166,7 +1140,7 @@ pub async fn consumer(
         }
         // Roll the subscription onto the current UTC day, then pick up any
         // newly-assigned partitions (the new day's topic, or a rebalance).
-        if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
+        if !replay && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
             last_rollover_check = std::time::Instant::now();
             roll_subscription_if_needed(
                 &consumer,
@@ -1206,7 +1180,7 @@ pub async fn consumer(
                             log_error!(error, "failed to push message to queue");
                             ALERT_PROCESSED.add(1, &output_error_attrs);
                         })?;
-                    if !exit_on_eof {
+                    if !replay {
                         if let Err(error) = consumer.store_offset_from_message(&message) {
                             log_error!(error, "failed to store offset");
                         }
@@ -1231,8 +1205,8 @@ pub async fn consumer(
                     })?;
                 trace!("Pushed message to redis");
                 // Mark processed so the periodic auto-commit advances the offset
-                // (only the prod path commits; the drain path never stores).
-                if !exit_on_eof {
+                // (only the prod path commits; a replay never stores).
+                if !replay {
                     if let Err(error) = consumer.store_offset_from_message(&message) {
                         log_error!(error, "failed to store offset");
                     }
@@ -1253,13 +1227,10 @@ pub async fn consumer(
             }
             Some(Err(e)) => {
                 ALERT_PROCESSED.add(1, &input_error_attrs);
-                // A partition whose topic has expired upstream fails on every
-                // poll and never recovers. Serving each one a full second of
-                // backoff turns this loop into a treadmill: once enough expired
-                // partitions are in the assignment the consumer can no longer
-                // drain the live topic, and it never reaches the idle branch
-                // below — which is where rollover would otherwise be noticed.
-                // Log sparsely and keep polling instead.
+                // Expired-topic partitions fail every poll forever. A full second
+                // each turns the loop into a treadmill: the consumer stops draining
+                // the live topic and never reaches the idle branch, where rollover
+                // is noticed. Log sparsely and keep polling.
                 if is_expired_partition(&e) {
                     if last_expired_log.elapsed() >= EXPIRED_LOG_INTERVAL {
                         last_expired_log = std::time::Instant::now();

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -1007,6 +1007,16 @@ pub async fn consumer(
     const WAITING_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_waiting_log = std::time::Instant::now();
 
+    // Expired-partition poll errors repeat indefinitely, so they get a short
+    // backoff (enough to keep the loop off a hot spin) and a throttled log.
+    // Both loops below share them: a full second per missing topic adds up to
+    // minutes of startup when a wide window is mostly expired.
+    const EXPIRED_POLL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+    const EXPIRED_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+    let mut last_expired_log = std::time::Instant::now()
+        .checked_sub(EXPIRED_LOG_INTERVAL)
+        .unwrap_or_else(std::time::Instant::now);
+
     // Poll once to trigger rebalance and get assignment
     loop {
         // This loop can sit across a UTC midnight; roll while waiting.
@@ -1050,6 +1060,18 @@ pub async fn consumer(
                         info!("Topic or partition unknown, exiting consumer {}", id);
                         return Ok(());
                     }
+                }
+                if is_expired_partition(&e) {
+                    if last_expired_log.elapsed() >= EXPIRED_LOG_INTERVAL {
+                        last_expired_log = std::time::Instant::now();
+                        warn!(
+                            "Waiting on partitions whose topics do not exist upstream \
+                             (subscribed date {}): {}",
+                            subscribed_date, e
+                        );
+                    }
+                    tokio::time::sleep(EXPIRED_POLL_BACKOFF).await;
+                    continue;
                 }
                 error!("Error during initial poll: {:?}", e);
                 // sleep and retry
@@ -1111,14 +1133,6 @@ pub async fn consumer(
     const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_heartbeat = std::time::Instant::now();
     let mut total_at_last_heartbeat: u64 = 0;
-
-    // Expired-partition poll errors repeat indefinitely, so they get a short
-    // backoff (enough to keep the loop off a hot spin) and a throttled log.
-    const EXPIRED_POLL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
-    const EXPIRED_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
-    let mut last_expired_log = std::time::Instant::now()
-        .checked_sub(EXPIRED_LOG_INTERVAL)
-        .unwrap_or_else(std::time::Instant::now);
 
     debug!("Starting Kafka consumer loop...");
 

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{
         data::count_files_in_dir,
         o11y::{
-            logging::{as_error, log_error},
+            logging::{as_error, log_error, WARN},
             metrics::CONSUMER_METER,
         },
     },
@@ -708,6 +708,22 @@ fn reposition_new_partitions(
     Ok(())
 }
 
+// A rebalance landing mid-pass must not take the consumer down; the caller
+// retries on its next pass. Reports whether the pass went through.
+fn position_or_warn(
+    consumer: &BaseConsumer,
+    timestamp_ms: i64,
+    positioned: &mut std::collections::HashSet<(String, i32)>,
+) -> bool {
+    match reposition_new_partitions(consumer, timestamp_ms, positioned) {
+        Ok(()) => true,
+        Err(error) => {
+            log_error!(WARN, error, "failed to position partitions, will retry");
+            false
+        }
+    }
+}
+
 /// Where a consumer starts reading, and whether it advances with the clock.
 ///
 /// The caller states which it wants rather than having it inferred from the
@@ -951,7 +967,7 @@ pub async fn consumer(
                 &mut subscribed_date,
                 &mut position_timestamp,
             );
-            reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
+            position_or_warn(&consumer, position_timestamp * 1000, &mut positioned);
         }
         if !exit_on_eof && last_waiting_log.elapsed() >= WAITING_LOG_INTERVAL {
             last_waiting_log = std::time::Instant::now();
@@ -966,15 +982,10 @@ pub async fn consumer(
                 if exit_on_eof {
                     // One-shot drain: (re)read from the requested timestamp.
                     seek_to_timestamp(&consumer, timestamp * 1000)?;
-                } else {
-                    // Resume committed partitions; skip old / start today otherwise.
-                    // position_timestamp, not timestamp: a rollover may have
-                    // advanced it while this loop waited for a first message.
-                    reposition_new_partitions(
-                        &consumer,
-                        position_timestamp * 1000,
-                        &mut positioned,
-                    )?;
+                } else if !position_or_warn(&consumer, position_timestamp * 1000, &mut positioned) {
+                    // Consuming unpositioned would replay an old night from
+                    // `earliest`; poll again and retry.
+                    continue;
                 }
                 break;
             }
@@ -1087,7 +1098,7 @@ pub async fn consumer(
                 &mut subscribed_date,
                 &mut position_timestamp,
             );
-            reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
+            position_or_warn(&consumer, position_timestamp * 1000, &mut positioned);
         }
         if max_in_queue > 0 && total % 1000 == 0 {
             // Pause rather than sleep: a consumer that stops polling for
@@ -1195,7 +1206,7 @@ pub async fn consumer(
                     break;
                 }
                 // Idle: catch a topic that has just rolled over.
-                reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
+                position_or_warn(&consumer, position_timestamp * 1000, &mut positioned);
             }
         }
     }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -468,10 +468,6 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
     ) -> Result<(), ConsumerError> {
         let config = AppConfig::from_path(config_path)?;
         let survey = self.survey();
-        // Resolved once here, not per worker, so every thread agrees on the day
-        // even if they spawn either side of UTC midnight.
-        let timestamp = start.timestamp();
-        let follow_current_date = start.follows_clock();
 
         // Resolves the topics to subscribe to for a given instant. The consumer
         // loop re-invokes this on every UTC-date rollover and re-subscribes, so
@@ -506,6 +502,7 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
 
         let n_threads = n_threads.unwrap_or(1);
         let max_in_queue = max_in_queue.unwrap_or(15000);
+        let plan = start.plan(kafka_config.subscription_window_days);
 
         let mut handles = vec![];
         for i in 0..n_threads {
@@ -519,8 +516,7 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
                     subscribe_to,
                     &output_queue,
                     max_in_queue,
-                    timestamp,
-                    follow_current_date,
+                    plan,
                     &config,
                     &kafka_config,
                     exit_on_eof,
@@ -735,6 +731,9 @@ pub enum StartDate {
     /// Begin at the current UTC day and roll onto each new daily topic as
     /// midnight passes. What the long-running consumers use.
     Current,
+    /// Begin at a past instant and catch up every night since, then roll like
+    /// `Current`.
+    From(i64),
     /// Pinned to one instant — replay, backfill, benchmarks. Never rolls over:
     /// advancing it would unsubscribe the consumer from the very topic it was
     /// started to read.
@@ -745,20 +744,72 @@ impl StartDate {
     /// Unix seconds that newly-assigned partitions are positioned to.
     pub fn timestamp(self) -> i64 {
         match self {
-            StartDate::Current => {
-                let now = chrono::Utc::now();
-                now.date_naive()
-                    .and_hms_opt(0, 0, 0)
-                    .map(|midnight| midnight.and_utc().timestamp())
-                    .unwrap_or_else(|| now.timestamp())
-            }
-            StartDate::Pinned(timestamp) => timestamp,
+            StartDate::Current => current_day_midnight(),
+            StartDate::From(timestamp) | StartDate::Pinned(timestamp) => timestamp,
         }
     }
 
     /// Whether the subscription should roll onto each new UTC day.
     pub fn follows_clock(self) -> bool {
-        matches!(self, StartDate::Current)
+        matches!(self, StartDate::Current | StartDate::From(_))
+    }
+
+    /// Resolve into the instants the poll loop runs on, widening the survey's
+    /// configured window if `From` reaches further back than it.
+    pub fn plan(self, configured_window_days: u64) -> StartPlan {
+        let today = current_day_midnight();
+        let position_timestamp = match self {
+            StartDate::Current => today,
+            StartDate::From(timestamp) | StartDate::Pinned(timestamp) => timestamp,
+        };
+        // `From` reaches *back* to its date; the window still ends at today.
+        let subscription_timestamp = match self {
+            StartDate::Pinned(timestamp) => timestamp,
+            _ => today,
+        };
+        let window_days = match self {
+            StartDate::From(_) => {
+                configured_window_days.max(days_between(position_timestamp, subscription_timestamp))
+            }
+            _ => configured_window_days,
+        };
+        StartPlan {
+            position_timestamp,
+            subscription_timestamp,
+            window_days,
+            follows_clock: self.follows_clock(),
+            positions_at_rolled_day: matches!(self, StartDate::Current),
+        }
+    }
+}
+
+/// Resolved once by `consume`, so every worker thread agrees on the day even if
+/// they spawn either side of UTC midnight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StartPlan {
+    /// A partition holding nothing at or after this is skipped to its end.
+    pub position_timestamp: i64,
+    /// Instant the subscription window ends at.
+    pub subscription_timestamp: i64,
+    pub window_days: u64,
+    pub follows_clock: bool,
+    /// False while catching up, whose older nights the rolled day would skip.
+    pub positions_at_rolled_day: bool,
+}
+
+fn current_day_midnight() -> i64 {
+    let now = chrono::Utc::now();
+    now.date_naive()
+        .and_hms_opt(0, 0, 0)
+        .map(|midnight| midnight.and_utc().timestamp())
+        .unwrap_or_else(|| now.timestamp())
+}
+
+fn days_between(from: i64, to: i64) -> u64 {
+    let day = |timestamp| chrono::DateTime::from_timestamp(timestamp, 0).map(|dt| dt.date_naive());
+    match (day(from), day(to)) {
+        (Some(from), Some(to)) => (to - from).num_days().max(0) as u64,
+        _ => 0,
     }
 }
 
@@ -784,16 +835,15 @@ fn rollover_target(
 fn roll_subscription_if_needed(
     consumer: &BaseConsumer,
     subscribe_to: &Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync>,
-    window_days: u64,
-    follow_current_date: bool,
+    plan: StartPlan,
     subscribed_date: &mut chrono::NaiveDate,
     position_timestamp: &mut i64,
 ) {
     let today = chrono::Utc::now().date_naive();
-    let Some(new_timestamp) = rollover_target(follow_current_date, *subscribed_date, today) else {
+    let Some(new_timestamp) = rollover_target(plan.follows_clock, *subscribed_date, today) else {
         return;
     };
-    let rolled = subscribe_to(new_timestamp, window_days);
+    let rolled = subscribe_to(new_timestamp, plan.window_days);
     let rolled_refs: Vec<&str> = rolled.iter().map(|s| s.as_str()).collect();
     match consumer.subscribe(&rolled_refs) {
         Ok(()) => {
@@ -802,7 +852,9 @@ fn roll_subscription_if_needed(
                 subscribed_date, today, rolled
             );
             *subscribed_date = today;
-            *position_timestamp = new_timestamp;
+            if plan.positions_at_rolled_day {
+                *position_timestamp = new_timestamp;
+            }
         }
         // Stay on the current subscription; the next check retries.
         Err(error) => log_error!(error, "failed to roll subscription onto new day"),
@@ -831,9 +883,7 @@ pub async fn consumer(
     subscribe_to: Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync>,
     output_queue: &str,
     max_in_queue: usize,
-    timestamp: i64,
-    // Whether to roll the subscription onto each new UTC day; see `StartDate`.
-    follow_current_date: bool,
+    plan: StartPlan,
     config: &AppConfig,
     survey_consumer_config: &KafkaConsumerConfig,
     exit_on_eof: bool,
@@ -843,15 +893,17 @@ pub async fn consumer(
     // Throwaway group so a one-shot replay never rebalances the long-running
     // consumers; the timestamp suffix keeps one run's threads together.
     let group_id = if exit_on_eof {
-        format!("{}-oneshot-{}", survey_consumer_config.group_id, timestamp)
+        format!(
+            "{}-oneshot-{}",
+            survey_consumer_config.group_id, plan.position_timestamp
+        )
     } else {
         survey_consumer_config.group_id.clone()
     };
     let username = survey_consumer_config.username.clone();
     let password = survey_consumer_config.password.clone();
 
-    let window_days = survey_consumer_config.subscription_window_days;
-    let subscription = subscribe_to(timestamp, window_days);
+    let subscription = subscribe_to(plan.subscription_timestamp, plan.window_days);
 
     let topics: Vec<String> = if exit_on_eof {
         // One-shot drain: keep only concrete topics that have messages, exit if none.
@@ -944,11 +996,12 @@ pub async fn consumer(
     // Declared here because the initial-assignment loop must roll over too.
     const ROLLOVER_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
     let mut last_rollover_check = std::time::Instant::now();
-    // Advance together on rollover, so a new topic starts at its own day.
-    let mut subscribed_date = chrono::DateTime::from_timestamp(timestamp, 0)
+    // Advance together on rollover (unless catching up), so a new topic starts
+    // at its own day.
+    let mut subscribed_date = chrono::DateTime::from_timestamp(plan.subscription_timestamp, 0)
         .map(|dt| dt.date_naive())
         .unwrap_or_else(|| chrono::Utc::now().date_naive());
-    let mut position_timestamp = timestamp;
+    let mut position_timestamp = plan.position_timestamp;
 
     // Idle and wedged look identical at INFO otherwise.
     const WAITING_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
@@ -962,8 +1015,7 @@ pub async fn consumer(
             roll_subscription_if_needed(
                 &consumer,
                 &subscribe_to,
-                window_days,
-                follow_current_date,
+                plan,
                 &mut subscribed_date,
                 &mut position_timestamp,
             );
@@ -981,7 +1033,7 @@ pub async fn consumer(
                 debug!("Got initial assignment, positioning partitions...");
                 if exit_on_eof {
                     // One-shot drain: (re)read from the requested timestamp.
-                    seek_to_timestamp(&consumer, timestamp * 1000)?;
+                    seek_to_timestamp(&consumer, plan.position_timestamp * 1000)?;
                 } else if !position_or_warn(&consumer, position_timestamp * 1000, &mut positioned) {
                     // Consuming unpositioned would replay an old night from
                     // `earliest`; poll again and retry.
@@ -1093,8 +1145,7 @@ pub async fn consumer(
             roll_subscription_if_needed(
                 &consumer,
                 &subscribe_to,
-                window_days,
-                follow_current_date,
+                plan,
                 &mut subscribed_date,
                 &mut position_timestamp,
             );

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -790,11 +790,23 @@ pub async fn consumer(
     // Poll once to trigger rebalance and get assignment
     loop {
         match consumer.poll(KAFKA_TIMEOUT_SECS) {
-            Some(Ok(_msg)) => {
+            Some(Ok(msg)) => {
                 debug!("Got initial assignment, positioning partitions...");
                 if exit_on_eof {
                     seek_to_timestamp(&consumer, timestamp * 1000)?;
                 } else {
+                    // This message is only an assignment signal and is dropped.
+                    // Rewind so it is redelivered: positioning does not seek a
+                    // committed partition, and one that it does seek overrides
+                    // this anyway.
+                    if let Err(error) = consumer.seek(
+                        msg.topic(),
+                        msg.partition(),
+                        rdkafka::Offset::Offset(msg.offset()),
+                        POSITION_TIMEOUT,
+                    ) {
+                        log_error!(WARN, error, "failed to rewind the first message");
+                    }
                     pending_positions =
                         position_or_warn(&consumer, timestamp * 1000, &mut positioned);
                 }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -824,7 +824,13 @@ pub async fn consumer(
     survey: &'static str,
 ) -> Result<(), ConsumerError> {
     let server = survey_consumer_config.server.clone();
-    let group_id = survey_consumer_config.group_id.clone();
+    // Throwaway group so a one-shot replay never rebalances the long-running
+    // consumers; the timestamp suffix keeps one run's threads together.
+    let group_id = if exit_on_eof {
+        format!("{}-oneshot-{}", survey_consumer_config.group_id, timestamp)
+    } else {
+        survey_consumer_config.group_id.clone()
+    };
     let username = survey_consumer_config.username.clone();
     let password = survey_consumer_config.password.clone();
 

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -1242,8 +1242,11 @@ pub async fn consumer(
                     info!("No more messages, exiting consumer {}", id);
                     break;
                 }
-                // Idle: catch a topic that has just rolled over.
-                position_or_warn(&consumer, position_timestamp * 1000, &mut positioned);
+                // Idle: catch a topic that has just rolled over. Not on a replay,
+                // which would be seeked back to the start of the night it finished.
+                if !replay {
+                    position_or_warn(&consumer, position_timestamp * 1000, &mut positioned);
+                }
             }
         }
     }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -754,6 +754,14 @@ impl StartDate {
         matches!(self, StartDate::Current | StartDate::From(_))
     }
 
+    /// Nights of history this start reaches back over, one topic each.
+    pub fn catch_up_days(self) -> u64 {
+        match self {
+            StartDate::From(timestamp) => days_between(timestamp, current_day_midnight()),
+            _ => 0,
+        }
+    }
+
     /// Resolve into the instants the poll loop runs on, widening the survey's
     /// configured window if `From` reaches further back than it.
     pub fn plan(self, configured_window_days: u64) -> StartPlan {
@@ -796,6 +804,10 @@ pub struct StartPlan {
     /// False while catching up, whose older nights the rolled day would skip.
     pub positions_at_rolled_day: bool,
 }
+
+/// Beyond this, a catch-up is asking for more nights than any survey retains,
+/// and every extra one is a topic that no longer exists.
+pub const MAX_CATCH_UP_DAYS: u64 = 30;
 
 fn current_day_midnight() -> i64 {
     let now = chrono::Utc::now();

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -1084,20 +1084,46 @@ pub async fn consumer(
             reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
         }
         if max_in_queue > 0 && total % 1000 == 0 {
+            // Pause rather than sleep: a consumer that stops polling for
+            // `max.poll.interval.ms` (5 min) is fenced out of the group.
+            let mut paused = false;
             loop {
                 let nb_in_queue = con
                     .llen::<&str, usize>(&output_queue)
                     .await
                     .inspect_err(as_error!("failed to get queue length"))?;
-                if nb_in_queue >= max_in_queue {
+                if nb_in_queue < max_in_queue {
+                    break;
+                }
+                if !paused {
                     info!(
-                        "{} (limit: {}) items in queue, sleeping...",
+                        "{} (limit: {}) items in queue, pausing consumption...",
                         nb_in_queue, max_in_queue
                     );
-                    tokio::time::sleep(core::time::Duration::from_millis(500)).await;
-                    continue;
+                    consumer.pause(&consumer.assignment()?)?;
+                    paused = true;
                 }
-                break;
+                // Yields nothing while paused, but forwards anything still in flight.
+                if let Some(Ok(message)) = consumer.poll(core::time::Duration::from_millis(500)) {
+                    let payload = message.payload().unwrap_or_default();
+                    con.rpush::<&str, Vec<u8>, usize>(&output_queue, payload.to_vec())
+                        .await
+                        .inspect_err(|error| {
+                            log_error!(error, "failed to push message to queue");
+                            ALERT_PROCESSED.add(1, &output_error_attrs);
+                        })?;
+                    if !exit_on_eof {
+                        if let Err(error) = consumer.store_offset_from_message(&message) {
+                            log_error!(error, "failed to store offset");
+                        }
+                    }
+                    ALERT_PROCESSED.add(1, &ok_attrs);
+                    total += 1;
+                }
+            }
+            if paused {
+                consumer.resume(&consumer.assignment()?)?;
+                info!("queue drained, resuming consumption");
             }
         }
         match consumer.poll(KAFKA_TIMEOUT_SECS) {

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -726,14 +726,6 @@ impl StartDate {
         matches!(self, StartDate::Current | StartDate::From(_))
     }
 
-    /// Nights of history this start reaches back over, one topic each.
-    pub fn catch_up_days(self) -> u64 {
-        match self {
-            StartDate::From(timestamp) => days_between(timestamp, current_day_midnight()),
-            _ => 0,
-        }
-    }
-
     /// Resolve into the instants the poll loop runs on, widening the survey's
     /// configured window if `From` reaches further back than it.
     pub fn plan(self, configured_window_days: u64) -> StartPlan {
@@ -779,10 +771,6 @@ pub struct StartPlan {
     /// Own consumer group, no commits, that night's topics alone, no rollover.
     pub replay: bool,
 }
-
-/// Beyond this, a catch-up is asking for more nights than any survey retains,
-/// and every extra one is a topic that no longer exists.
-pub const MAX_CATCH_UP_DAYS: u64 = 30;
 
 fn current_day_midnight() -> i64 {
     let now = chrono::Utc::now();
@@ -971,7 +959,8 @@ pub async fn consumer(
         .create()
         .inspect_err(as_error!("failed to create consumer"))?;
 
-    // Subscribe to topic(s)/pattern(s) - broker handles partition assignment.
+    // Subscribe to topic(s)/pattern(s), broker handles partition assignment.
+    info!("Consumer {} subscribing to {} topic(s)", id, topics.len());
     let topic_refs: Vec<&str> = topics.iter().map(|s| s.as_str()).collect();
     consumer
         .subscribe(&topic_refs)

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{
         data::count_files_in_dir,
         o11y::{
-            logging::{as_error, log_error},
+            logging::{as_error, log_error, WARN},
             metrics::CONSUMER_METER,
         },
     },
@@ -40,6 +40,11 @@ static ALERT_PROCESSED: LazyLock<Counter<u64>> = LazyLock::new(|| {
 
 const MAX_RETRIES_PRODUCER: usize = 6;
 const KAFKA_TIMEOUT_SECS: std::time::Duration = std::time::Duration::from_secs(30);
+
+// Positioning runs between two polls, so it must stay well under
+// `max.poll.interval.ms` (5 min) or librdkafka fences the member.
+const POSITION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const POSITION_CHUNK: usize = 12;
 
 // rdkafka's Metadata type provides *references* to MetadataTopic and
 // MetadataPartition values, neither of which implement Clone. We use a custom
@@ -395,15 +400,11 @@ pub enum ConsumerError {
 
 #[async_trait::async_trait]
 pub trait AlertConsumer: Sized {
-    /// Concrete topic name(s) for a specific date. Used by the producer side and
-    /// by the one-shot (`exit_on_eof`) drain path.
+    /// Concrete topic name(s) for a specific date.
     fn topic_names(&self, timestamp: i64) -> Vec<String>;
-    /// Subscription entries for the long-running consumer. Entries beginning with
-    /// `^` are interpreted by librdkafka as regular expressions, so the consumer
-    /// auto-discovers each new day's topic (e.g. `ztf_20260629_programid1`) and
-    /// rolls over on its own without restarting. Surveys with a single static
-    /// topic (e.g. LSST) return literal topic names instead. Each survey
-    /// implements this per its topic layout.
+    /// Subscription entries for the long-running consumer. A leading `^` makes
+    /// librdkafka treat the entry as a regex, so new daily topics are joined
+    /// automatically; surveys with a static topic return literal names.
     fn topic_patterns(&self) -> Vec<String>;
     fn output_queue(&self) -> String;
     fn survey(&self) -> &'static str;
@@ -424,10 +425,8 @@ pub trait AlertConsumer: Sized {
         );
         Ok(())
     }
-    // No `#[instrument]` here: `consume` runs the consumer loop for the
-    // entire process lifetime, and any wrapping span would make every
-    // per-message child span a descendant of the same root trace, which
-    // grows until Tempo rejects it (TRACE_TOO_LARGE).
+    // No `#[instrument]`: one span for the process lifetime would grow until
+    // Tempo rejects the trace (TRACE_TOO_LARGE).
     async fn consume(
         &self,
         topics: Option<Vec<String>>,
@@ -441,8 +440,6 @@ pub trait AlertConsumer: Sized {
         let config = AppConfig::from_path(config_path)?;
         let survey = self.survey();
 
-        // Prod: subscribe to topic pattern(s) so new daily topics auto-roll over.
-        // exit_on_eof (tests/dev): target the concrete topic for the date.
         let subscription = topics.unwrap_or_else(|| {
             if exit_on_eof {
                 self.topic_names(timestamp)
@@ -562,10 +559,8 @@ fn seek_to_timestamp(consumer: &BaseConsumer, timestamp_ms: i64) -> KafkaResult<
     Ok(())
 }
 
-// Position the given `targets` partitions for the long-running consumer: those
-// with a committed offset resume from it; the rest are resolved by `timestamp_ms`
-// (an old day's topic has nothing at/after it -> seek to end/skip; today's and
-// any newly-created daily topic -> its start).
+// Resolve uncommitted partitions against `timestamp_ms`: old topics skip to the
+// end, today's starts at its beginning.
 fn position_partitions(
     consumer: &BaseConsumer,
     targets: &TopicPartitionList,
@@ -574,50 +569,24 @@ fn position_partitions(
     if targets.count() == 0 {
         return Ok(());
     }
-    let committed = consumer.committed(KAFKA_TIMEOUT_SECS)?;
-
     let mut to_resolve = TopicPartitionList::new();
     for elem in targets.elements() {
-        match committed
-            .find_partition(elem.topic(), elem.partition())
-            .map(|c| c.offset())
-        {
-            Some(rdkafka::Offset::Offset(offset)) => {
-                consumer.seek(
-                    elem.topic(),
-                    elem.partition(),
-                    rdkafka::Offset::Offset(offset),
-                    KAFKA_TIMEOUT_SECS,
-                )?;
-            }
-            _ => {
-                to_resolve.add_partition_offset(
-                    elem.topic(),
-                    elem.partition(),
-                    rdkafka::Offset::Offset(timestamp_ms),
-                )?;
-            }
-        }
-    }
-
-    if to_resolve.count() == 0 {
-        return Ok(());
+        to_resolve.add_partition_offset(
+            elem.topic(),
+            elem.partition(),
+            rdkafka::Offset::Offset(timestamp_ms),
+        )?;
     }
     let resolved = consumer.offsets_for_times(to_resolve, KAFKA_TIMEOUT_SECS)?;
-    // Persist the resolved start/skip position for each uncommitted partition.
-    // With the default (eager) assignor, discovering the next day's topic revokes
-    // and reassigns everything; committing here means an old skipped topic resumes
-    // from its end (stays skipped) rather than resetting to `earliest` and
-    // replaying, and today's topic resumes from its start.
+    // Commit the resolved position so an eager rebalance doesn't reset it to `earliest`.
     let mut to_commit = TopicPartitionList::new();
     for elem in resolved.elements() {
         let offset = match elem.offset() {
             rdkafka::Offset::Offset(offset) => offset,
-            // No message at/after the timestamp (an old or empty topic): resolve
-            // the end offset numerically so it can be committed and skipped.
+            // Nothing at/after the timestamp: skip to the end.
             _ => {
                 consumer
-                    .fetch_watermarks(elem.topic(), elem.partition(), KAFKA_TIMEOUT_SECS)?
+                    .fetch_watermarks(elem.topic(), elem.partition(), POSITION_TIMEOUT)?
                     .1
             }
         };
@@ -625,7 +594,7 @@ fn position_partitions(
             elem.topic(),
             elem.partition(),
             rdkafka::Offset::Offset(offset),
-            KAFKA_TIMEOUT_SECS,
+            POSITION_TIMEOUT,
         )?;
         to_commit.add_partition_offset(
             elem.topic(),
@@ -639,38 +608,78 @@ fn position_partitions(
     Ok(())
 }
 
-// Position only partitions that have appeared in the assignment since the last
-// call, recording them in `positioned`. Positioning each partition exactly once
-// (rather than re-seeking the whole assignment whenever it changes) means a
-// still-active partition is never rewound to its lagging committed offset, and a
-// same-size membership swap (which a count check would miss) is still handled.
-// A genuinely-new daily topic is correctly picked up here; an old retained topic
-// re-assigned mid-run is skipped. (A brand-new partition consumed between poll
-// and this check would be rewound once here — a bounded, idempotent replay.)
+// Position newly-assigned partitions. A committed partition needs nothing:
+// librdkafka already resumes it from its offset, so it is recorded for free.
+// Only uncommitted ones cost broker round-trips, and those are done
+// POSITION_CHUNK at a time so one pass can't exhaust the poll interval; the rest
+// stay paused until their turn. Returns whether any are still pending.
 fn reposition_new_partitions(
     consumer: &BaseConsumer,
     timestamp_ms: i64,
     positioned: &mut std::collections::HashSet<(String, i32)>,
-) -> KafkaResult<()> {
+) -> KafkaResult<bool> {
     let assignment = consumer.assignment()?;
-    let mut fresh = TopicPartitionList::new();
+    let mut pending = TopicPartitionList::new();
     for elem in assignment.elements() {
         if !positioned.contains(&(elem.topic().to_string(), elem.partition())) {
-            fresh.add_partition_offset(elem.topic(), elem.partition(), rdkafka::Offset::Invalid)?;
+            pending.add_partition_offset(
+                elem.topic(),
+                elem.partition(),
+                rdkafka::Offset::Invalid,
+            )?;
         }
     }
-    if fresh.count() == 0 {
-        return Ok(());
+    if pending.count() == 0 {
+        return Ok(false);
     }
-    position_partitions(consumer, &fresh, timestamp_ms)?;
-    for elem in fresh.elements() {
-        positioned.insert((elem.topic().to_string(), elem.partition()));
+    consumer.pause(&pending)?;
+
+    let committed = consumer.committed_offsets(pending, KAFKA_TIMEOUT_SECS)?;
+    let mut ready = TopicPartitionList::new();
+    let mut chunk = TopicPartitionList::new();
+    let mut remaining = 0;
+    for elem in committed.elements() {
+        let target = match elem.offset() {
+            rdkafka::Offset::Offset(_) => &mut ready,
+            _ if chunk.count() < POSITION_CHUNK => &mut chunk,
+            _ => {
+                remaining += 1;
+                continue;
+            }
+        };
+        target.add_partition_offset(elem.topic(), elem.partition(), rdkafka::Offset::Invalid)?;
     }
-    Ok(())
+
+    position_partitions(consumer, &chunk, timestamp_ms)?;
+    for tpl in [&ready, &chunk] {
+        consumer.resume(tpl)?;
+        for elem in tpl.elements() {
+            positioned.insert((elem.topic().to_string(), elem.partition()));
+        }
+    }
+    if remaining > 0 {
+        debug!("{} partitions still pending positioning", remaining);
+    }
+    Ok(remaining > 0)
 }
 
-// No `#[instrument]` here: this function is the long-lived Kafka poll loop;
-// instrumenting it would funnel every per-message span into one giant trace.
+// A rebalance landing mid-pass must not take the consumer down; the next pass retries.
+fn position_or_warn(
+    consumer: &BaseConsumer,
+    timestamp_ms: i64,
+    positioned: &mut std::collections::HashSet<(String, i32)>,
+) -> bool {
+    match reposition_new_partitions(consumer, timestamp_ms, positioned) {
+        Ok(pending) => pending,
+        Err(error) => {
+            log_error!(WARN, error, "failed to position partitions, will retry");
+            true
+        }
+    }
+}
+
+// No `#[instrument]`: this loop is long-lived, so one span would swallow every
+// per-message span into a single unbounded trace.
 pub async fn consumer(
     id: &str,
     subscription: Vec<String>,
@@ -683,7 +692,13 @@ pub async fn consumer(
     survey: &'static str,
 ) -> Result<(), ConsumerError> {
     let server = survey_consumer_config.server.clone();
-    let group_id = survey_consumer_config.group_id.clone();
+    // Throwaway group so a one-shot replay never rebalances the long-running
+    // consumers; the timestamp suffix keeps one run's threads in the same group.
+    let group_id = if exit_on_eof {
+        format!("{}-oneshot-{}", survey_consumer_config.group_id, timestamp)
+    } else {
+        survey_consumer_config.group_id.clone()
+    };
     let username = survey_consumer_config.username.clone();
     let password = survey_consumer_config.password.clone();
 
@@ -732,20 +747,16 @@ pub async fn consumer(
         .set("bootstrap.servers", &server)
         .set("group.id", &group_id)
         .set("auto.offset.reset", "earliest")
-        // Manual offset storage so the bootstrap seek isn't clobbered; in the
-        // prod path we store offsets explicitly after each push (see below).
+        // Manual storage so the bootstrap seek isn't clobbered.
         .set("enable.auto.offset.store", "false");
 
     if !exit_on_eof {
-        // Long-running consumer: commit stored offsets so restarts and rebalances
-        // resume in place instead of replaying. We deliberately keep the default
-        // (eager) assignment strategy: switching a live consumer group to
-        // cooperative-sticky is an incompatible rebalance protocol, and members
-        // already in the group on the eager protocol reject the join with
-        // InconsistentGroupProtocol.
+        // Commit so restarts resume in place. The default (eager) assignor is
+        // deliberate: cooperative-sticky would be rejected by members already in
+        // the group with InconsistentGroupProtocol.
         client_config
             .set("enable.auto.commit", "true")
-            // How quickly a newly-created daily topic is discovered and joined.
+            // How quickly a new daily topic is discovered.
             .set("topic.metadata.refresh.interval.ms", "10000");
     }
 
@@ -772,8 +783,9 @@ pub async fn consumer(
     // Wait for initial assignment
     debug!("Waiting for partition assignment...");
 
-    // Partitions already positioned (prod path only); see reposition_new_partitions.
+    // Partitions already positioned (prod path only).
     let mut positioned: std::collections::HashSet<(String, i32)> = std::collections::HashSet::new();
+    let mut pending_positions = false;
 
     // Poll once to trigger rebalance and get assignment
     loop {
@@ -781,11 +793,10 @@ pub async fn consumer(
             Some(Ok(_msg)) => {
                 debug!("Got initial assignment, positioning partitions...");
                 if exit_on_eof {
-                    // One-shot drain: (re)read from the requested timestamp.
                     seek_to_timestamp(&consumer, timestamp * 1000)?;
                 } else {
-                    // Resume committed partitions; skip old / start today otherwise.
-                    reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
+                    pending_positions =
+                        position_or_warn(&consumer, timestamp * 1000, &mut positioned);
                 }
                 break;
             }
@@ -852,10 +863,7 @@ pub async fn consumer(
     // start timer
     let start = std::time::Instant::now();
 
-    // Emit a periodic "still alive" line so low-volume surveys (e.g. WINTER,
-    // which may push far fewer than the every-1000 progress log) visibly report
-    // progress instead of looking stalled. Also confirms the loop is polling
-    // even when idle between nights.
+    // Low-volume surveys rarely reach the every-1000 progress log, so report anyway.
     const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_heartbeat = std::time::Instant::now();
     let mut total_at_last_heartbeat: u64 = 0;
@@ -878,31 +886,70 @@ pub async fn consumer(
             last_heartbeat = std::time::Instant::now();
             total_at_last_heartbeat = total;
         }
-        // Pick up newly-assigned partitions (e.g. the next day's topic rolling
-        // over). Kept off the per-message hot path: checked once per 1000
-        // messages and whenever the poll goes idle (rollover happens in the
-        // quiet gap between nights, so the idle check catches it promptly).
+        // Pick up the next day's topic, off the per-message hot path.
         if !exit_on_eof && total % 1000 == 0 {
-            reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
+            pending_positions = position_or_warn(&consumer, timestamp * 1000, &mut positioned);
         }
         if max_in_queue > 0 && total % 1000 == 0 {
+            // Back-pressure. Pause rather than sleep: a consumer that stops
+            // polling for `max.poll.interval.ms` (5 min) is fenced out of the group.
+            let mut paused = false;
             loop {
                 let nb_in_queue = con
                     .llen::<&str, usize>(&output_queue)
                     .await
                     .inspect_err(as_error!("failed to get queue length"))?;
-                if nb_in_queue >= max_in_queue {
+                if nb_in_queue < max_in_queue {
+                    break;
+                }
+                if !paused {
                     info!(
-                        "{} (limit: {}) items in queue, sleeping...",
+                        "{} (limit: {}) items in queue, pausing consumption...",
                         nb_in_queue, max_in_queue
                     );
-                    tokio::time::sleep(core::time::Duration::from_millis(500)).await;
-                    continue;
+                    consumer.pause(&consumer.assignment()?)?;
+                    paused = true;
                 }
-                break;
+                // Yields nothing while paused, but forwards anything still in flight.
+                if let Some(Ok(message)) = consumer.poll(core::time::Duration::from_millis(500)) {
+                    let payload = message.payload().unwrap_or_default();
+                    con.rpush::<&str, Vec<u8>, usize>(&output_queue, payload.to_vec())
+                        .await
+                        .inspect_err(as_error!("failed to push message to queue"))?;
+                    if !exit_on_eof {
+                        if let Err(error) = consumer.store_offset_from_message(&message) {
+                            log_error!(error, "failed to store offset");
+                        }
+                    }
+                    ALERT_PROCESSED.add(1, &ok_attrs);
+                    total += 1;
+                }
+            }
+            if paused {
+                // Only what is positioned; the rest is paused on purpose.
+                let assignment = consumer.assignment()?;
+                let mut to_resume = TopicPartitionList::new();
+                for elem in assignment.elements() {
+                    if exit_on_eof
+                        || positioned.contains(&(elem.topic().to_string(), elem.partition()))
+                    {
+                        to_resume.add_partition_offset(
+                            elem.topic(),
+                            elem.partition(),
+                            rdkafka::Offset::Invalid,
+                        )?;
+                    }
+                }
+                consumer.resume(&to_resume)?;
+                info!("queue drained, resuming consumption");
             }
         }
-        match consumer.poll(KAFKA_TIMEOUT_SECS) {
+        let poll_timeout = if pending_positions {
+            core::time::Duration::from_millis(500)
+        } else {
+            KAFKA_TIMEOUT_SECS
+        };
+        match consumer.poll(poll_timeout) {
             Some(Ok(message)) => {
                 let payload = message.payload().unwrap_or_default();
                 con.rpush::<&str, Vec<u8>, usize>(&output_queue, payload.to_vec())
@@ -946,7 +993,7 @@ pub async fn consumer(
                     break;
                 }
                 // Idle: catch a topic that has just rolled over.
-                reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
+                pending_positions = position_or_warn(&consumer, timestamp * 1000, &mut positioned);
             }
         }
     }

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -6,7 +6,7 @@ mod ztf;
 
 pub use base::{
     consumer, count_messages, delete_topic, initialize_topic, subscription_window, AlertConsumer,
-    AlertProducer, StartDate,
+    AlertProducer, StartDate, StartPlan,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -6,7 +6,7 @@ mod ztf;
 
 pub use base::{
     consumer, count_messages, delete_topic, initialize_topic, subscription_window, AlertConsumer,
-    AlertProducer, StartDate, StartPlan,
+    AlertProducer, StartDate, StartPlan, MAX_CATCH_UP_DAYS,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -6,7 +6,7 @@ mod ztf;
 
 pub use base::{
     consumer, count_messages, delete_topic, initialize_topic, subscription_window, AlertConsumer,
-    AlertProducer, StartDate, StartPlan, MAX_CATCH_UP_DAYS,
+    AlertProducer, StartDate, StartPlan,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -40,13 +40,8 @@ impl AlertConsumer for ZtfAlertConsumer {
             .collect()
     }
     fn topic_patterns(&self) -> Vec<String> {
-        // Regex matching any date for the selected program id(s), e.g.
-        // ^ztf_[0-9]+_programid(1|2)$ — librdkafka auto-joins new daily topics.
-        // NB: librdkafka's matcher is POSIX/Thompson-NFA, so only basic
-        // constructs are used (no `\d`, no `{n}` bounded repetition).
+        // librdkafka's matcher is POSIX, so no `\d` and no `{n}`.
         let ids = if self.program_ids.is_empty() {
-            // Empty selection would otherwise yield `programid()`, matching
-            // nothing; fall back to any program id.
             "[0-9]+".to_string()
         } else {
             self.program_ids

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -442,8 +442,7 @@ async fn test_consumer_rolls_over_and_skips_old() {
                     std::sync::Arc::new(move |_, _| window.clone()),
                     &oq,
                     0,
-                    cold_start_ts,
-                    true,
+                    boom::kafka::StartDate::From(cold_start_ts).plan(1),
                     &config,
                     &kafka_cfg,
                     false,
@@ -666,6 +665,61 @@ fn test_start_date_signals_rollover_intent() {
     );
 }
 
+// Catching up from a past date means two different instants: the window ends at
+// today, so every night since is subscribed, while partitions are still
+// positioned at the requested date. Positioning them at today instead would find
+// nothing at or after it in the older topics and skip every one of them.
+#[test]
+fn test_from_date_catches_up_every_night_since() {
+    use boom::kafka::{AlertConsumer, StartDate, ZtfAlertConsumer};
+    use boom::utils::enums::ProgramId;
+
+    let today = chrono::Utc::now().date_naive();
+    let start = today.checked_sub_days(chrono::Days::new(10)).unwrap();
+    let start_ts = start.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+
+    let plan = StartDate::From(start_ts).plan(1);
+    assert_eq!(plan.position_timestamp, start_ts);
+    assert_eq!(
+        plan.window_days, 10,
+        "the window must reach back to the start date"
+    );
+    assert!(
+        plan.follows_clock,
+        "catch-up still rolls onto each new night"
+    );
+    assert!(
+        !plan.positions_at_rolled_day,
+        "rolling must not move the position past the nights being caught up"
+    );
+
+    let topics = ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public]))
+        .subscription_topics(plan.subscription_timestamp, plan.window_days);
+    assert_eq!(topics.len(), 11, "10 nights back plus today");
+    assert!(topics.contains(&format!("ztf_{}_programid1", start.format("%Y%m%d"))));
+    assert!(topics.contains(&format!("ztf_{}_programid1", today.format("%Y%m%d"))));
+}
+
+// The other two modes read from the instant they subscribe to, over the window
+// the survey is configured with.
+#[test]
+fn test_current_and_pinned_plans_keep_the_configured_window() {
+    use boom::kafka::StartDate;
+
+    let current = StartDate::Current.plan(1);
+    assert_eq!(current.window_days, 1);
+    assert_eq!(current.position_timestamp, current.subscription_timestamp);
+    assert!(current.follows_clock);
+    assert!(current.positions_at_rolled_day);
+
+    let pinned = StartDate::Pinned(1_741_651_200).plan(1);
+    assert_eq!(pinned.window_days, 1);
+    assert_eq!(pinned.position_timestamp, 1_741_651_200);
+    assert_eq!(pinned.subscription_timestamp, 1_741_651_200);
+    assert!(!pinned.follows_clock);
+    assert!(!pinned.positions_at_rolled_day);
+}
+
 // A pinned replay still has to subscribe to the topic it was asked for.
 #[test]
 fn test_pinned_date_window_contains_that_date() {
@@ -776,8 +830,7 @@ async fn test_consumer_started_with_no_data_still_consumes() {
                     std::sync::Arc::new(move |_, _| subscription.clone()),
                     &oq,
                     0,
-                    cold_start_ts,
-                    true,
+                    boom::kafka::StartDate::From(cold_start_ts).plan(1),
                     &config,
                     &kafka_cfg,
                     false,

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -701,31 +701,6 @@ fn test_from_date_catches_up_every_night_since() {
     assert!(topics.contains(&format!("ztf_{}_programid1", today.format("%Y%m%d"))));
 }
 
-// Catching up is bounded: a date further back than any survey retains would
-// subscribe to hundreds of topics that no longer exist, each of which fails
-// every poll.
-#[test]
-fn test_catch_up_is_bounded_and_only_applies_to_from() {
-    use boom::kafka::{StartDate, MAX_CATCH_UP_DAYS};
-
-    let old = chrono::Utc::now()
-        .date_naive()
-        .checked_sub_days(chrono::Days::new(MAX_CATCH_UP_DAYS + 500))
-        .unwrap()
-        .and_hms_opt(0, 0, 0)
-        .unwrap()
-        .and_utc()
-        .timestamp();
-
-    assert!(StartDate::From(old).catch_up_days() > MAX_CATCH_UP_DAYS);
-    assert_eq!(
-        StartDate::Pinned(old).catch_up_days(),
-        0,
-        "a pinned replay reaches back over nothing"
-    );
-    assert_eq!(StartDate::Current.catch_up_days(), 0);
-}
-
 // The other two modes read from the instant they subscribe to, over the window
 // the survey is configured with.
 #[test]

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -635,7 +635,7 @@ fn test_lsst_subscription_topic_is_static() {
 }
 
 // Rollover intent is stated by the caller, not inferred from the timestamp.
-// The throughput benchmark runs `kafka_consumer ztf 20250311`, and chasing the
+// The throughput benchmark runs `kafka_consumer ztf --on 20250311`, and chasing the
 // wall clock would unsubscribe it from the only topic it was started to read.
 #[test]
 fn test_start_date_signals_rollover_intent() {
@@ -692,6 +692,7 @@ fn test_from_date_catches_up_every_night_since() {
         !plan.positions_at_rolled_day,
         "rolling must not move the position past the nights being caught up"
     );
+    assert!(!plan.replay, "a catch-up is the production path");
 
     let topics = ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public]))
         .subscription_topics(plan.subscription_timestamp, plan.window_days);
@@ -736,6 +737,7 @@ fn test_current_and_pinned_plans_keep_the_configured_window() {
     assert_eq!(current.position_timestamp, current.subscription_timestamp);
     assert!(current.follows_clock);
     assert!(current.positions_at_rolled_day);
+    assert!(!current.replay);
 
     let pinned = StartDate::Pinned(1_741_651_200).plan(1);
     assert_eq!(pinned.window_days, 1);
@@ -743,6 +745,10 @@ fn test_current_and_pinned_plans_keep_the_configured_window() {
     assert_eq!(pinned.subscription_timestamp, 1_741_651_200);
     assert!(!pinned.follows_clock);
     assert!(!pinned.positions_at_rolled_day);
+    assert!(
+        pinned.replay,
+        "pinning to one night is what puts the run on the replay path"
+    );
 }
 
 // A pinned replay still has to subscribe to the topic it was asked for.

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -343,6 +343,203 @@ async fn wait_for_payloads(
     }
 }
 
+/// Block until the group's committed offsets across every partition of `topic`
+/// add up to `total`. Summing avoids assuming which partition the keys landed
+/// on. Panics on timeout.
+async fn wait_for_committed(
+    server: &str,
+    group_id: &str,
+    topic: &str,
+    total: i64,
+    timeout: std::time::Duration,
+) {
+    use rdkafka::consumer::{BaseConsumer, Consumer};
+
+    let probe: BaseConsumer = rdkafka::config::ClientConfig::new()
+        .set("bootstrap.servers", server)
+        .set("group.id", group_id)
+        .create()
+        .unwrap();
+    let metadata = probe
+        .fetch_metadata(Some(topic), std::time::Duration::from_secs(10))
+        .unwrap();
+    let partitions: Vec<i32> = metadata
+        .topics()
+        .iter()
+        .find(|t| t.name() == topic)
+        .unwrap()
+        .partitions()
+        .iter()
+        .map(|p| p.id())
+        .collect();
+
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let mut tpl = rdkafka::TopicPartitionList::new();
+        for id in &partitions {
+            tpl.add_partition_offset(topic, *id, rdkafka::Offset::Invalid)
+                .unwrap();
+        }
+        let committed = probe
+            .committed_offsets(tpl, std::time::Duration::from_secs(10))
+            .unwrap();
+        let sum: i64 = committed
+            .elements()
+            .iter()
+            .filter_map(|e| match e.offset() {
+                rdkafka::Offset::Offset(o) => Some(o),
+                _ => None,
+            })
+            .sum();
+        if sum >= total {
+            return;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("timed out waiting for {total} committed offsets on {topic}, saw {sum}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+}
+
+/// Run the long-running consumer on its own OS thread + runtime, as prod does.
+/// Send on the returned channel to stop it.
+fn spawn_consumer(
+    subscription: Vec<String>,
+    output_queue: String,
+    timestamp: i64,
+    config: boom::conf::AppConfig,
+    kafka_cfg: boom::conf::KafkaConsumerConfig,
+) -> (std::sync::mpsc::Sender<()>, std::thread::JoinHandle<()>) {
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    let handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.spawn(async move {
+            let _ = boom::kafka::consumer(
+                "0",
+                subscription,
+                &output_queue,
+                0,
+                timestamp,
+                &config,
+                &kafka_cfg,
+                false,
+                "ZTF",
+            )
+            .await;
+        });
+        let _ = stop_rx.recv();
+        rt.shutdown_timeout(std::time::Duration::from_secs(1));
+    });
+    (stop_tx, handle)
+}
+
+// Regression: the initial assignment poll discards the message it polls, and
+// positioning does not seek a partition that already has a committed offset.
+// Without an explicit rewind that message is skipped for good on every restart.
+#[tokio::test]
+async fn test_consumer_restart_loses_no_message() {
+    use boom::conf::{AppConfig, KafkaConsumerConfig};
+    use boom::kafka::{delete_topic, initialize_topic};
+    use rdkafka::config::ClientConfig;
+    use rdkafka::producer::{FutureProducer, FutureRecord};
+    use std::time::Duration;
+
+    let server = "localhost:9092";
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let prefix = format!("restarttest{now_ms}");
+    let topic = format!("{prefix}_20260628");
+    let output_queue = format!("{prefix}_queue");
+    let group_id = format!("{prefix}_group");
+
+    let app_config = AppConfig::from_path(TEST_CONFIG_FILE).unwrap();
+    let mut con = app_config.build_redis().await.unwrap();
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", server)
+        .create()
+        .unwrap();
+    initialize_topic(server, &topic, 1).await.unwrap();
+
+    let kafka_cfg = KafkaConsumerConfig {
+        server: server.to_string(),
+        group_id: group_id.clone(),
+        schema_registry: None,
+        schema_github_fallback_url: None,
+        username: None,
+        password: None,
+    };
+    let cold_start_ts = now_ms / 1000 - 3600;
+
+    // First run: drain a batch, then wait for the offsets to actually commit —
+    // otherwise the second run is a cold start and the regression can't show.
+    let first: Vec<String> = (0..5).map(|i| format!("first-{i}")).collect();
+    for p in &first {
+        producer
+            .send(
+                FutureRecord::to(topic.as_str())
+                    .payload(p.as_str())
+                    .key("k")
+                    .timestamp(now_ms),
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+    }
+    let (stop_tx, handle) = spawn_consumer(
+        vec![topic.clone()],
+        output_queue.clone(),
+        cold_start_ts,
+        app_config.clone(),
+        kafka_cfg.clone(),
+    );
+    wait_for_payloads(&mut con, &output_queue, &first, Duration::from_secs(40)).await;
+    wait_for_committed(
+        server,
+        &group_id,
+        &topic,
+        first.len() as i64,
+        Duration::from_secs(30),
+    )
+    .await;
+    let _ = stop_tx.send(());
+    let _ = handle.join();
+
+    // Second run on the same group: the message polled to detect the assignment
+    // sits at the committed offset, and must still reach the queue.
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+    let second: Vec<String> = (0..5).map(|i| format!("second-{i}")).collect();
+    for p in &second {
+        producer
+            .send(
+                FutureRecord::to(topic.as_str())
+                    .payload(p.as_str())
+                    .key("k")
+                    .timestamp(now_ms),
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+    }
+    let (stop_tx, handle) = spawn_consumer(
+        vec![topic.clone()],
+        output_queue.clone(),
+        cold_start_ts,
+        app_config.clone(),
+        kafka_cfg,
+    );
+    wait_for_payloads(&mut con, &output_queue, &second, Duration::from_secs(40)).await;
+
+    let _ = stop_tx.send(());
+    let _ = handle.join();
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+    let _ = delete_topic(server, &topic).await;
+}
+
 // End-to-end test of the self-rollover consumer: the long-running consumer
 // subscribes to a topic *pattern* and must (a) skip an old retained topic's
 // messages on cold start, (b) consume the current day's messages, and (c)

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -700,6 +700,31 @@ fn test_from_date_catches_up_every_night_since() {
     assert!(topics.contains(&format!("ztf_{}_programid1", today.format("%Y%m%d"))));
 }
 
+// Catching up is bounded: a date further back than any survey retains would
+// subscribe to hundreds of topics that no longer exist, each of which fails
+// every poll.
+#[test]
+fn test_catch_up_is_bounded_and_only_applies_to_from() {
+    use boom::kafka::{StartDate, MAX_CATCH_UP_DAYS};
+
+    let old = chrono::Utc::now()
+        .date_naive()
+        .checked_sub_days(chrono::Days::new(MAX_CATCH_UP_DAYS + 500))
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    assert!(StartDate::From(old).catch_up_days() > MAX_CATCH_UP_DAYS);
+    assert_eq!(
+        StartDate::Pinned(old).catch_up_days(),
+        0,
+        "a pinned replay reaches back over nothing"
+    );
+    assert_eq!(StartDate::Current.catch_up_days(), 0);
+}
+
 // The other two modes read from the instant they subscribe to, over the window
 // the survey is configured with.
 #[test]

--- a/tests/throughput/compose.yaml
+++ b/tests/throughput/compose.yaml
@@ -130,7 +130,9 @@ services:
     networks:
       - boom
     # have it sleep 5 seconds to allow kafka to finish producing
-    command: ["/bin/sh", "-c", "sleep 5 && /app/kafka_consumer ztf 20250311 --programids public"]
+    # --date-mode pinned: the benchmark replays one archived night, so the
+    # consumer must stay on it instead of catching up to today.
+    command: ["/bin/sh", "-c", "sleep 5 && /app/kafka_consumer ztf 20250311 --programids public --date-mode pinned"]
     environment:
       RUST_LOG: error,boom=debug
       # No OTel collector runs in the throughput compose. Skipping SDK init

--- a/tests/throughput/compose.yaml
+++ b/tests/throughput/compose.yaml
@@ -130,9 +130,8 @@ services:
     networks:
       - boom
     # have it sleep 5 seconds to allow kafka to finish producing
-    # --date-mode pinned: the benchmark replays one archived night, so the
-    # consumer must stay on it instead of catching up to today.
-    command: ["/bin/sh", "-c", "sleep 5 && /app/kafka_consumer ztf 20250311 --programids public --date-mode pinned"]
+    # --on: replay one archived night instead of catching up to today.
+    command: ["/bin/sh", "-c", "sleep 5 && /app/kafka_consumer ztf --on 20250311 --programids public"]
     environment:
       RUST_LOG: error,boom=debug
       # No OTel collector runs in the throughput compose. Skipping SDK init


### PR DESCRIPTION
Reworks how the Kafka consumer picks its starting point, and fixes three ways a
long-running consumer could stall or drop out of its group.

The date is no longer a positional argument, so every existing invocation changes.

- Replace the positional `DATE` with two mutually exclusive options: `--from DATE`
  treats it as a starting point and catches up every night since, rolling onto each
  new nightly topic; `--on DATE` replays that date alone, without committing offsets,
  so the night stays replayable
- Add `--exit-on-eof`, which only decides whether an `--on` run stops once its topics
  are drained. It is accepted only alongside `--on`, replacing the old
  `deployment_env == "dev"` gate with a parse-time constraint
- Back off 100ms rather than a full second per missing topic while waiting for the
  initial assignment
- Catching up positions partitions at the requested date while the subscription window
  ends at today, so past nights are read instead of skipped as stale
- Run replays in their own per-date consumer group, so replaying a night no longer
  joins the production group and rebalances the long-running consumers
- Pause consumption instead of sleeping when the output queue is full, so a long
  backlog no longer stops the poll loop and gets the consumer fenced out of its group
- Warn and retry when positioning partitions fails, instead of killing a long-running
  consumer on a transient error during a rebalance

On a survey with a single static topic (LSST), the date is a seek offset rather than a
topic selector, so `--on DATE` replays from that instant to the head of the stream
instead of one bounded night.