### PR TITLE
Expose LSST SSO ephemeris and cross-survey aperture excess

### DIFF
--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -221,8 +221,14 @@ pub struct LsstSsoAssociation {
     /// proportion to how fast the object moves.
     pub sky_motion: Option<f32>,
     /// Sun-object-observer angle (`ssSource.phaseAngle`), which sets how much of the
-    /// brightness is geometry rather than activity.
+    /// brightness is geometry rather than activity. Degrees.
     pub phase_angle: Option<f32>,
+    /// Sun-to-object distance (`ssSource.helioRange`), au.
+    pub helio_dist: Option<f32>,
+    /// Observer-to-object distance (`ssSource.topoRange`), au. With `helio_dist`
+    /// and `phase_angle` this is the geometry needed to reduce an apparent
+    /// magnitude to an absolute one.
+    pub topo_dist: Option<f32>,
     /// Who made the association.
     pub source: Option<String>,
 }
@@ -243,6 +249,8 @@ impl LsstSsoAssociation {
             predicted_mag: ss_source.and_then(|s| s.eph_vmag),
             sky_motion: ss_source.and_then(|s| s.eph_rate),
             phase_angle: ss_source.and_then(|s| s.phase_angle),
+            helio_dist: ss_source.and_then(|s| s.helio_range),
+            topo_dist: ss_source.and_then(|s| s.topo_range),
             source: Some("rubin".to_string()),
         }
     }
