### PR TITLE
Subscribe Kafka consumers to a bounded daily-topic window

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,6 +46,12 @@ kafka:
     ztf:
       server: "localhost:9092"
       group_id: "" # Set via BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID environment variable
+      # Days before the current one to stay subscribed to. 1 keeps yesterday
+      # alongside today so a night spanning UTC midnight isn't cut off. Raise
+      # temporarily (via BOOM_KAFKA__CONSUMER__ZTF__SUBSCRIPTION_WINDOW_DAYS) to
+      # catch up after an upstream outage, then set it back; upstream retention
+      # (~7 days for ZTF) bounds what a lookback can recover.
+      subscription_window_days: 1
     lsst:
       server: "rubin-alert-stream-bootstrap.slac.stanford.edu:9094"
       schema_registry: "https://rubin-alert-schemas.slac.stanford.edu/schema-registry"

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -49,6 +49,12 @@ kafka:
     ztf:
       server: "localhost:9092"
       group_id: "" # Set via BOOM_KAFKA__CONSUMER__ZTF__GROUP_ID environment variable
+      # Days before the current one to stay subscribed to. 1 keeps yesterday
+      # alongside today so a night spanning UTC midnight isn't cut off. Raise
+      # temporarily (via BOOM_KAFKA__CONSUMER__ZTF__SUBSCRIPTION_WINDOW_DAYS) to
+      # catch up after an upstream outage, then set it back; upstream retention
+      # (~7 days for ZTF) bounds what a lookback can recover.
+      subscription_window_days: 1
     lsst:
       server: "rubin-alert-stream-bootstrap.slac.stanford.edu:9094"
       schema_registry: "https://rubin-alert-schemas.slac.stanford.edu/schema-registry"

