### PR TITLE
Restart docker-metadata-exporter on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -172,15 +172,27 @@ jobs:
           docker compose --profile prod
           -f docker-compose.yaml
           -f docker-compose.cutouts-mongo.yaml up -d
-      # Grafana's provisioning lives in a bind mount (config/grafana/provisioning),
-      # so editing it doesn't change the service definition and `up -d` above leaves
-      # the running container alone. Dashboards survive that (the file provider
-      # re-reads them every 30s), but alerting provisioning is read ONCE at startup —
-      # without this, new/changed alert rules, contact points, and notification
-      # policies silently never take effect. Restarting is cheap: all Grafana state
-      # lives in the grafana_data volume.
+      # Services whose only "source code" is a bind-mounted file read once at
+      # startup. Editing that file doesn't change the service definition, so the
+      # `up -d` above leaves the container running the version it started with
+      # and the change silently never takes effect — recreate them explicitly.
+      #
+      # - grafana: dashboards survive (the file provider re-reads
+      #   config/grafana/dashboards every 30s), but alerting provisioning is read
+      #   ONCE at startup, so new/changed alert rules, contact points, and
+      #   notification policies would never load. All Grafana state lives in the
+      #   grafana_data volume, so recreating is cheap.
+      # - docker-metadata-exporter: runs scripts/docker_metadata_exporter.py off
+      #   a bind mount under a stock python image. #563 added docker_container_up
+      #   and docker_container_health_status to that script, but the container
+      #   kept serving the pre-#563 metrics, so the panels and the api-down alert
+      #   that query them had no series at all.
+      #
+      # Other services with bind-mounted configs (prometheus, loki, tempo,
+      # promtail, otel-collector) are in the same class: if you change their
+      # config, add them here or restart them by hand.
       - run: >
           docker compose --profile prod
           -f docker-compose.yaml
           -f docker-compose.cutouts-mongo.yaml
-          up -d --force-recreate --no-deps grafana
+          up -d --force-recreate --no-deps grafana docker-metadata-exporter

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -206,6 +206,18 @@ the container running, so edits here require an explicit
 `docker compose up -d --force-recreate --no-deps grafana`. The production deploy
 workflow does this on every run.
 
+The same trap applies to every service whose config or script is a bind mount:
+`up -d` compares the *service definition*, not the file contents, so a container
+keeps running the version it started with. `scripts/docker_metadata_exporter.py`
+was bitten by this — #563 added `docker_container_up` and
+`docker_container_health_status` to it, but the exporter container kept serving
+the pre-#563 metrics, which left the "Service up/down" and "Healthcheck state"
+panels empty and the `api-down` alert querying series that did not exist. The
+deploy workflow now force-recreates `docker-metadata-exporter` alongside
+`grafana`; if you change `config/prometheus.yaml`, the Loki/Tempo/Promtail
+configs, or `config/otel-collector-config.yaml`, add that service to the same
+step or restart it by hand.
+
 All alerts route to a single **Slack** contact point. Set
 `SLACK_WEBHOOK_URL` in your environment / `.env` to a Slack incoming-webhook
 URL; if unset, alerts still fire and are visible in Grafana but no Slack


### PR DESCRIPTION
This is another service whose image doesn't change much and it mounts a text file in the repo, so it requires a restart on deploy.