@@ -568,6 +576,8 @@ mod sso_tests {
         ss.eph_offset = Some(0.3);
         ss.eph_rate = Some(42.0);
         ss.phase_angle = Some(12.5);
+        ss.helio_range = Some(3.0114);
+        ss.topo_range = Some(2.2049);
 
         let sso = LsstSsoAssociation::from_rubin(Some("123"), Some(&ss));
         assert!(sso.is_sso);
@@ -576,6 +586,8 @@ mod sso_tests {
         assert_eq!(sso.separation_arcsec, Some(0.3));
         assert_eq!(sso.sky_motion, Some(42.0));
         assert_eq!(sso.phase_angle, Some(12.5));
+        assert_eq!(sso.helio_dist, Some(3.0114));
+        assert_eq!(sso.topo_dist, Some(2.2049));
         assert_eq!(sso.source.as_deref(), Some("rubin"));
     }
 

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -7,7 +7,7 @@ use crate::enrichment::{
 use crate::utils::db::mongify;
 use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, Band, PerBandProperties, PhotometryMag,
+    analyze_photometry, prepare_photometry, ActivityMetrics, Band, PerBandProperties, PhotometryMag,
 };
 use apache_avro_derive::AvroSchema;
 use apache_avro_macros::serdavro;
@@ -194,15 +194,73 @@ pub struct LsstAlertForEnrichment {
     pub survey_matches: Option<LsstSurveyMatches>,
 }
 
+/// Solar system association for a single LSST detection, mirroring the ZTF block so
+/// a filter reads identically on both surveys.
+///
+/// Rubin supplies the ephemeris directly in `ssSource`, so unlike ZTF nothing here
+/// is derived: the predicted magnitude, the observed-minus-predicted separation and
+/// the predicted sky motion all come from `mpc_orbits` upstream.
+#[derive(
+    Debug, Clone, Default, serde::Deserialize, serde::Serialize, AvroSchema, utoipa::ToSchema,
+)]
+#[serde(default)]
+pub struct LsstSsoAssociation {
+    /// Whether Rubin associated this detection with a solar system object.
+    pub is_sso: bool,
+    /// MPC designation, when Rubin has made an MPC association.
+    pub designation: Option<String>,
+    /// Observed versus predicted angular separation (`ssSource.ephOffset`). The LSST
+    /// analogue of ZTF's `ssdistnr`, and worth monitoring in aggregate: a drifting
+    /// distribution means the upstream orbits are going stale.
+    pub separation_arcsec: Option<f32>,
+    /// Predicted V-band magnitude from the orbit's H/G (`ssSource.ephVmag`).
+    /// Against the measured magnitude this gives an activity indicator directly.
+    pub predicted_mag: Option<f32>,
+    /// Predicted total on-sky rate of motion (`ssSource.ephRate`). Needed to tell
+    /// genuine extension from trailing, which inflates every morphology metric in
+    /// proportion to how fast the object moves.
+    pub sky_motion: Option<f32>,
+    /// Sun-object-observer angle (`ssSource.phaseAngle`), which sets how much of the
+    /// brightness is geometry rather than activity.
+    pub phase_angle: Option<f32>,
+    /// Who made the association.
+    pub source: Option<String>,
+}
+
+impl LsstSsoAssociation {
+    /// Build from Rubin's own association. `ss_object_id` decides `is_sso` so this
+    /// agrees with `rock`; `ss_source` may be absent even when it is set.
+    pub fn from_rubin(ss_object_id: Option<&str>, ss_source: Option<&SsSource>) -> Self {
+        let is_sso = ss_object_id.is_some();
+        LsstSsoAssociation {
+            is_sso,
+            designation: ss_source.and_then(|s| s.designation.clone()),
+            separation_arcsec: ss_source.and_then(|s| s.eph_offset),
+            predicted_mag: ss_source.and_then(|s| s.eph_vmag),
+            sky_motion: ss_source.and_then(|s| s.eph_rate),
+            phase_angle: ss_source.and_then(|s| s.phase_angle),
+            source: is_sso.then(|| "rubin".to_string()),
+        }
+    }
+}
+
 /// LSST alert properties computed during enrichment and inserted back into the alert document
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, AvroSchema, utoipa::ToSchema)]
 pub struct LsstAlertProperties {
+    /// Deprecated alias for `sso.is_sso`, kept so existing filters keep working.
     pub rock: bool,
     pub stationary: bool,
     pub star: Option<bool>,
     pub near_brightstar: Option<bool>,
     pub photstats: PerBandProperties,
     pub multisurvey_photstats: PerBandProperties,
+    /// `None` on alerts enriched before this existed: never evaluated, which is not
+    /// the same as evaluated and found not to be a solar system object.
+    #[serde(default)]
+    pub sso: Option<LsstSsoAssociation>,
+    /// `None` on alerts enriched before this existed.
+    #[serde(default)]
+    pub activity: Option<ActivityMetrics>,
 }
 
 pub struct LsstEnrichmentWorker {
@@ -376,6 +434,12 @@ impl LsstEnrichmentWorker {
     ) -> Result<LsstAlertProperties, EnrichmentWorkerError> {
         // Compute numerical and boolean features from lightcurve and candidate analysis
         let is_rock = alert.ss_object_id.is_some();
+        let sso =
+            LsstSsoAssociation::from_rubin(alert.ss_object_id.as_deref(), alert.ss_source.as_ref());
+        let activity = ActivityMetrics::from_fluxes(
+            alert.candidate.dia_source.psf_flux,
+            alert.candidate.dia_source.ap_flux,
+        );
 
         // Determine if this is a star based on LSPSC cross-matches
         let mut is_star = Some(false);
@@ -477,11 +541,51 @@ impl LsstEnrichmentWorker {
 
         Ok(LsstAlertProperties {
             rock: is_rock,
+            sso: Some(sso),
+            activity: Some(activity),
             star: is_star,
             near_brightstar: is_near_brightstar,
             stationary,
             photstats,
             multisurvey_photstats,
         })
+    }
+}
+
+#[cfg(test)]
+mod sso_tests {
+    use super::*;
+
+    #[test]
+    fn test_rubin_ephemeris_is_surfaced() {
+        let mut ss = SsSource::default();
+        ss.designation = Some("2026 XX1".to_string());
+        ss.eph_vmag = Some(19.4);
+        ss.eph_offset = Some(0.3);
+        ss.eph_rate = Some(42.0);
+        ss.phase_angle = Some(12.5);
+
+        let sso = LsstSsoAssociation::from_rubin(Some("123"), Some(&ss));
+        assert!(sso.is_sso);
+        assert_eq!(sso.designation.as_deref(), Some("2026 XX1"));
+        assert_eq!(sso.predicted_mag, Some(19.4));
+        assert_eq!(sso.separation_arcsec, Some(0.3));
+        assert_eq!(sso.sky_motion, Some(42.0));
+        assert_eq!(sso.phase_angle, Some(12.5));
+        assert_eq!(sso.source.as_deref(), Some("rubin"));
+    }
+
+    // Rubin can link a detection to an ssObject without supplying ssSource, so
+    // is_sso must follow ssObjectId and agree with `rock`.
+    #[test]
+    fn test_is_sso_follows_ss_object_id_not_the_ephemeris() {
+        let sso = LsstSsoAssociation::from_rubin(Some("123"), None);
+        assert!(sso.is_sso, "must agree with rock");
+        assert!(sso.predicted_mag.is_none());
+        assert!(sso.designation.is_none());
+
+        let not_sso = LsstSsoAssociation::from_rubin(None, None);
+        assert!(!not_sso.is_sso);
+        assert!(not_sso.source.is_none());
     }
 }

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -231,15 +231,19 @@ impl LsstSsoAssociation {
     /// Build from Rubin's own association. `ss_object_id` decides `is_sso` so this
     /// agrees with `rock`; `ss_source` may be absent even when it is set.
     pub fn from_rubin(ss_object_id: Option<&str>, ss_source: Option<&SsSource>) -> Self {
-        let is_sso = ss_object_id.is_some();
+        // Gated on ss_object_id so is_sso agrees with `rock`, and so a stray
+        // ss_source can never populate an ephemeris under is_sso: false.
+        let Some(_) = ss_object_id else {
+            return LsstSsoAssociation::default();
+        };
         LsstSsoAssociation {
-            is_sso,
+            is_sso: true,
             designation: ss_source.and_then(|s| s.designation.clone()),
             separation_arcsec: ss_source.and_then(|s| s.eph_offset),
             predicted_mag: ss_source.and_then(|s| s.eph_vmag),
             sky_motion: ss_source.and_then(|s| s.eph_rate),
             phase_angle: ss_source.and_then(|s| s.phase_angle),
-            source: is_sso.then(|| "rubin".to_string()),
+            source: Some("rubin".to_string()),
         }
     }
 }
@@ -587,5 +591,21 @@ mod sso_tests {
         let not_sso = LsstSsoAssociation::from_rubin(None, None);
         assert!(!not_sso.is_sso);
         assert!(not_sso.source.is_none());
+    }
+
+    // An ephemeris without an ssObjectId would otherwise yield is_sso: false with a
+    // designation and predicted magnitude attached, which filters would disagree
+    // about depending on which field they cut on.
+    #[test]
+    fn test_ephemeris_without_ss_object_id_is_not_surfaced() {
+        let mut ss = SsSource::default();
+        ss.designation = Some("2026 XX1".to_string());
+        ss.eph_vmag = Some(19.4);
+
+        let sso = LsstSsoAssociation::from_rubin(None, Some(&ss));
+        assert!(!sso.is_sso);
+        assert!(sso.designation.is_none());
+        assert!(sso.predicted_mag.is_none());
+        assert!(sso.source.is_none());
     }
 }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -10,8 +10,8 @@ use crate::utils::cutouts::{AlertCutout, CutoutStorage};
 use crate::utils::db::mongify;
 use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, AllBandsProperties, Band, PerBandProperties,