--- a/src/bin/kafka_consumer.rs
+++ b/src/bin/kafka_consumer.rs
@@ -1,7 +1,8 @@
 use boom::{
     conf::load_dotenv,
     kafka::{
-        AlertConsumer, DecamAlertConsumer, LsstAlertConsumer, WinterAlertConsumer, ZtfAlertConsumer,
+        AlertConsumer, DecamAlertConsumer, LsstAlertConsumer, StartDate, WinterAlertConsumer,
+        ZtfAlertConsumer,
     },
     utils::{
         enums::{ProgramId, Survey},
@@ -93,11 +94,12 @@ async fn run(
     meter_provider: Option<SdkMeterProvider>,
     tracer_provider: Option<SdkTracerProvider>,
 ) {
-    let date = args.date.unwrap_or_else(|| {
-        let today = chrono::Utc::now().naive_utc().date();
-        today.and_hms_opt(0, 0, 0).unwrap()
-    });
-    let timestamp = date.and_utc().timestamp();
+    // An explicit date pins the run to that day (replay/backfill); without one
+    // the consumer tracks the current day and rolls over nightly.
+    let start = match args.date {
+        Some(date) => StartDate::Pinned(date.and_utc().timestamp()),
+        None => StartDate::Current,
+    };
 
     let exit_on_eof = if args.deployment_env == "dev" {
         args.exit_on_eof
@@ -118,7 +120,7 @@ async fn run(
             match consumer
                 .consume(
                     topics,
-                    timestamp,
+                    start,
                     None,
                     Some(args.processes),
                     Some(args.max_in_queue),
@@ -139,7 +141,7 @@ async fn run(
             match consumer
                 .consume(
                     topics,
-                    timestamp,
+                    start,
                     None,
                     Some(args.processes),
                     Some(args.max_in_queue),
@@ -160,7 +162,7 @@ async fn run(
             match consumer
                 .consume(
                     topics,
-                    timestamp,
+                    start,
                     None,
                     Some(args.processes),
                     Some(args.max_in_queue),
@@ -181,7 +183,7 @@ async fn run(
             match consumer
                 .consume(
                     topics,
-                    timestamp,
+                    start,
                     None,
                     Some(args.processes),
                     Some(args.max_in_queue),

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -458,6 +458,10 @@ fn default_kafka_server() -> String {
     "localhost:9092".to_string()
 }
 
+fn default_subscription_window_days() -> u64 {
+    1
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct KafkaConsumerConfig {
     #[serde(default = "default_kafka_server")]
@@ -467,6 +471,13 @@ pub struct KafkaConsumerConfig {
     pub schema_github_fallback_url: Option<String>, // URL of the GitHub fallback for schemas (if any)
     pub username: Option<String>,                   // Username for authentication (if any)
     pub password: Option<String>,                   // Password for authentication (if any)
+    /// Days before the current one to stay subscribed to, for surveys whose
+    /// topics are per-night. 1 (the default) keeps yesterday alongside today so
+    /// a night spanning UTC midnight isn't cut off. Raise it temporarily to
+    /// catch up after an upstream outage — bounded by upstream retention, which
+    /// is about 7 days for ZTF. Ignored by surveys with a single static topic.
+    #[serde(default = "default_subscription_window_days")]
+    pub subscription_window_days: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -459,7 +459,7 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
     async fn consume(
         &self,
         topics: Option<Vec<String>>,
-        timestamp: i64,
+        start: StartDate,
         kafka_config: Option<KafkaConsumerConfig>,
         n_threads: Option<usize>,
         max_in_queue: Option<usize>,
@@ -468,6 +468,10 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
     ) -> Result<(), ConsumerError> {
         let config = AppConfig::from_path(config_path)?;
         let survey = self.survey();
+        // Resolved once here, not per worker, so every thread agrees on the day
+        // even if they spawn either side of UTC midnight.
+        let timestamp = start.timestamp();
+        let follow_current_date = start.follows_clock();
 
         // Resolves the topics to subscribe to for a given instant. The consumer
         // loop re-invokes this on every UTC-date rollover and re-subscribes, so
@@ -516,6 +520,7 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
                     &output_queue,
                     max_in_queue,
                     timestamp,
+                    follow_current_date,
                     &config,
                     &kafka_config,
                     exit_on_eof,
@@ -703,15 +708,42 @@ fn reposition_new_partitions(
     Ok(())
 }
 
-/// Whether a consumer that started on `start_date` should keep following the
-/// clock onto each new daily topic.
+/// Where a consumer starts reading, and whether it advances with the clock.
 ///
-/// True only when it started on the live date, which is the case for the
-/// long-running production consumers (no explicit date, so they default to
-/// today). A run pinned to a past date is doing a replay or a backfill and must
-/// stay there.
-pub fn tracks_current_date(start_date: chrono::NaiveDate, current_date: chrono::NaiveDate) -> bool {
-    start_date == current_date
+/// The caller states which it wants rather than having it inferred from the
+/// timestamp. Inferring would get two cases wrong: a pinned run that happens to
+/// name today's date is still a pinned run, and a consumer started moments
+/// before UTC midnight would race the comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartDate {
+    /// Begin at the current UTC day and roll onto each new daily topic as
+    /// midnight passes. What the long-running consumers use.
+    Current,
+    /// Pinned to one instant — replay, backfill, benchmarks. Never rolls over:
+    /// advancing it would unsubscribe the consumer from the very topic it was
+    /// started to read.
+    Pinned(i64),
+}
+
+impl StartDate {
+    /// Unix seconds that newly-assigned partitions are positioned to.
+    pub fn timestamp(self) -> i64 {
+        match self {
+            StartDate::Current => {
+                let now = chrono::Utc::now();
+                now.date_naive()
+                    .and_hms_opt(0, 0, 0)
+                    .map(|midnight| midnight.and_utc().timestamp())
+                    .unwrap_or_else(|| now.timestamp())
+            }
+            StartDate::Pinned(timestamp) => timestamp,
+        }
+    }
+
+    /// Whether the subscription should roll onto each new UTC day.
+    pub fn follows_clock(self) -> bool {
+        matches!(self, StartDate::Current)
+    }
 }
 
 /// Whether a poll error refers to a partition whose topic no longer exists
@@ -737,6 +769,8 @@ pub async fn consumer(
     output_queue: &str,
     max_in_queue: usize,
     timestamp: i64,
+    // Whether to roll the subscription onto each new UTC day; see `StartDate`.
+    follow_current_date: bool,
     config: &AppConfig,
     survey_consumer_config: &KafkaConsumerConfig,
     exit_on_eof: bool,
@@ -938,11 +972,6 @@ pub async fn consumer(
         .map(|dt| dt.date_naive())
         .unwrap_or_else(|| chrono::Utc::now().date_naive());
     let mut position_timestamp = timestamp;
-    // Only a consumer that started on the live date should chase the clock. A
-    // run pinned to an explicit past date — replay, backfill, the throughput
-    // benchmark — must stay on the date it was asked for; rolling it forward
-    // would unsubscribe it from the very topic it was started to read.
-    let follow_current_date = tracks_current_date(subscribed_date, chrono::Utc::now().date_naive());
 
     // Expired-partition poll errors repeat indefinitely, so they get a short
     // backoff (enough to keep the loop off a hot spin) and a throttled log.

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -393,23 +393,22 @@ pub enum ConsumerError {
     ConfigError(#[from] config::ConfigError),
 }
 
-/// How many days back the daily-topic subscription window reaches, in addition
-/// to the current UTC day.
-///
-/// A survey night straddles UTC midnight, so yesterday's topic has to stay
-/// subscribed alongside today's or the tail of a night is dropped at rollover.
-/// Nothing older is included: those topics are already drained, and upstream
-/// expires the underlying partitions while still advertising the topic names,
-/// so re-subscribing to them only re-adds partitions that fail every poll.
-pub const SUBSCRIPTION_WINDOW_DAYS: u64 = 1;
-
 /// UTC dates a date-partitioned survey should currently be subscribed to,
-/// oldest first. See [`SUBSCRIPTION_WINDOW_DAYS`].
-pub fn subscription_window(timestamp: i64) -> Vec<chrono::NaiveDate> {
+/// oldest first: the day containing `timestamp` plus the preceding
+/// `window_days`.
+///
+/// The default of 1 keeps yesterday alongside today, because a survey night
+/// straddles UTC midnight and the tail of it would otherwise be dropped at
+/// rollover. Going wider is a deliberate, temporary act: upstream expires a
+/// topic's partitions while still advertising its name, so every extra day
+/// risks re-adding partitions that fail every poll (survivable — see
+/// `is_expired_partition` — but not free). Its intended use is catching up
+/// after an upstream outage, bounded by upstream retention.
+pub fn subscription_window(timestamp: i64, window_days: u64) -> Vec<chrono::NaiveDate> {
     let today = chrono::DateTime::from_timestamp(timestamp, 0)
         .map(|dt| dt.date_naive())
         .unwrap_or_else(|| chrono::Utc::now().date_naive());
-    (0..=SUBSCRIPTION_WINDOW_DAYS)
+    (0..=window_days)
         .rev()
         .filter_map(|days_back| today.checked_sub_days(chrono::Days::new(days_back)))
         .collect()
@@ -433,7 +432,7 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
     /// librdkafka expands a regex against every topic the cluster advertises,
     /// which for a daily-topic survey is the entire history of past nights — a
     /// set that grows without bound and is almost entirely expired.
-    fn subscription_topics(&self, timestamp: i64) -> Vec<String>;
+    fn subscription_topics(&self, timestamp: i64, window_days: u64) -> Vec<String>;
     fn output_queue(&self) -> String;
     fn survey(&self) -> &'static str;
     #[instrument(skip(self))]
@@ -474,15 +473,15 @@ pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
         // loop re-invokes this on every UTC-date rollover and re-subscribes, so
         // new daily topics are picked up without a restart.
         // exit_on_eof (tests/dev): target the concrete topic for the date.
-        let subscribe_to: Arc<dyn Fn(i64) -> Vec<String> + Send + Sync> = match topics {
-            Some(overridden) => Arc::new(move |_| overridden.clone()),
+        let subscribe_to: Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync> = match topics {
+            Some(overridden) => Arc::new(move |_, _| overridden.clone()),
             None if exit_on_eof => {
                 let survey_consumer = self.clone();
-                Arc::new(move |at| survey_consumer.topic_names(at))
+                Arc::new(move |at, _| survey_consumer.topic_names(at))
             }
             None => {
                 let survey_consumer = self.clone();
-                Arc::new(move |at| survey_consumer.subscription_topics(at))
+                Arc::new(move |at, days| survey_consumer.subscription_topics(at, days))
             }
         };
         let kafka_config = match kafka_config {
@@ -734,7 +733,7 @@ fn is_expired_partition(error: &KafkaError) -> bool {
 // instrumenting it would funnel every per-message span into one giant trace.
 pub async fn consumer(
     id: &str,
-    subscribe_to: Arc<dyn Fn(i64) -> Vec<String> + Send + Sync>,
+    subscribe_to: Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync>,
     output_queue: &str,
     max_in_queue: usize,
     timestamp: i64,
@@ -748,7 +747,8 @@ pub async fn consumer(
     let username = survey_consumer_config.username.clone();
     let password = survey_consumer_config.password.clone();
 
-    let subscription = subscribe_to(timestamp);
+    let window_days = survey_consumer_config.subscription_window_days;
+    let subscription = subscribe_to(timestamp, window_days);
 
     let topics: Vec<String> = if exit_on_eof {
         // One-shot drain: keep only concrete topics that have messages, exit if none.
@@ -980,7 +980,7 @@ pub async fn consumer(
                     .and_hms_opt(0, 0, 0)
                     .map(|midnight| midnight.and_utc().timestamp())
                     .unwrap_or(position_timestamp);
-                let rolled = subscribe_to(position_timestamp);
+                let rolled = subscribe_to(position_timestamp, window_days);
                 let rolled_refs: Vec<&str> = rolled.iter().map(|s| s.as_str()).collect();
                 match consumer.subscribe(&rolled_refs) {
                     Ok(()) => {

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use indicatif::ProgressBar;
 use opentelemetry::{metrics::Counter, KeyValue};
@@ -393,18 +393,47 @@ pub enum ConsumerError {
     ConfigError(#[from] config::ConfigError),
 }
 
+/// How many days back the daily-topic subscription window reaches, in addition
+/// to the current UTC day.
+///
+/// A survey night straddles UTC midnight, so yesterday's topic has to stay
+/// subscribed alongside today's or the tail of a night is dropped at rollover.
+/// Nothing older is included: those topics are already drained, and upstream
+/// expires the underlying partitions while still advertising the topic names,
+/// so re-subscribing to them only re-adds partitions that fail every poll.
+pub const SUBSCRIPTION_WINDOW_DAYS: u64 = 1;
+
+/// UTC dates a date-partitioned survey should currently be subscribed to,
+/// oldest first. See [`SUBSCRIPTION_WINDOW_DAYS`].
+pub fn subscription_window(timestamp: i64) -> Vec<chrono::NaiveDate> {
+    let today = chrono::DateTime::from_timestamp(timestamp, 0)
+        .map(|dt| dt.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    (0..=SUBSCRIPTION_WINDOW_DAYS)
+        .rev()
+        .filter_map(|days_back| today.checked_sub_days(chrono::Days::new(days_back)))
+        .collect()
+}
+
 #[async_trait::async_trait]
-pub trait AlertConsumer: Sized {
+pub trait AlertConsumer: Sized + Clone + Send + Sync + 'static {
     /// Concrete topic name(s) for a specific date. Used by the producer side and
     /// by the one-shot (`exit_on_eof`) drain path.
     fn topic_names(&self, timestamp: i64) -> Vec<String>;
-    /// Subscription entries for the long-running consumer. Entries beginning with
-    /// `^` are interpreted by librdkafka as regular expressions, so the consumer
-    /// auto-discovers each new day's topic (e.g. `ztf_20260629_programid1`) and
-    /// rolls over on its own without restarting. Surveys with a single static
-    /// topic (e.g. LSST) return literal topic names instead. Each survey
-    /// implements this per its topic layout.
-    fn topic_patterns(&self) -> Vec<String>;
+    /// Concrete topic names the long-running consumer subscribes to at
+    /// `timestamp`.
+    ///
+    /// Date-partitioned surveys return a bounded window (see
+    /// [`subscription_window`]); surveys with a single static topic (e.g. LSST)
+    /// return that literal name and ignore `timestamp`. The consumer re-invokes
+    /// this whenever the UTC date changes and re-subscribes to the result, which
+    /// is what makes rollover automatic.
+    ///
+    /// This deliberately returns literal names rather than a `^…` regex.
+    /// librdkafka expands a regex against every topic the cluster advertises,
+    /// which for a daily-topic survey is the entire history of past nights — a
+    /// set that grows without bound and is almost entirely expired.
+    fn subscription_topics(&self, timestamp: i64) -> Vec<String>;
     fn output_queue(&self) -> String;
     fn survey(&self) -> &'static str;
     #[instrument(skip(self))]
@@ -441,15 +470,21 @@ pub trait AlertConsumer: Sized {
         let config = AppConfig::from_path(config_path)?;
         let survey = self.survey();
 
-        // Prod: subscribe to topic pattern(s) so new daily topics auto-roll over.
+        // Resolves the topics to subscribe to for a given instant. The consumer
+        // loop re-invokes this on every UTC-date rollover and re-subscribes, so
+        // new daily topics are picked up without a restart.
         // exit_on_eof (tests/dev): target the concrete topic for the date.
-        let subscription = topics.unwrap_or_else(|| {
-            if exit_on_eof {
-                self.topic_names(timestamp)
-            } else {
-                self.topic_patterns()
+        let subscribe_to: Arc<dyn Fn(i64) -> Vec<String> + Send + Sync> = match topics {
+            Some(overridden) => Arc::new(move |_| overridden.clone()),
+            None if exit_on_eof => {
+                let survey_consumer = self.clone();
+                Arc::new(move |at| survey_consumer.topic_names(at))
             }
-        });
+            None => {
+                let survey_consumer = self.clone();
+                Arc::new(move |at| survey_consumer.subscription_topics(at))
+            }
+        };
         let kafka_config = match kafka_config {
             Some(cfg) => cfg,
             None => config
@@ -471,14 +506,14 @@ pub trait AlertConsumer: Sized {
 
         let mut handles = vec![];
         for i in 0..n_threads {
-            let subscription = subscription.clone();
+            let subscribe_to = subscribe_to.clone();
             let output_queue = self.output_queue();
             let config = config.clone();
             let kafka_config = kafka_config.clone();
             let handle = tokio::spawn(async move {
                 let result = consumer(
                     &i.to_string(),
-                    subscription,
+                    subscribe_to,
                     &output_queue,
                     max_in_queue,
                     timestamp,
@@ -669,11 +704,26 @@ fn reposition_new_partitions(
     Ok(())
 }
 
+/// Whether a poll error refers to a partition whose topic no longer exists
+/// upstream — typically an expired daily topic still present in the group's
+/// assignment. Unlike a transient broker error these never recover, so they
+/// must not be retried on the same backoff.
+fn is_expired_partition(error: &KafkaError) -> bool {
+    matches!(
+        error,
+        KafkaError::MessageConsumption(
+            rdkafka::error::RDKafkaErrorCode::UnknownTopicOrPartition
+                | rdkafka::error::RDKafkaErrorCode::UnknownTopic
+                | rdkafka::error::RDKafkaErrorCode::UnknownPartition
+        )
+    )
+}
+
 // No `#[instrument]` here: this function is the long-lived Kafka poll loop;
 // instrumenting it would funnel every per-message span into one giant trace.
 pub async fn consumer(
     id: &str,
-    subscription: Vec<String>,
+    subscribe_to: Arc<dyn Fn(i64) -> Vec<String> + Send + Sync>,
     output_queue: &str,
     max_in_queue: usize,
     timestamp: i64,
@@ -686,6 +736,8 @@ pub async fn consumer(
     let group_id = survey_consumer_config.group_id.clone();
     let username = survey_consumer_config.username.clone();
     let password = survey_consumer_config.password.clone();
+
+    let subscription = subscribe_to(timestamp);
 
     let topics: Vec<String> = if exit_on_eof {
         // One-shot drain: keep only concrete topics that have messages, exit if none.
@@ -860,6 +912,30 @@ pub async fn consumer(
     let mut last_heartbeat = std::time::Instant::now();
     let mut total_at_last_heartbeat: u64 = 0;
 
+    // How often the loop re-checks whether the UTC date has rolled onto a new
+    // daily topic. Cheap (a clock read, then a no-op unless the date changed),
+    // and deliberately driven by elapsed time rather than by message count: a
+    // count-gated check cannot fire while no messages are arriving, which is
+    // precisely the state rollover has to recover from.
+    const ROLLOVER_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+    let mut last_rollover_check = std::time::Instant::now();
+    // The date whose topics are currently subscribed, and the instant that
+    // newly-assigned partitions are positioned to. Both advance together on
+    // rollover, so a freshly-joined topic starts at its own day rather than at
+    // whichever day the process happened to boot on.
+    let mut subscribed_date = chrono::DateTime::from_timestamp(timestamp, 0)
+        .map(|dt| dt.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    let mut position_timestamp = timestamp;
+
+    // Expired-partition poll errors repeat indefinitely, so they get a short
+    // backoff (enough to keep the loop off a hot spin) and a throttled log.
+    const EXPIRED_POLL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+    const EXPIRED_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+    let mut last_expired_log = std::time::Instant::now()
+        .checked_sub(EXPIRED_LOG_INTERVAL)
+        .unwrap_or_else(std::time::Instant::now);
+
     debug!("Starting Kafka consumer loop...");
 
     // Process the rest normally
@@ -878,12 +954,31 @@ pub async fn consumer(
             last_heartbeat = std::time::Instant::now();
             total_at_last_heartbeat = total;
         }
-        // Pick up newly-assigned partitions (e.g. the next day's topic rolling
-        // over). Kept off the per-message hot path: checked once per 1000
-        // messages and whenever the poll goes idle (rollover happens in the
-        // quiet gap between nights, so the idle check catches it promptly).
-        if !exit_on_eof && total % 1000 == 0 {
-            reposition_new_partitions(&consumer, timestamp * 1000, &mut positioned)?;
+        // Roll the subscription onto the current UTC day, then pick up any
+        // newly-assigned partitions (the new day's topic, or a rebalance).
+        if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
+            last_rollover_check = std::time::Instant::now();
+            let today = chrono::Utc::now().date_naive();
+            if today != subscribed_date {
+                position_timestamp = today
+                    .and_hms_opt(0, 0, 0)
+                    .map(|midnight| midnight.and_utc().timestamp())
+                    .unwrap_or(position_timestamp);
+                let rolled = subscribe_to(position_timestamp);
+                let rolled_refs: Vec<&str> = rolled.iter().map(|s| s.as_str()).collect();
+                match consumer.subscribe(&rolled_refs) {
+                    Ok(()) => {
+                        info!(
+                            "Rolled subscription from {} to {}, now subscribed to {:?}",
+                            subscribed_date, today, rolled
+                        );
+                        subscribed_date = today;
+                    }
+                    // Stay on the current subscription; the next check retries.
+                    Err(error) => log_error!(error, "failed to roll subscription onto new day"),
+                }
+            }
+            reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
         }
         if max_in_queue > 0 && total % 1000 == 0 {
             loop {
@@ -934,8 +1029,27 @@ pub async fn consumer(
                 }
             }
             Some(Err(e)) => {
-                error!("Error while consuming from Kafka, retrying: {}", e);
                 ALERT_PROCESSED.add(1, &input_error_attrs);
+                // A partition whose topic has expired upstream fails on every
+                // poll and never recovers. Serving each one a full second of
+                // backoff turns this loop into a treadmill: once enough expired
+                // partitions are in the assignment the consumer can no longer
+                // drain the live topic, and it never reaches the idle branch
+                // below — which is where rollover would otherwise be noticed.
+                // Log sparsely and keep polling instead.
+                if is_expired_partition(&e) {
+                    if last_expired_log.elapsed() >= EXPIRED_LOG_INTERVAL {
+                        last_expired_log = std::time::Instant::now();
+                        warn!(
+                            "Polling a partition whose topic no longer exists upstream \
+                             (subscribed date {}): {}",
+                            subscribed_date, e
+                        );
+                    }
+                    tokio::time::sleep(EXPIRED_POLL_BACKOFF).await;
+                    continue;
+                }
+                error!("Error while consuming from Kafka, retrying: {}", e);
                 tokio::time::sleep(core::time::Duration::from_secs(1)).await;
                 continue;
             }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -704,6 +704,17 @@ fn reposition_new_partitions(
     Ok(())
 }
 
+/// Whether a consumer that started on `start_date` should keep following the
+/// clock onto each new daily topic.
+///
+/// True only when it started on the live date, which is the case for the
+/// long-running production consumers (no explicit date, so they default to
+/// today). A run pinned to a past date is doing a replay or a backfill and must
+/// stay there.
+pub fn tracks_current_date(start_date: chrono::NaiveDate, current_date: chrono::NaiveDate) -> bool {
+    start_date == current_date
+}
+
 /// Whether a poll error refers to a partition whose topic no longer exists
 /// upstream — typically an expired daily topic still present in the group's
 /// assignment. Unlike a transient broker error these never recover, so they
@@ -927,6 +938,11 @@ pub async fn consumer(
         .map(|dt| dt.date_naive())
         .unwrap_or_else(|| chrono::Utc::now().date_naive());
     let mut position_timestamp = timestamp;
+    // Only a consumer that started on the live date should chase the clock. A
+    // run pinned to an explicit past date — replay, backfill, the throughput
+    // benchmark — must stay on the date it was asked for; rolling it forward
+    // would unsubscribe it from the very topic it was started to read.
+    let follow_current_date = tracks_current_date(subscribed_date, chrono::Utc::now().date_naive());
 
     // Expired-partition poll errors repeat indefinitely, so they get a short
     // backoff (enough to keep the loop off a hot spin) and a throttled log.
@@ -959,7 +975,7 @@ pub async fn consumer(
         if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
             last_rollover_check = std::time::Instant::now();
             let today = chrono::Utc::now().date_naive();
-            if today != subscribed_date {
+            if follow_current_date && today != subscribed_date {
                 position_timestamp = today
                     .and_hms_opt(0, 0, 0)
                     .map(|midnight| midnight.and_utc().timestamp())

--- a/src/kafka/decam.rs
+++ b/src/kafka/decam.rs
@@ -1,11 +1,12 @@
 use crate::{
-    kafka::base::{AlertConsumer, AlertProducer},
+    kafka::base::{subscription_window, AlertConsumer, AlertProducer},
     utils::{data::count_files_in_dir, enums::Survey},
 };
 use tracing::info;
 
 const DECAM_DEFAULT_NB_PARTITIONS: usize = 15;
 
+#[derive(Clone)]
 pub struct DecamAlertConsumer {
     output_queue: String,
 }
@@ -26,12 +27,15 @@ impl AlertConsumer for DecamAlertConsumer {
         let date = chrono::DateTime::from_timestamp(timestamp, 0).unwrap();
         vec![format!("decam_{}_programid{}", date.format("%Y%m%d"), 1)]
     }
-    fn topic_patterns(&self) -> Vec<String> {
-        // Regex matching any date and program id — librdkafka auto-joins new
-        // daily topics. (DECAM only produces programid1 today, but this keeps
-        // the consumer from being pinned to it.) librdkafka's matcher is
-        // POSIX/Thompson-NFA: use `[0-9]+`, not `\d`.
-        vec![r"^decam_[0-9]+_programid[0-9]+$".to_string()]
+    fn subscription_topics(&self, timestamp: i64) -> Vec<String> {
+        // Concrete names over the rollover window rather than a
+        // `^decam_[0-9]+_programid[0-9]+$` regex: a pattern also matches every
+        // past night the cluster still advertises, whose partitions have
+        // already been expired upstream.
+        subscription_window(timestamp)
+            .iter()
+            .map(|date| format!("decam_{}_programid{}", date.format("%Y%m%d"), 1))
+            .collect()
     }
     fn output_queue(&self) -> String {
         self.output_queue.clone()

--- a/src/kafka/decam.rs
+++ b/src/kafka/decam.rs
@@ -27,12 +27,12 @@ impl AlertConsumer for DecamAlertConsumer {
         let date = chrono::DateTime::from_timestamp(timestamp, 0).unwrap();
         vec![format!("decam_{}_programid{}", date.format("%Y%m%d"), 1)]
     }
-    fn subscription_topics(&self, timestamp: i64) -> Vec<String> {
+    fn subscription_topics(&self, timestamp: i64, window_days: u64) -> Vec<String> {
         // Concrete names over the rollover window rather than a
         // `^decam_[0-9]+_programid[0-9]+$` regex: a pattern also matches every
         // past night the cluster still advertises, whose partitions have
         // already been expired upstream.
-        subscription_window(timestamp)
+        subscription_window(timestamp, window_days)
             .iter()
             .map(|date| format!("decam_{}_programid{}", date.format("%Y%m%d"), 1))
             .collect()

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -30,7 +30,7 @@ impl AlertConsumer for LsstAlertConsumer {
             vec!["lsst-alerts-v11".to_string()]
         }
     }
-    fn subscription_topics(&self, _timestamp: i64) -> Vec<String> {
+    fn subscription_topics(&self, _timestamp: i64, _window_days: u64) -> Vec<String> {
         // LSST uses a single static topic (not date-partitioned), so there is
         // nothing to roll over: subscribe to the literal topic name.
         self.topic_names(0)

--- a/src/kafka/lsst.rs
+++ b/src/kafka/lsst.rs
@@ -1,6 +1,7 @@
 use crate::{kafka::base::AlertConsumer, utils::enums::Survey};
 use tracing::instrument;
 
+#[derive(Clone)]
 pub struct LsstAlertConsumer {
     output_queue: String,
     simulated: bool,
@@ -29,7 +30,7 @@ impl AlertConsumer for LsstAlertConsumer {
             vec!["lsst-alerts-v11".to_string()]
         }
     }
-    fn topic_patterns(&self) -> Vec<String> {
+    fn subscription_topics(&self, _timestamp: i64) -> Vec<String> {
         // LSST uses a single static topic (not date-partitioned), so there is
         // nothing to roll over: subscribe to the literal topic name.
         self.topic_names(0)

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -5,7 +5,8 @@ mod winter;
 mod ztf;
 
 pub use base::{
-    consumer, count_messages, delete_topic, initialize_topic, AlertConsumer, AlertProducer,
+    consumer, count_messages, delete_topic, initialize_topic, subscription_window, AlertConsumer,
+    AlertProducer, SUBSCRIPTION_WINDOW_DAYS,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -5,8 +5,8 @@ mod winter;
 mod ztf;
 
 pub use base::{
-    consumer, count_messages, delete_topic, initialize_topic, subscription_window,
-    tracks_current_date, AlertConsumer, AlertProducer,
+    consumer, count_messages, delete_topic, initialize_topic, subscription_window, AlertConsumer,
+    AlertProducer, StartDate,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -6,7 +6,7 @@ mod ztf;
 
 pub use base::{
     consumer, count_messages, delete_topic, initialize_topic, subscription_window,
-    tracks_current_date, AlertConsumer, AlertProducer, SUBSCRIPTION_WINDOW_DAYS,
+    tracks_current_date, AlertConsumer, AlertProducer,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -5,8 +5,8 @@ mod winter;
 mod ztf;
 
 pub use base::{
-    consumer, count_messages, delete_topic, initialize_topic, subscription_window, AlertConsumer,
-    AlertProducer, SUBSCRIPTION_WINDOW_DAYS,
+    consumer, count_messages, delete_topic, initialize_topic, subscription_window,
+    tracks_current_date, AlertConsumer, AlertProducer, SUBSCRIPTION_WINDOW_DAYS,
 };
 pub use decam::{DecamAlertConsumer, DecamAlertProducer};
 pub use lsst::LsstAlertConsumer;

--- a/src/kafka/winter.rs
+++ b/src/kafka/winter.rs
@@ -1,11 +1,12 @@
 use crate::{
-    kafka::base::{AlertConsumer, AlertProducer},
+    kafka::base::{subscription_window, AlertConsumer, AlertProducer},
     utils::{data::count_files_in_dir, enums::Survey},
 };
 use tracing::info;
 
 const WINTER_DEFAULT_NB_PARTITIONS: usize = 15;
 
+#[derive(Clone)]
 pub struct WinterAlertConsumer {
     output_queue: String,
 }
@@ -27,10 +28,14 @@ impl AlertConsumer for WinterAlertConsumer {
         let date = chrono::DateTime::from_timestamp(timestamp, 0).unwrap();
         vec![format!("winter_{}", date.format("%Y%m%d"))]
     }
-    fn topic_patterns(&self) -> Vec<String> {
-        // Regex matching any date — librdkafka auto-joins new daily topics.
-        // librdkafka's matcher is POSIX/Thompson-NFA: use `[0-9]+`, not `\d`.
-        vec![r"^winter_[0-9]+$".to_string()]
+    fn subscription_topics(&self, timestamp: i64) -> Vec<String> {
+        // Concrete names over the rollover window rather than a `^winter_[0-9]+$`
+        // regex: a pattern also matches every past night the cluster still
+        // advertises, whose partitions have already been expired upstream.
+        subscription_window(timestamp)
+            .iter()
+            .map(|date| format!("winter_{}", date.format("%Y%m%d")))
+            .collect()
     }
     fn output_queue(&self) -> String {
         self.output_queue.clone()

--- a/src/kafka/winter.rs
+++ b/src/kafka/winter.rs
@@ -28,11 +28,11 @@ impl AlertConsumer for WinterAlertConsumer {
         let date = chrono::DateTime::from_timestamp(timestamp, 0).unwrap();
         vec![format!("winter_{}", date.format("%Y%m%d"))]
     }
-    fn subscription_topics(&self, timestamp: i64) -> Vec<String> {
+    fn subscription_topics(&self, timestamp: i64, window_days: u64) -> Vec<String> {
         // Concrete names over the rollover window rather than a `^winter_[0-9]+$`
         // regex: a pattern also matches every past night the cluster still
         // advertises, whose partitions have already been expired upstream.
-        subscription_window(timestamp)
+        subscription_window(timestamp, window_days)
             .iter()
             .map(|date| format!("winter_{}", date.format("%Y%m%d")))
             .collect()

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -44,13 +44,13 @@ impl AlertConsumer for ZtfAlertConsumer {
             .map(|program_id| format!("ztf_{}_programid{}", date.format("%Y%m%d"), program_id))
             .collect()
     }
-    fn subscription_topics(&self, timestamp: i64) -> Vec<String> {
+    fn subscription_topics(&self, timestamp: i64, window_days: u64) -> Vec<String> {
         // One concrete topic per (date, program id) over the rollover window.
         // Not a `^ztf_[0-9]+_programid(…)$` regex: librdkafka expands a pattern
         // against every topic the cluster advertises, and IPAC keeps advertising
         // topic names for nights whose partitions it has long since expired, so
         // the pattern grows an assignment of dead partitions without bound.
-        subscription_window(timestamp)
+        subscription_window(timestamp, window_days)
             .iter()
             .flat_map(|date| {
                 self.program_ids.iter().map(move |program_id| {

--- a/src/kafka/ztf.rs
+++ b/src/kafka/ztf.rs
@@ -1,5 +1,5 @@
 use crate::{
-    kafka::base::{AlertConsumer, AlertProducer},
+    kafka::base::{subscription_window, AlertConsumer, AlertProducer},
     utils::{
         data::{count_files_in_dir, download_to_file},
         enums::{ProgramId, Survey},
@@ -10,6 +10,7 @@ use tracing::{info, instrument};
 
 const ZTF_DEFAULT_NB_PARTITIONS: usize = 15;
 
+#[derive(Clone)]
 pub struct ZtfAlertConsumer {
     output_queue: String,
     program_ids: Vec<ProgramId>,
@@ -18,7 +19,11 @@ pub struct ZtfAlertConsumer {
 impl ZtfAlertConsumer {
     #[instrument]
     pub fn new(output_queue: Option<&str>, program_ids: Option<Vec<ProgramId>>) -> Self {
-        let program_ids = program_ids.unwrap_or_else(|| vec![ProgramId::Public]);
+        // An empty selection would yield no topics at all, so it falls back to
+        // the public program the same way an unset one does.
+        let program_ids = program_ids
+            .filter(|ids| !ids.is_empty())
+            .unwrap_or_else(|| vec![ProgramId::Public]);
         let output_queue = output_queue
             .unwrap_or("ZTF_alerts_packets_queue")
             .to_string();
@@ -39,23 +44,20 @@ impl AlertConsumer for ZtfAlertConsumer {
             .map(|program_id| format!("ztf_{}_programid{}", date.format("%Y%m%d"), program_id))
             .collect()
     }
-    fn topic_patterns(&self) -> Vec<String> {
-        // Regex matching any date for the selected program id(s), e.g.
-        // ^ztf_[0-9]+_programid(1|2)$ — librdkafka auto-joins new daily topics.
-        // NB: librdkafka's matcher is POSIX/Thompson-NFA, so only basic
-        // constructs are used (no `\d`, no `{n}` bounded repetition).
-        let ids = if self.program_ids.is_empty() {
-            // Empty selection would otherwise yield `programid()`, matching
-            // nothing; fall back to any program id.
-            "[0-9]+".to_string()
-        } else {
-            self.program_ids
-                .iter()
-                .map(|program_id| program_id.to_string())
-                .collect::<Vec<_>>()
-                .join("|")
-        };
-        vec![format!(r"^ztf_[0-9]+_programid({})$", ids)]
+    fn subscription_topics(&self, timestamp: i64) -> Vec<String> {
+        // One concrete topic per (date, program id) over the rollover window.
+        // Not a `^ztf_[0-9]+_programid(…)$` regex: librdkafka expands a pattern
+        // against every topic the cluster advertises, and IPAC keeps advertising
+        // topic names for nights whose partitions it has long since expired, so
+        // the pattern grows an assignment of dead partitions without bound.
+        subscription_window(timestamp)
+            .iter()
+            .flat_map(|date| {
+                self.program_ids.iter().map(move |program_id| {
+                    format!("ztf_{}_programid{}", date.format("%Y%m%d"), program_id)
+                })
+            })
+            .collect()
     }
     fn output_queue(&self) -> String {
         self.output_queue.clone()

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -1,6 +1,6 @@
 use boom::{
     kafka::{
-        count_messages, delete_topic, AlertConsumer, AlertProducer, ZtfAlertConsumer,
+        count_messages, delete_topic, AlertConsumer, AlertProducer, StartDate, ZtfAlertConsumer,
         ZtfAlertProducer,
     },
     utils::{data::count_files_in_dir, enums::ProgramId, testing::TEST_CONFIG_FILE},
@@ -107,7 +107,7 @@ async fn test_produce_and_consume_from_archive() {
     ztf_alert_consumer
         .consume(
             Some(vec![topic]),
-            timestamp,
+            StartDate::Pinned(timestamp),
             None,
             Some(1),
             None,
@@ -443,6 +443,7 @@ async fn test_consumer_rolls_over_and_skips_old() {
                     &oq,
                     0,
                     cold_start_ts,
+                    true,
                     &config,
                     &kafka_cfg,
                     false,
@@ -634,20 +635,34 @@ fn test_lsst_subscription_topic_is_static() {
     assert_eq!(at_epoch, much_later);
 }
 
-// Rollover must not hijack a consumer that was pinned to an explicit past date.
+// Rollover intent is stated by the caller, not inferred from the timestamp.
 // The throughput benchmark runs `kafka_consumer ztf 20250311`, and chasing the
 // wall clock would unsubscribe it from the only topic it was started to read.
 #[test]
-fn test_pinned_past_date_does_not_follow_the_clock() {
-    use boom::kafka::tracks_current_date;
+fn test_start_date_signals_rollover_intent() {
+    use boom::kafka::StartDate;
 
-    let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 9).unwrap();
-    let pinned = chrono::NaiveDate::from_ymd_opt(2025, 3, 11).unwrap();
+    assert!(StartDate::Current.follows_clock());
+    assert!(!StartDate::Pinned(1_741_651_200).follows_clock());
 
-    assert!(!tracks_current_date(pinned, today));
+    // Pinned to *today* is still pinned -- the case an inferred check, comparing
+    // the start date against the current date, would get wrong.
+    let today_midnight = chrono::Utc::now()
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+    assert!(!StartDate::Pinned(today_midnight).follows_clock());
+
+    // Pinned reports exactly what it was given; Current resolves to a UTC midnight.
+    assert_eq!(StartDate::Pinned(1_741_651_200).timestamp(), 1_741_651_200);
+    let current = StartDate::Current.timestamp();
+    assert_eq!(current % 86_400, 0, "should resolve to a UTC midnight");
+    let now = chrono::Utc::now().timestamp();
     assert!(
-        tracks_current_date(today, today),
-        "a consumer started on the live date must keep rolling over"
+        (0..86_400).contains(&(now - current)),
+        "should resolve to the current UTC day"
     );
 }
 

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -417,6 +417,7 @@ async fn test_consumer_rolls_over_and_skips_old() {
         schema_github_fallback_url: None,
         username: None,
         password: None,
+        subscription_window_days: 1,
     };
     // Run the consumer on its own OS thread + runtime so its blocking rdkafka
     // `poll` doesn't starve the test driver's runtime (this mirrors prod, where
@@ -438,7 +439,7 @@ async fn test_consumer_rolls_over_and_skips_old() {
             rt.spawn(async move {
                 let _ = consumer(
                     "0",
-                    std::sync::Arc::new(move |_| window.clone()),
+                    std::sync::Arc::new(move |_, _| window.clone()),
                     &oq,
                     0,
                     cold_start_ts,
@@ -501,14 +502,14 @@ async fn test_consumer_rolls_over_and_skips_old() {
 // the poll loop; these assert the replacement stays small and concrete.
 #[test]
 fn test_subscription_window_is_today_and_yesterday() {
-    use boom::kafka::{subscription_window, SUBSCRIPTION_WINDOW_DAYS};
+    use boom::kafka::subscription_window;
 
     // 2026-08-09 00:00:00 UTC
     let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 9).unwrap();
     let ts = today.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
 
-    let window = subscription_window(ts);
-    assert_eq!(window.len() as u64, SUBSCRIPTION_WINDOW_DAYS + 1);
+    let window = subscription_window(ts, 1);
+    assert_eq!(window.len(), 2);
     assert_eq!(
         window,
         vec![chrono::NaiveDate::from_ymd_opt(2026, 8, 8).unwrap(), today,],
@@ -528,7 +529,7 @@ fn test_subscription_window_crosses_month_boundary() {
         .timestamp();
 
     assert_eq!(
-        subscription_window(ts),
+        subscription_window(ts, 1),
         vec![
             chrono::NaiveDate::from_ymd_opt(2026, 8, 31).unwrap(),
             chrono::NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
@@ -550,7 +551,7 @@ fn test_ztf_subscription_topics_are_concrete_and_bounded() {
         .timestamp();
 
     let consumer = ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public]));
-    let topics = consumer.subscription_topics(ts);
+    let topics = consumer.subscription_topics(ts, 1);
 
     assert_eq!(
         topics,
@@ -581,7 +582,7 @@ fn test_ztf_subscription_topics_cover_every_program_id() {
 
     let consumer =
         ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public, ProgramId::Partnership]));
-    let topics = consumer.subscription_topics(ts);
+    let topics = consumer.subscription_topics(ts, 1);
 
     assert_eq!(topics.len(), 4, "2 days x 2 program ids");
     for expected in [
@@ -608,7 +609,7 @@ fn test_ztf_empty_program_ids_falls_back_to_public() {
         .and_utc()
         .timestamp();
 
-    let topics = ZtfAlertConsumer::new(None, Some(vec![])).subscription_topics(ts);
+    let topics = ZtfAlertConsumer::new(None, Some(vec![])).subscription_topics(ts, 1);
     assert_eq!(
         topics,
         vec![
@@ -626,8 +627,8 @@ fn test_lsst_subscription_topic_is_static() {
     use boom::kafka::LsstAlertConsumer;
 
     let consumer = LsstAlertConsumer::new(None, false);
-    let at_epoch = consumer.subscription_topics(0);
-    let much_later = consumer.subscription_topics(1_800_000_000);
+    let at_epoch = consumer.subscription_topics(0, 1);
+    let much_later = consumer.subscription_topics(1_800_000_000, 9);
 
     assert_eq!(at_epoch.len(), 1);
     assert_eq!(at_epoch, much_later);
@@ -665,9 +666,44 @@ fn test_pinned_date_window_contains_that_date() {
         .timestamp();
 
     let topics =
-        ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public])).subscription_topics(pinned);
+        ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public])).subscription_topics(pinned, 1);
     assert!(
         topics.contains(&"ztf_20250311_programid1".to_string()),
         "the pinned date's own topic must be in the window, got {topics:?}"
     );
+}
+
+// After an upstream outage the window can be widened to catch up on the nights
+// that were missed, rather than skipping them (see issue #569). Recovery is
+// still bounded by upstream retention -- ZTF keeps roughly 7 days.
+#[test]
+fn test_widened_window_reaches_back_over_an_outage() {
+    use boom::kafka::AlertConsumer;
+    use boom::kafka::ZtfAlertConsumer;
+    use boom::utils::enums::ProgramId;
+
+    let ts = chrono::NaiveDate::from_ymd_opt(2026, 8, 10)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    let consumer = ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public]));
+
+    // Default: only the current night and the one before it.
+    let narrow = consumer.subscription_topics(ts, 1);
+    assert_eq!(narrow.len(), 2);
+    assert!(!narrow.contains(&"ztf_20260806_programid1".to_string()));
+
+    // Widened to cover a 5-day gap: every intervening night is subscribed.
+    let wide = consumer.subscription_topics(ts, 5);
+    assert_eq!(wide.len(), 6, "5 days back plus the current day");
+    for day in 5..=10 {
+        let expected = format!("ztf_202608{:02}_programid1", day);
+        assert!(wide.contains(&expected), "missing {expected}");
+    }
+    // Oldest first, so the backlog is consumed in chronological order.
+    assert_eq!(wide.first().unwrap(), "ztf_20260805_programid1");
+    assert_eq!(wide.last().unwrap(), "ztf_20260810_programid1");
 }

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -344,10 +344,13 @@ async fn wait_for_payloads(
 }
 
 // End-to-end test of the self-rollover consumer: the long-running consumer
-// subscribes to a topic *pattern* and must (a) skip an old retained topic's
-// messages on cold start, (b) consume the current day's messages, and (c)
-// auto-discover and consume the *next* day's topic created while it is running,
-// all without restarting. Requires a local Kafka broker + redis.
+// subscribes to the bounded window of concrete daily topic names and must
+// (a) skip an old retained topic's messages on cold start, (b) consume the
+// current day's messages, and (c) consume the *next* day's topic, which does
+// not yet exist at subscribe time and is created while the consumer is
+// running, all without restarting. (c) also covers the regression this window
+// replaced a pattern subscription to avoid: a subscribed-but-absent topic must
+// not stall the poll loop. Requires a local Kafka broker + redis.
 //
 // The consumer runs on its own dedicated OS thread + runtime (see below) so its
 // blocking rdkafka `poll` can't starve this test driver's runtime.
@@ -361,9 +364,8 @@ async fn test_consumer_rolls_over_and_skips_old() {
 
     let server = "localhost:9092";
     let now_ms = chrono::Utc::now().timestamp_millis();
-    // Unique, regex-safe prefix so the pattern matches only this test's topics.
+    // Unique prefix so this test's topics can't collide with another run's.
     let prefix = format!("rollovertest{now_ms}");
-    let pattern = format!("^{prefix}_[0-9]+$");
     let output_queue = format!("{prefix}_queue");
     let group_id = format!("{prefix}_group");
     let topic_day1 = format!("{prefix}_20260628");
@@ -424,7 +426,9 @@ async fn test_consumer_rolls_over_and_skips_old() {
     let consumer_thread = {
         let config = app_config.clone();
         let oq = output_queue.clone();
-        let pat = pattern.clone();
+        // The rollover window as the survey impls build it: both days are
+        // subscribed up front, and day 2 does not exist yet.
+        let window = vec![topic_day1.clone(), topic_day2.clone()];
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(2)
@@ -434,7 +438,7 @@ async fn test_consumer_rolls_over_and_skips_old() {
             rt.spawn(async move {
                 let _ = consumer(
                     "0",
-                    vec![pat],
+                    std::sync::Arc::new(move |_| window.clone()),
                     &oq,
                     0,
                     cold_start_ts,
@@ -489,4 +493,142 @@ async fn test_consumer_rolls_over_and_skips_old() {
     let _: () = con.del(&output_queue).await.unwrap_or(());
     let _ = delete_topic(server, &topic_day1).await;
     let _ = delete_topic(server, &topic_day2).await;
+}
+
+// The rollover window is what keeps a daily-topic subscription bounded. A
+// pattern subscription matched every night the cluster still advertised, so an
+// unbounded set of expired partitions accumulated in the assignment and starved
+// the poll loop; these assert the replacement stays small and concrete.
+#[test]
+fn test_subscription_window_is_today_and_yesterday() {
+    use boom::kafka::{subscription_window, SUBSCRIPTION_WINDOW_DAYS};
+
+    // 2026-08-09 00:00:00 UTC
+    let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 9).unwrap();
+    let ts = today.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+
+    let window = subscription_window(ts);
+    assert_eq!(window.len() as u64, SUBSCRIPTION_WINDOW_DAYS + 1);
+    assert_eq!(
+        window,
+        vec![chrono::NaiveDate::from_ymd_opt(2026, 8, 8).unwrap(), today,],
+        "window should be oldest-first and cover the night straddling UTC midnight"
+    );
+}
+
+#[test]
+fn test_subscription_window_crosses_month_boundary() {
+    use boom::kafka::subscription_window;
+
+    let ts = chrono::NaiveDate::from_ymd_opt(2026, 9, 1)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    assert_eq!(
+        subscription_window(ts),
+        vec![
+            chrono::NaiveDate::from_ymd_opt(2026, 8, 31).unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn test_ztf_subscription_topics_are_concrete_and_bounded() {
+    use boom::kafka::AlertConsumer;
+    use boom::kafka::ZtfAlertConsumer;
+    use boom::utils::enums::ProgramId;
+
+    let ts = chrono::NaiveDate::from_ymd_opt(2026, 8, 9)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    let consumer = ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public]));
+    let topics = consumer.subscription_topics(ts);
+
+    assert_eq!(
+        topics,
+        vec![
+            "ztf_20260808_programid1".to_string(),
+            "ztf_20260809_programid1".to_string(),
+        ]
+    );
+    assert!(
+        topics.iter().all(|t| !t.starts_with('^')),
+        "topics must be literal names; a `^…` entry is treated by librdkafka as \
+         a regex and would match every past night"
+    );
+}
+
+#[test]
+fn test_ztf_subscription_topics_cover_every_program_id() {
+    use boom::kafka::AlertConsumer;
+    use boom::kafka::ZtfAlertConsumer;
+    use boom::utils::enums::ProgramId;
+
+    let ts = chrono::NaiveDate::from_ymd_opt(2026, 8, 9)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    let consumer =
+        ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public, ProgramId::Partnership]));
+    let topics = consumer.subscription_topics(ts);
+
+    assert_eq!(topics.len(), 4, "2 days x 2 program ids");
+    for expected in [
+        "ztf_20260808_programid1",
+        "ztf_20260808_programid2",
+        "ztf_20260809_programid1",
+        "ztf_20260809_programid2",
+    ] {
+        assert!(topics.contains(&expected.to_string()), "missing {expected}");
+    }
+}
+
+// An empty selection would otherwise subscribe to nothing at all, silently
+// consuming no alerts.
+#[test]
+fn test_ztf_empty_program_ids_falls_back_to_public() {
+    use boom::kafka::AlertConsumer;
+    use boom::kafka::ZtfAlertConsumer;
+
+    let ts = chrono::NaiveDate::from_ymd_opt(2026, 8, 9)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    let topics = ZtfAlertConsumer::new(None, Some(vec![])).subscription_topics(ts);
+    assert_eq!(
+        topics,
+        vec![
+            "ztf_20260808_programid1".to_string(),
+            "ztf_20260809_programid1".to_string(),
+        ]
+    );
+}
+
+// LSST is not date-partitioned: its single static topic must be returned
+// unchanged whatever the date, and must never be windowed.
+#[test]
+fn test_lsst_subscription_topic_is_static() {
+    use boom::kafka::AlertConsumer;
+    use boom::kafka::LsstAlertConsumer;
+
+    let consumer = LsstAlertConsumer::new(None, false);
+    let at_epoch = consumer.subscription_topics(0);
+    let much_later = consumer.subscription_topics(1_800_000_000);
+
+    assert_eq!(at_epoch.len(), 1);
+    assert_eq!(at_epoch, much_later);
 }

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -632,3 +632,42 @@ fn test_lsst_subscription_topic_is_static() {
     assert_eq!(at_epoch.len(), 1);
     assert_eq!(at_epoch, much_later);
 }
+
+// Rollover must not hijack a consumer that was pinned to an explicit past date.
+// The throughput benchmark runs `kafka_consumer ztf 20250311`, and chasing the
+// wall clock would unsubscribe it from the only topic it was started to read.
+#[test]
+fn test_pinned_past_date_does_not_follow_the_clock() {
+    use boom::kafka::tracks_current_date;
+
+    let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 9).unwrap();
+    let pinned = chrono::NaiveDate::from_ymd_opt(2025, 3, 11).unwrap();
+
+    assert!(!tracks_current_date(pinned, today));
+    assert!(
+        tracks_current_date(today, today),
+        "a consumer started on the live date must keep rolling over"
+    );
+}
+
+// A pinned replay still has to subscribe to the topic it was asked for.
+#[test]
+fn test_pinned_date_window_contains_that_date() {
+    use boom::kafka::AlertConsumer;
+    use boom::kafka::ZtfAlertConsumer;
+    use boom::utils::enums::ProgramId;
+
+    let pinned = chrono::NaiveDate::from_ymd_opt(2025, 3, 11)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp();
+
+    let topics =
+        ZtfAlertConsumer::new(None, Some(vec![ProgramId::Public])).subscription_topics(pinned);
+    assert!(
+        topics.contains(&"ztf_20250311_programid1".to_string()),
+        "the pinned date's own topic must be in the window, got {topics:?}"
+    );
+}


### PR DESCRIPTION
This PR subscribes kafka consumers to a bounded daily-topic window. 

Issue: The topic pattern matched every past night, accumulating expired partitions until the per-error backoff starved the live topic and stalled ingestion.