### PR TITLE
rollover check on new daily topic

### DIFF
--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -746,6 +746,59 @@ impl StartDate {
     }
 }
 
+/// The UTC-midnight timestamp the subscription should roll onto, or `None` if it
+/// should stay where it is. Split out from [`roll_subscription_if_needed`] so the
+/// decision is testable without a broker.
+fn rollover_target(
+    follow_current_date: bool,
+    subscribed_date: chrono::NaiveDate,
+    today: chrono::NaiveDate,
+) -> Option<i64> {
+    if !follow_current_date || today == subscribed_date {
+        return None;
+    }
+    today
+        .and_hms_opt(0, 0, 0)
+        .map(|midnight| midnight.and_utc().timestamp())
+}
+
+/// Re-subscribe if the UTC date has rolled onto a new daily topic. Returns the
+/// timestamp new partitions should be positioned to.
+///
+/// This must be called from BOTH the initial-assignment loop and the main poll
+/// loop. A consumer started between nights never receives a first message, so it
+/// never leaves the initial loop; a rollover check that only ran in the main loop
+/// would therefore never fire, leaving the consumer subscribed to yesterday's
+/// topics while the night's alerts went to a topic it had never joined. That is
+/// not hypothetical — it cost a full night of ZTF ingestion on 2026-08-14.
+fn roll_subscription_if_needed(
+    consumer: &BaseConsumer,
+    subscribe_to: &Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync>,
+    window_days: u64,
+    follow_current_date: bool,
+    subscribed_date: &mut chrono::NaiveDate,
+    position_timestamp: &mut i64,
+) {
+    let today = chrono::Utc::now().date_naive();
+    let Some(new_timestamp) = rollover_target(follow_current_date, *subscribed_date, today) else {
+        return;
+    };
+    let rolled = subscribe_to(new_timestamp, window_days);
+    let rolled_refs: Vec<&str> = rolled.iter().map(|s| s.as_str()).collect();
+    match consumer.subscribe(&rolled_refs) {
+        Ok(()) => {
+            info!(
+                "Rolled subscription from {} to {}, now subscribed to {:?}",
+                subscribed_date, today, rolled
+            );
+            *subscribed_date = today;
+            *position_timestamp = new_timestamp;
+        }
+        // Stay on the current subscription; the next check retries.
+        Err(error) => log_error!(error, "failed to roll subscription onto new day"),
+    }
+}
+
 /// Whether a poll error refers to a partition whose topic no longer exists
 /// upstream — typically an expired daily topic still present in the group's
 /// assignment. Unlike a transient broker error these never recover, so they
