### PR TITLE
repair tempo healthcheck by invoking busybox sh directly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -716,7 +716,7 @@ services:
     networks:
       - boom
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3200/ready | grep -q 'ready' || exit 1"]
+      test: ["CMD", "/busybox/sh", "-c", "wget -qO- http://127.0.0.1:3200/ready | grep -q 'ready' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -716,7 +716,7 @@ services:
     networks:
       - boom
     healthcheck:
-      test: ["CMD", "/busybox/sh", "-c", "wget -qO- http://127.0.0.1:3200/ready | grep -q 'ready' || exit 1"]
+      test: ["CMD", "/busybox/sh", "-c", "/busybox/wget -qO- http://127.0.0.1:3200/ready | /busybox/grep -q 'ready' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yaml` file, improving the healthcheck command for one of the services by switching from `CMD-SHELL` to `CMD` and explicitly using `/busybox/sh`. This change ensures the healthcheck runs to avoid having an unhealthy container forever.