-    PhotometryMag, ZTF_ZP,
+    analyze_photometry, prepare_photometry, ActivityMetrics, AllBandsProperties, Band,
+    PerBandProperties, PhotometryMag, ZTF_ZP,
 };
 use apache_avro_derive::AvroSchema;
 use apache_avro_macros::serdavro;
@@ -428,6 +428,9 @@ pub struct ZtfAlertProperties {
     /// Consumers must not read `None` as "not an asteroid".
     #[serde(default)]
     pub sso: Option<ZtfSsoAssociation>,
+    /// `None` on alerts enriched before this existed.
+    #[serde(default)]
+    pub activity: Option<ActivityMetrics>,
 }
 
 /// ZTF alert ML classifier scores
@@ -677,6 +680,7 @@ impl ZtfEnrichmentWorker {
         let ssmagnr = candidate.ssmagnr.unwrap_or(f32::INFINITY);
         let is_rock = ssdistnr >= 0.0 && ssdistnr < 12.0 && ssmagnr >= 0.0;
 
+        let activity = ActivityMetrics::from_magnitudes(Some(candidate.magpsf), candidate.magap);
         let sso = ZtfSsoAssociation::from_ipac(
             candidate.ssnamenr.clone(),
             candidate.ssdistnr,
@@ -784,6 +788,7 @@ impl ZtfEnrichmentWorker {
                 photstats,
                 multisurvey_photstats: Some(multisurvey_photstats),
                 sso: Some(sso),
+                activity: Some(activity),
             },
             all_bands_properties,
             programid,

--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -149,10 +149,16 @@ impl ActivityMetrics {
         Self::from_excess(aperture_excess)
     }
 
-    /// LSST: fluxes rather than magnitudes. Non-positive fluxes are not convertible.
+    /// LSST: signed fluxes rather than magnitudes.
+    ///
+    /// Same sign rather than positive: a negative source has a well defined
+    /// aperture excess. Mixed signs are rejected -- relating a positive residual to
+    /// a negative one is not one.
     pub fn from_fluxes(psf_flux: Option<f32>, ap_flux: Option<f32>) -> Self {
         let aperture_excess = match (psf_flux, ap_flux) {
-            (Some(psf), Some(ap)) if psf > 0.0 && ap > 0.0 => Some(2.5 * (ap / psf).log10()),
+            (Some(psf), Some(ap)) if psf != 0.0 && ap != 0.0 && psf.signum() == ap.signum() => {
+                Some(2.5 * (ap / psf).log10())
+            }
             _ => None,
         };
         Self::from_excess(aperture_excess)
@@ -1068,14 +1074,55 @@ mod activity_tests {
     // Difference imaging routinely yields non-positive fluxes; a log of those is
     // not a measurement.
     #[test]
-    fn test_non_positive_fluxes_yield_no_measurement() {
+    fn test_zero_or_missing_fluxes_yield_no_measurement() {
         for (psf, ap) in [
             (Some(0.0), Some(10.0)),
-            (Some(10.0), Some(-5.0)),
+            (Some(10.0), Some(0.0)),
             (None, Some(10.0)),
         ] {
             let a = ActivityMetrics::from_fluxes(psf, ap);
             assert!(a.aperture_excess.is_none());
+        }
+    }
+
+    // A negative source measures the same way as a positive one.
+    #[test]
+    fn test_same_sign_negative_fluxes_measure_the_same_excess() {
+        let positive = ActivityMetrics::from_fluxes(Some(100.0), Some(150.0));
+        let negative = ActivityMetrics::from_fluxes(Some(-100.0), Some(-150.0));
+        assert_eq!(positive.aperture_excess, negative.aperture_excess);
+        assert!(positive.aperture_excess.expect("measured") > 0.0);
+    }
+
+    // The magnitudes are built from |flux|, so they agree with the flux path on
+    // same-sign input -- and would silently disagree on mixed-sign input.
+    #[test]
+    fn test_flux_and_magnitude_paths_agree_on_same_sign_input() {
+        for (psf, ap) in [(100.0f32, 150.0f32), (-100.0, -150.0)] {
+            let (magpsf, _) = flux2mag(psf.abs(), 1.0, LSST_ZP_AB_NJY);
+            let (magap, _) = flux2mag(ap.abs(), 1.0, LSST_ZP_AB_NJY);
+            let from_flux = ActivityMetrics::from_fluxes(Some(psf), Some(ap))
+                .aperture_excess
+                .expect("measured");
+            let from_mag = ActivityMetrics::from_magnitudes(Some(magpsf), Some(magap))
+                .aperture_excess
+                .expect("measured");
+            assert!(
+                (from_flux - from_mag).abs() < 1e-4,
+                "{from_flux} vs {from_mag}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mixed_sign_fluxes_yield_no_measurement() {
+        for (psf, ap) in [(100.0, -150.0), (-100.0, 150.0)] {
+            assert!(
+                ActivityMetrics::from_fluxes(Some(psf), Some(ap))
+                    .aperture_excess
+                    .is_none(),
+                "from_fluxes({psf}, {ap})"
+            );
         }
     }
 

--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -111,6 +111,58 @@ pub struct BandProperties {
     pub fading: Option<BandRateProperties>,
 }
 
+/// Morphological indicators of cometary activity, computed per survey but expressed
+/// on one scale so a filter reads identically on ZTF and LSST.
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    AvroSchema,
+    utoipa::ToSchema,
+)]
+#[serde(default)]
+pub struct ActivityMetrics {
+    /// Flux in the aperture beyond what a point source would put there, in
+    /// magnitudes. Positive means extended. Cross-survey comparable because both
+    /// sides reduce to a magnitude difference.
+    ///
+    /// Confounded by trailing: a fast mover smears during the exposure and looks
+    /// extended. Use alongside `sso.sky_motion` rather than alone.
+    ///
+    /// Computed here only because the degenerate cases are batch-fatal in an
+    /// aggregation: `$divide` by a zero flux and `$log10` of a negative one both
+    /// abort the whole pipeline, and difference imaging produces such fluxes
+    /// routinely. No threshold is applied — filters choose their own cut.
+    pub aperture_excess: Option<f32>,
+}
+
+impl ActivityMetrics {
+    /// ZTF: aperture and PSF magnitudes directly. Brighter aperture => positive.
+    pub fn from_magnitudes(magpsf: Option<f32>, magap: Option<f32>) -> Self {
+        let aperture_excess = match (magpsf, magap) {
+            (Some(psf), Some(ap)) if psf.is_finite() && ap.is_finite() => Some(psf - ap),
+            _ => None,
+        };
+        Self::from_excess(aperture_excess)
+    }
+
+    /// LSST: fluxes rather than magnitudes. Non-positive fluxes are not convertible.
+    pub fn from_fluxes(psf_flux: Option<f32>, ap_flux: Option<f32>) -> Self {
+        let aperture_excess = match (psf_flux, ap_flux) {
+            (Some(psf), Some(ap)) if psf > 0.0 && ap > 0.0 => Some(2.5 * (ap / psf).log10()),
+            _ => None,
+        };
+        Self::from_excess(aperture_excess)
+    }
+
+    fn from_excess(aperture_excess: Option<f32>) -> Self {
+        ActivityMetrics { aperture_excess }
+    }
+}
+
 // TODO: avro serialization fail when we use skip_serializing_none,
 // since the optional fields are not just None but simply missing
 // (this needs to be fixed in the apache_avro-related crates)
@@ -978,5 +1030,48 @@ mod tests {
         let rising_dt = rising_stats.dt;
         assert_eq!(rising_nb_data, 2);
         assert!((rising_dt - 1.0).abs() < 1e-6);
+    }
+}
+
+#[cfg(test)]
+mod activity_tests {
+    use super::*;
+
+    #[test]
+    fn test_ztf_aperture_excess_positive_when_aperture_brighter() {
+        // Brighter aperture => smaller magnitude => positive excess.
+        let a = ActivityMetrics::from_magnitudes(Some(18.0), Some(17.5));
+        assert_eq!(a.aperture_excess, Some(0.5));
+
+        let point = ActivityMetrics::from_magnitudes(Some(18.0), Some(18.0));
+        assert_eq!(point.aperture_excess, Some(0.0));
+    }
+
+    #[test]
+    fn test_lsst_flux_ratio_matches_the_magnitude_scale() {
+        // A 1.585x aperture/psf flux ratio is 0.5 mag, so both surveys agree.
+        let a = ActivityMetrics::from_fluxes(Some(100.0), Some(158.489));
+        let excess = a.aperture_excess.unwrap();
+        assert!((excess - 0.5).abs() < 1e-3, "got {excess}");
+    }
+
+    // Difference imaging routinely yields non-positive fluxes; a log of those is
+    // not a measurement.
+    #[test]
+    fn test_non_positive_fluxes_yield_no_measurement() {
+        for (psf, ap) in [
+            (Some(0.0), Some(10.0)),
+            (Some(10.0), Some(-5.0)),
+            (None, Some(10.0)),
+        ] {
+            let a = ActivityMetrics::from_fluxes(psf, ap);
+            assert!(a.aperture_excess.is_none());
+        }
+    }
+
+    #[test]
+    fn test_missing_magnitudes_yield_no_measurement() {
+        let a = ActivityMetrics::from_magnitudes(Some(18.0), None);
+        assert!(a.aperture_excess.is_none());
     }
 }

--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -158,8 +158,18 @@ impl ActivityMetrics {
         Self::from_excess(aperture_excess)
     }
 
+    /// Single point where the value is admitted, so the finiteness check cannot
+    /// be forgotten by a future constructor.
+    ///
+    /// Guarding the inputs is not sufficient on the flux path: a ratio of two
+    /// perfectly finite fluxes overflows f32 once they differ by more than ~1e38,
+    /// which difference imaging reaches with a near-zero PSF flux. A non-finite
+    /// value stored here would serialize as a BSON double the filters then
+    /// compare against, so it is dropped rather than passed on.
     fn from_excess(aperture_excess: Option<f32>) -> Self {
-        ActivityMetrics { aperture_excess }
+        ActivityMetrics {
+            aperture_excess: aperture_excess.filter(|e| e.is_finite()),
+        }
     }
 }
 
@@ -1066,6 +1076,37 @@ mod activity_tests {
         ] {
             let a = ActivityMetrics::from_fluxes(psf, ap);
             assert!(a.aperture_excess.is_none());
+        }
+    }
+
+    // Both fluxes can be finite and positive and still produce a non-finite
+    // ratio, so the inputs alone are not enough to guard on.
+    #[test]
+    fn test_finite_fluxes_with_an_overflowing_ratio_yield_no_measurement() {
+        let a = ActivityMetrics::from_fluxes(Some(f32::MIN_POSITIVE), Some(f32::MAX));
+        assert!(a.aperture_excess.is_none(), "got {:?}", a.aperture_excess);
+    }
+
+    #[test]
+    fn test_non_finite_inputs_yield_no_measurement() {
+        for (psf, ap) in [
+            (Some(f32::INFINITY), Some(10.0)),
+            (Some(10.0), Some(f32::INFINITY)),
+            (Some(f32::INFINITY), Some(f32::INFINITY)),
+            (Some(f32::NAN), Some(10.0)),
+        ] {
+            assert!(
+                ActivityMetrics::from_fluxes(psf, ap)
+                    .aperture_excess
+                    .is_none(),
+                "from_fluxes({psf:?}, {ap:?})"
+            );
+            assert!(
+                ActivityMetrics::from_magnitudes(psf, ap)
+                    .aperture_excess
+                    .is_none(),
+                "from_magnitudes({psf:?}, {ap:?})"
+            );
         }
     }
 

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -189,6 +189,7 @@ fn create_mock_enriched_ztf_alert(candid: i64, object_id: &str, is_rock: bool) -
                 predicted_mag: is_rock.then_some(18.1),
                 source: is_rock.then(|| "ipac".to_string()),
             }),
+            activity: None,
         },
         survey_matches: BabamulSurveyMatches::default(),
     }


### PR DESCRIPTION
This PR exposes LSST SSO ephemeris and cross-survey aperture excess.