@@ -872,8 +925,49 @@ pub async fn consumer(
     // Partitions already positioned (prod path only); see reposition_new_partitions.
     let mut positioned: std::collections::HashSet<(String, i32)> = std::collections::HashSet::new();
 
+    // Rollover state. Declared here rather than alongside the main loop because
+    // the initial-assignment loop below must be able to roll over too.
+    const ROLLOVER_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+    let mut last_rollover_check = std::time::Instant::now();
+    // The date whose topics are currently subscribed, and the instant that
+    // newly-assigned partitions are positioned to. Both advance together on
+    // rollover, so a freshly-joined topic starts at its own day rather than at
+    // whichever day the process happened to boot on.
+    let mut subscribed_date = chrono::DateTime::from_timestamp(timestamp, 0)
+        .map(|dt| dt.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    let mut position_timestamp = timestamp;
+
+    // A consumer that has not yet seen its first message is indistinguishable
+    // from a wedged one at INFO level, which is how a lost night went unnoticed.
+    // Say so out loud while waiting.
+    const WAITING_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+    let mut last_waiting_log = std::time::Instant::now();
+
     // Poll once to trigger rebalance and get assignment
     loop {
+        // Between nights there is nothing to consume, so this loop can sit here
+        // across a UTC midnight. Roll the subscription while waiting, or the new
+        // day's topic is never joined.
+        if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
+            last_rollover_check = std::time::Instant::now();
+            roll_subscription_if_needed(
+                &consumer,
+                &subscribe_to,
+                window_days,
+                follow_current_date,
+                &mut subscribed_date,
+                &mut position_timestamp,
+            );
+            reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
+        }
+        if !exit_on_eof && last_waiting_log.elapsed() >= WAITING_LOG_INTERVAL {
+            last_waiting_log = std::time::Instant::now();
+            info!(
+                "Consumer {} waiting for first message; subscribed for {} (idle between nights is normal)",
+                id, subscribed_date
+            );
+        }
         match consumer.poll(KAFKA_TIMEOUT_SECS) {
             Some(Ok(_msg)) => {
                 debug!("Got initial assignment, positioning partitions...");
@@ -957,22 +1051,6 @@ pub async fn consumer(
     let mut last_heartbeat = std::time::Instant::now();
     let mut total_at_last_heartbeat: u64 = 0;
 
-    // How often the loop re-checks whether the UTC date has rolled onto a new
-    // daily topic. Cheap (a clock read, then a no-op unless the date changed),
-    // and deliberately driven by elapsed time rather than by message count: a
-    // count-gated check cannot fire while no messages are arriving, which is
-    // precisely the state rollover has to recover from.
-    const ROLLOVER_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
-    let mut last_rollover_check = std::time::Instant::now();
-    // The date whose topics are currently subscribed, and the instant that
-    // newly-assigned partitions are positioned to. Both advance together on
-    // rollover, so a freshly-joined topic starts at its own day rather than at
-    // whichever day the process happened to boot on.
-    let mut subscribed_date = chrono::DateTime::from_timestamp(timestamp, 0)
-        .map(|dt| dt.date_naive())
-        .unwrap_or_else(|| chrono::Utc::now().date_naive());
-    let mut position_timestamp = timestamp;
-
     // Expired-partition poll errors repeat indefinitely, so they get a short
     // backoff (enough to keep the loop off a hot spin) and a throttled log.
     const EXPIRED_POLL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
@@ -1003,26 +1081,14 @@ pub async fn consumer(
         // newly-assigned partitions (the new day's topic, or a rebalance).
         if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
             last_rollover_check = std::time::Instant::now();
-            let today = chrono::Utc::now().date_naive();
-            if follow_current_date && today != subscribed_date {
-                position_timestamp = today
-                    .and_hms_opt(0, 0, 0)
-                    .map(|midnight| midnight.and_utc().timestamp())
-                    .unwrap_or(position_timestamp);
-                let rolled = subscribe_to(position_timestamp, window_days);
-                let rolled_refs: Vec<&str> = rolled.iter().map(|s| s.as_str()).collect();
-                match consumer.subscribe(&rolled_refs) {
-                    Ok(()) => {
-                        info!(
-                            "Rolled subscription from {} to {}, now subscribed to {:?}",
-                            subscribed_date, today, rolled
-                        );
-                        subscribed_date = today;
-                    }
-                    // Stay on the current subscription; the next check retries.
-                    Err(error) => log_error!(error, "failed to roll subscription onto new day"),
-                }
-            }
+            roll_subscription_if_needed(
+                &consumer,
+                &subscribe_to,
+                window_days,
+                follow_current_date,
+                &mut subscribed_date,
+                &mut position_timestamp,
+            );
             reposition_new_partitions(&consumer, position_timestamp * 1000, &mut positioned)?;
         }
         if max_in_queue > 0 && total % 1000 == 0 {
@@ -1111,4 +1177,57 @@ pub async fn consumer(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod rollover_tests {
+    use super::*;
+
+    fn d(y: i32, m: u32, day: u32) -> chrono::NaiveDate {
+        chrono::NaiveDate::from_ymd_opt(y, m, day).unwrap()
+    }
+
+    #[test]
+    fn test_rolls_onto_a_new_utc_day() {
+        let target = rollover_target(true, d(2026, 8, 13), d(2026, 8, 14))
+            .expect("a new day must produce a rollover target");
+        assert_eq!(target % 86_400, 0, "targets UTC midnight");
+        assert_eq!(
+            chrono::DateTime::from_timestamp(target, 0)
+                .unwrap()
+                .date_naive(),
+            d(2026, 8, 14)
+        );
+    }
+
+    #[test]
+    fn test_no_roll_within_the_same_day() {
+        assert!(rollover_target(true, d(2026, 8, 14), d(2026, 8, 14)).is_none());
+    }
+
+    // A pinned run (replay, backfill, benchmark) must never chase the clock.
+    #[test]
+    fn test_pinned_run_never_rolls() {
+        assert!(rollover_target(false, d(2025, 3, 11), d(2026, 8, 14)).is_none());
+    }
+
+    // Regression, 2026-08-14: a consumer deployed between nights never receives a
+    // first message, so it never left the initial-assignment loop. The rollover
+    // check lived only in the main loop and so never ran, leaving the consumer on
+    // the previous day's topics while that night's 24,112 alerts were published to
+    // a topic it had never joined. The decision itself was always correct -- it was
+    // simply never reached -- so this asserts the multi-day case the outage
+    // produced, and `roll_subscription_if_needed` is now called from both loops.
+    #[test]
+    fn test_rolls_across_a_multi_day_gap() {
+        let target = rollover_target(true, d(2026, 8, 12), d(2026, 8, 14))
+            .expect("a stale subscription must roll forward however far behind it is");
+        assert_eq!(
+            chrono::DateTime::from_timestamp(target, 0)
+                .unwrap()
+                .date_naive(),
+            d(2026, 8, 14),
+            "rolls to today, not merely one day forward"
+        );
+    }
 }

--- a/src/kafka/base.rs
+++ b/src/kafka/base.rs
@@ -746,8 +746,7 @@ impl StartDate {
     }
 }
 
-/// The UTC-midnight timestamp the subscription should roll onto, or `None` if it
-/// should stay where it is. Split out from [`roll_subscription_if_needed`] so the
+/// UTC-midnight timestamp to roll onto, or `None` to stay put. Split out so the
 /// decision is testable without a broker.
 fn rollover_target(
     follow_current_date: bool,
@@ -762,15 +761,10 @@ fn rollover_target(
         .map(|midnight| midnight.and_utc().timestamp())
 }
 
-/// Re-subscribe if the UTC date has rolled onto a new daily topic. Returns the
-/// timestamp new partitions should be positioned to.
+/// Re-subscribe if the UTC date has rolled onto a new daily topic.
 ///
-/// This must be called from BOTH the initial-assignment loop and the main poll
-/// loop. A consumer started between nights never receives a first message, so it
-/// never leaves the initial loop; a rollover check that only ran in the main loop
-/// would therefore never fire, leaving the consumer subscribed to yesterday's
-/// topics while the night's alerts went to a topic it had never joined. That is
-/// not hypothetical — it cost a full night of ZTF ingestion on 2026-08-14.
+/// Must be called from both poll loops: a consumer started between nights never
+/// receives a first message, so it never leaves the initial-assignment loop.
 fn roll_subscription_if_needed(
     consumer: &BaseConsumer,
     subscribe_to: &Arc<dyn Fn(i64, u64) -> Vec<String> + Send + Sync>,
@@ -925,30 +919,22 @@ pub async fn consumer(
     // Partitions already positioned (prod path only); see reposition_new_partitions.
     let mut positioned: std::collections::HashSet<(String, i32)> = std::collections::HashSet::new();
 
-    // Rollover state. Declared here rather than alongside the main loop because
-    // the initial-assignment loop below must be able to roll over too.
+    // Declared here because the initial-assignment loop must roll over too.
     const ROLLOVER_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
     let mut last_rollover_check = std::time::Instant::now();
-    // The date whose topics are currently subscribed, and the instant that
-    // newly-assigned partitions are positioned to. Both advance together on
-    // rollover, so a freshly-joined topic starts at its own day rather than at
-    // whichever day the process happened to boot on.
+    // Advance together on rollover, so a new topic starts at its own day.
     let mut subscribed_date = chrono::DateTime::from_timestamp(timestamp, 0)
         .map(|dt| dt.date_naive())
         .unwrap_or_else(|| chrono::Utc::now().date_naive());
     let mut position_timestamp = timestamp;
 
-    // A consumer that has not yet seen its first message is indistinguishable
-    // from a wedged one at INFO level, which is how a lost night went unnoticed.
-    // Say so out loud while waiting.
+    // Idle and wedged look identical at INFO otherwise.
     const WAITING_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
     let mut last_waiting_log = std::time::Instant::now();
 
     // Poll once to trigger rebalance and get assignment
     loop {
-        // Between nights there is nothing to consume, so this loop can sit here
-        // across a UTC midnight. Roll the subscription while waiting, or the new
-        // day's topic is never joined.
+        // This loop can sit across a UTC midnight; roll while waiting.
         if !exit_on_eof && last_rollover_check.elapsed() >= ROLLOVER_CHECK_INTERVAL {
             last_rollover_check = std::time::Instant::now();
             roll_subscription_if_needed(
@@ -1211,13 +1197,7 @@ mod rollover_tests {
         assert!(rollover_target(false, d(2025, 3, 11), d(2026, 8, 14)).is_none());
     }
 
-    // Regression, 2026-08-14: a consumer deployed between nights never receives a
-    // first message, so it never left the initial-assignment loop. The rollover
-    // check lived only in the main loop and so never ran, leaving the consumer on
-    // the previous day's topics while that night's 24,112 alerts were published to
-    // a topic it had never joined. The decision itself was always correct -- it was
-    // simply never reached -- so this asserts the multi-day case the outage
-    // produced, and `roll_subscription_if_needed` is now called from both loops.
+    // A stale subscription rolls all the way to today, not one day forward.
     #[test]
     fn test_rolls_across_a_multi_day_gap() {
         let target = rollover_target(true, d(2026, 8, 12), d(2026, 8, 14))

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -722,3 +722,115 @@ fn test_widened_window_reaches_back_over_an_outage() {
     assert_eq!(wide.first().unwrap(), "ztf_20260805_programid1");
     assert_eq!(wide.last().unwrap(), "ztf_20260810_programid1");
 }
+
+// Regression, 2026-08-14. The existing rollover test produces to the topic BEFORE
+// starting the consumer, so the consumer receives a first message immediately and
+// leaves the initial-assignment loop. Production does not work that way: a deploy
+// between nights starts a consumer with nothing to read, and that loop only exits
+// on a first message. The consumer sat there for 14 hours while the night's alerts
+// went to a topic it never joined, and the test suite showed nothing because no
+// test had ever started a consumer against an empty subscription.
+//
+// This starts a consumer with no data at all, then produces, and asserts the
+// messages still arrive. Requires a local Kafka broker + redis.
+#[tokio::test]
+async fn test_consumer_started_with_no_data_still_consumes() {
+    use boom::conf::{AppConfig, KafkaConsumerConfig};
+    use boom::kafka::{consumer, delete_topic, initialize_topic};
+    use rdkafka::config::ClientConfig;
+    use rdkafka::producer::{FutureProducer, FutureRecord};
+    use std::time::Duration;
+
+    let server = "localhost:9092";
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let prefix = format!("coldstarttest{now_ms}");
+    let output_queue = format!("{prefix}_queue");
+    let group_id = format!("{prefix}_group");
+    let topic = format!("{prefix}_20260814");
+
+    let app_config = AppConfig::from_path(TEST_CONFIG_FILE).unwrap();
+    let mut con = app_config.build_redis().await.unwrap();
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+
+    // Topic exists but is completely empty — the between-nights state.
+    initialize_topic(server, &topic, 1).await.unwrap();
+
+    let cold_start_ts = now_ms / 1000 - 3600;
+    let kafka_cfg = KafkaConsumerConfig {
+        server: server.to_string(),
+        group_id,
+        schema_registry: None,
+        schema_github_fallback_url: None,
+        username: None,
+        password: None,
+        subscription_window_days: 1,
+    };
+
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    let consumer_thread = {
+        let config = app_config.clone();
+        let oq = output_queue.clone();
+        let subscription = vec![topic.clone()];
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.spawn(async move {
+                let _ = consumer(
+                    "0",
+                    std::sync::Arc::new(move |_, _| subscription.clone()),
+                    &oq,
+                    0,
+                    cold_start_ts,
+                    true,
+                    &config,
+                    &kafka_cfg,
+                    false,
+                    "WINTER",
+                )
+                .await;
+            });
+            let _ = stop_rx.recv();
+            rt.shutdown_timeout(std::time::Duration::from_secs(1));
+        })
+    };
+
+    // Let it settle into the initial-assignment loop with nothing to read. Under
+    // the old code this is where it stayed forever.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    assert!(
+        con.llen::<&str, usize>(&output_queue).await.unwrap_or(0) == 0,
+        "nothing should have been consumed yet"
+    );
+
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", server)
+        .create()
+        .unwrap();
+    let payloads: Vec<String> = (0..5).map(|i| format!("late-{i}")).collect();
+    for p in &payloads {
+        producer
+            .send(
+                FutureRecord::to(topic.as_str())
+                    .payload(p.as_str())
+                    .key("k")
+                    .timestamp(chrono::Utc::now().timestamp_millis()),
+                Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+    }
+
+    let seen = wait_for_payloads(&mut con, &output_queue, &payloads, Duration::from_secs(60)).await;
+    assert!(
+        payloads.iter().all(|p| seen.contains(p)),
+        "a consumer that started with no data must still consume once data arrives; saw {seen:?}"
+    );
+
+    let _ = stop_tx.send(());
+    let _ = consumer_thread.join();
+    let _: () = con.del(&output_queue).await.unwrap_or(());
+    let _ = delete_topic(server, &topic).await;
+}

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -723,16 +723,9 @@ fn test_widened_window_reaches_back_over_an_outage() {
     assert_eq!(wide.last().unwrap(), "ztf_20260810_programid1");
 }
 
-// Regression, 2026-08-14. The existing rollover test produces to the topic BEFORE
-// starting the consumer, so the consumer receives a first message immediately and
-// leaves the initial-assignment loop. Production does not work that way: a deploy
-// between nights starts a consumer with nothing to read, and that loop only exits
-// on a first message. The consumer sat there for 14 hours while the night's alerts
-// went to a topic it never joined, and the test suite showed nothing because no
-// test had ever started a consumer against an empty subscription.
-//
-// This starts a consumer with no data at all, then produces, and asserts the
-// messages still arrive. Requires a local Kafka broker + redis.
+// The other rollover test produces before starting the consumer, so it never
+// exercises an empty subscription. This starts one with no data, then produces.
+// Requires a local Kafka broker + redis.
 #[tokio::test]
 async fn test_consumer_started_with_no_data_still_consumes() {
     use boom::conf::{AppConfig, KafkaConsumerConfig};
@@ -797,8 +790,7 @@ async fn test_consumer_started_with_no_data_still_consumes() {
         })
     };
 
-    // Let it settle into the initial-assignment loop with nothing to read. Under
-    // the old code this is where it stayed forever.
+    // Settle into the initial-assignment loop with nothing to read.
     tokio::time::sleep(Duration::from_secs(10)).await;
     assert!(
         con.llen::<&str, usize>(&output_queue).await.unwrap_or(0) == 0,


### PR DESCRIPTION
This PR re-subscribes if the UTC date has rolled onto a new daily topic.