### PR TITLE
Parallelize reprocess_crossmatch and make interrupted runs resumable

### DIFF
--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -34,7 +34,7 @@ const ARCSEC_TO_RAD: f64 = std::f64::consts::PI / 180.0 / 3600.0;
 const STATE_COLLECTION: &str = "reprocess_crossmatch_state";
 const STATUS_MATCHING: &str = "matching";
 const STATUS_CLEAN: &str = "clean";
-const TEMP_PROBE_SAMPLE: i64 = 200;
+const TEMP_PROBE_SAMPLE: i64 = 10_000;
 
 /// Catalog-driven costs extra full passes over alerts_aux, so it only wins when the
 /// catalog is substantially smaller, not merely smaller.
@@ -272,6 +272,12 @@ async fn range_shards(
     };
 
     if bounds.len() < parts {
+        warn!(
+            "only {} sampled bounds on '{}' for {} shards, running as a single shard",
+            bounds.len(),
+            field,
+            parts
+        );
         return vec![Document::new()];
     }
     let step = bounds.len() / parts;
@@ -295,7 +301,7 @@ async fn sharded_update_many(
 ) -> Result<u64, mongodb::error::Error> {
     let done = Arc::new(AtomicUsize::new(0));
     let total = shards.len();
-    let results = futures::future::join_all(shards.iter().map(|shard| {
+    let results = futures::future::join_all(shards.iter().enumerate().map(|(index, shard)| {
         let filter = if shard.is_empty() {
             base_filter.clone()
         } else if base_filter.is_empty() {
@@ -308,12 +314,25 @@ async fn sharded_update_many(
         let done = Arc::clone(&done);
         async move {
             let result = collection.update_many(filter, update).await;
-            info!(
-                "[{}] shard {}/{} done",
-                label,
-                done.fetch_add(1, Ordering::Relaxed) + 1,
-                total
-            );
+            let completed = done.fetch_add(1, Ordering::Relaxed) + 1;
+            match &result {
+                Ok(outcome) => info!(
+                    "[{}] shard {}/{} done, {} modified ({} shards complete)",
+                    label,
+                    index + 1,
+                    total,
+                    outcome.modified_count,
+                    completed
+                ),
+                Err(e) => warn!(
+                    error = %e,
+                    "[{}] shard {}/{} failed ({} shards complete)",
+                    label,
+                    index + 1,
+                    total,
+                    completed
+                ),
+            }
             result
         }
     }))

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use boom::{
     api::catalogs::WATCHLIST_PREFIX,
@@ -15,17 +17,28 @@ use boom::{
 };
 use clap::{Parser, ValueEnum};
 use flare::{spatial::great_circle_distance, Time};
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
 use mongodb::{
-    bson::{doc, Document},
-    options::{UpdateOneModel, WriteModel},
+    bson::{doc, Bson, Document},
+    options::{UpdateModifications, UpdateOneModel, WriteModel},
     Namespace,
 };
 use tracing::{error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
 const QUEUE_MULTIPLIER: usize = 2;
+const CURSOR_BATCH_SIZE: u32 = 10_000;
+const PROGRESS_LOG_SECS: u64 = 60;
+const ARCSEC_TO_RAD: f64 = std::f64::consts::PI / 180.0 / 3600.0;
+const STATE_COLLECTION: &str = "reprocess_crossmatch_state";
+const STATUS_MATCHING: &str = "matching";
+const STATUS_CLEAN: &str = "clean";
+const TEMP_PROBE_SAMPLE: i64 = 200;
+
+/// Catalog-driven costs extra full passes over alerts_aux, so it only wins when the
+/// catalog is substantially smaller, not merely smaller.
+const CATALOG_DRIVEN_MARGIN: u64 = 4;
 
 /// Binary for reprocessing crossmatches between a survey's alerts_aux collection and one or more catalogs.
 /// The scheduler pipeline only crossmatches at first insert, so adding a catalog to
@@ -54,12 +67,34 @@ struct Cli {
     #[arg(long, value_name = "FILE", default_value = "config.yaml")]
     config: String,
 
+    /// Number of records accumulated per worker before a bulk write is issued.
     #[arg(long, default_value_t = 5000, value_parser = parse_positive_usize)]
     batch_size: usize,
 
-    /// Number of parallel worker tasks. Each worker holds its own DB connection.
+    /// Number of parallel worker tasks, and of shards the cleanup passes are split into.
     #[arg(long, default_value_t = 1, value_parser = parse_positive_usize)]
     processes: usize,
+
+    /// Queries kept in flight per worker. Workers are database-bound, so
+    /// `processes` × `concurrency` is what sets throughput, not the core count.
+    /// Keep that product under `database.max_pool_size`.
+    #[arg(long, default_value_t = 8, value_parser = parse_positive_usize)]
+    concurrency: usize,
+
+    /// Objects-driven only: skip alerts_aux records that already carry every
+    /// selected catalog. Makes an interrupted run resumable.
+    #[arg(long, default_value_t = false)]
+    skip_existing: bool,
+
+    /// Catalog-driven only: leave records with no match untouched instead of writing an
+    /// empty array. Safe when filling in a new catalog, but it will not clear stale matches.
+    #[arg(long, default_value_t = false)]
+    skip_empty: bool,
+
+    /// Catalog-driven only: force the scan that clears the temp buffer, which is
+    /// otherwise skipped when no interrupted run is detected.
+    #[arg(long, default_value_t = false)]
+    reset_temp: bool,
 }
 
 /// Reprocessing can be done in two directions:
@@ -87,6 +122,210 @@ struct AuxIdAndCoords {
     coordinates: Coordinates,
 }
 
+fn aux_match_projection() -> Document {
+    doc! { "_id": 1, "coordinates.radec_geojson.coordinates": 1 }
+}
+
+/// The indicatif bar hides itself when stderr is not a terminal, i.e. whenever the run
+/// is piped to a log file, so mirror it into the tracing output.
+fn spawn_progress_logger(pb: ProgressBar, label: String) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(PROGRESS_LOG_SECS));
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let pos = pb.position();
+            let len = pb.length().unwrap_or(0);
+            let elapsed = pb.elapsed().as_secs_f64();
+            let rate = if elapsed > 0.0 {
+                pos as f64 / elapsed
+            } else {
+                0.0
+            };
+            let eta_secs = if rate > 0.0 && len > pos {
+                ((len - pos) as f64 / rate) as u64
+            } else {
+                0
+            };
+            let pct = if len > 0 {
+                pos as f64 * 100.0 / len as f64
+            } else {
+                0.0
+            };
+            info!(
+                "[{}] {}/{} ({:.2}%) {:.0} docs/s, eta {}h{:02}m",
+                label,
+                pos,
+                len,
+                pct,
+                rate,
+                eta_secs / 3600,
+                (eta_secs % 3600) / 60,
+            );
+        }
+    })
+}
+
+async fn set_reprocess_state(
+    db: &mongodb::Database,
+    state_id: &str,
+    status: &str,
+) -> Result<(), mongodb::error::Error> {
+    db.collection::<Document>(STATE_COLLECTION)
+        .update_one(
+            doc! { "_id": state_id },
+            doc! { "$set": { "status": status, "updated_at": Time::now().to_jd() } },
+        )
+        .upsert(true)
+        .await?;
+    Ok(())
+}
+
+/// A run is bracketed by a state marker, so an interrupted one is known without touching
+/// alerts_aux. Versions before the marker wrote temp on *every* existing record, which is
+/// why a leftover from those is still caught by a small random sample.
+async fn temp_needs_reset(
+    db: &mongodb::Database,
+    aux_collection: &mongodb::Collection<Document>,
+    state_id: &str,
+    temp_field: &str,
+) -> Result<bool, mongodb::error::Error> {
+    let previous = db
+        .collection::<Document>(STATE_COLLECTION)
+        .find_one(doc! { "_id": state_id })
+        .await?;
+    if let Some(previous) = previous {
+        if previous.get_str("status").unwrap_or(STATUS_CLEAN) == STATUS_MATCHING {
+            warn!(
+                "previous run for '{}' was interrupted while matching",
+                state_id
+            );
+            return Ok(true);
+        }
+    }
+    let mut probe = aux_collection
+        .aggregate(vec![
+            doc! { "$sample": { "size": TEMP_PROBE_SAMPLE } },
+            doc! { "$match": { temp_field: { "$exists": true } } },
+            doc! { "$limit": 1 },
+        ])
+        .await?;
+    Ok(probe.try_next().await?.is_some())
+}
+
+// -----------------------------------------------------------------------------
+// Sharded full-collection updates: a single `update_many` runs as one server-side
+// operation, so splitting it into ranges is the only way to use more than one
+// thread for a pass over a billion documents. Ranges are cut on an indexed field
+// that tracks insertion order, so that each shard walks a roughly contiguous
+// region on disk rather than jumping around it.
+// -----------------------------------------------------------------------------
+
+/// `created_at` is exactly insertion order, but it is only indexed if someone created
+/// that index; `_id` always is, and both ZTF object ids and LSST diaObject ids happen
+/// to be allocated in an order that correlates well with insertion.
+async fn shard_field(collection: &mongodb::Collection<Document>) -> &'static str {
+    let indexed_on_created_at = match collection.list_indexes().await {
+        Ok(cursor) => match cursor.try_collect::<Vec<_>>().await {
+            Ok(indexes) => indexes
+                .iter()
+                .any(|index| index.keys.keys().next().is_some_and(|k| k == "created_at")),
+            Err(_) => false,
+        },
+        Err(_) => false,
+    };
+    if indexed_on_created_at {
+        "created_at"
+    } else {
+        "_id"
+    }
+}
+
+async fn range_shards(
+    collection: &mongodb::Collection<Document>,
+    parts: usize,
+    field: &str,
+) -> Vec<Document> {
+    if parts <= 1 {
+        return vec![Document::new()];
+    }
+    let sample_size = (parts * 20).min(10_000);
+    let bounds: Vec<Bson> = match collection
+        .aggregate(vec![
+            doc! { "$sample": { "size": sample_size as i64 } },
+            doc! { "$project": { field: 1 } },
+            doc! { "$sort": { field: 1 } },
+        ])
+        .await
+    {
+        Ok(cursor) => match cursor.try_collect::<Vec<Document>>().await {
+            Ok(docs) => docs.iter().filter_map(|d| d.get(field).cloned()).collect(),
+            Err(e) => {
+                warn!(error = %e, "could not sample {} bounds, falling back to a single shard", field);
+                Vec::new()
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "could not sample {} bounds, falling back to a single shard", field);
+            Vec::new()
+        }
+    };
+
+    if bounds.len() < parts {
+        return vec![Document::new()];
+    }
+    let step = bounds.len() / parts;
+    let cuts: Vec<Bson> = (1..parts).map(|i| bounds[i * step].clone()).collect();
+
+    let mut shards = Vec::with_capacity(cuts.len() + 1);
+    shards.push(doc! { field: { "$lt": cuts[0].clone() } });
+    for pair in cuts.windows(2) {
+        shards.push(doc! { field: { "$gte": pair[0].clone(), "$lt": pair[1].clone() } });
+    }
+    shards.push(doc! { field: { "$gte": cuts[cuts.len() - 1].clone() } });
+    shards
+}
+
+async fn sharded_update_many(
+    collection: &mongodb::Collection<Document>,
+    shards: &[Document],
+    base_filter: &Document,
+    update: UpdateModifications,
+    label: &str,
+) -> Result<u64, mongodb::error::Error> {
+    let done = Arc::new(AtomicUsize::new(0));
+    let total = shards.len();
+    let results = futures::future::join_all(shards.iter().map(|shard| {
+        let filter = if shard.is_empty() {
+            base_filter.clone()
+        } else if base_filter.is_empty() {
+            shard.clone()
+        } else {
+            doc! { "$and": [base_filter.clone(), shard.clone()] }
+        };
+        let collection = collection.clone();
+        let update = update.clone();
+        let done = Arc::clone(&done);
+        async move {
+            let result = collection.update_many(filter, update).await;
+            info!(
+                "[{}] shard {}/{} done",
+                label,
+                done.fetch_add(1, Ordering::Relaxed) + 1,
+                total
+            );
+            result
+        }
+    }))
+    .await;
+
+    let mut modified = 0;
+    for result in results {
+        modified += result?.modified_count;
+    }
+    Ok(modified)
+}
+
 // -----------------------------------------------------------------------------
 // objects-driven: stream alerts_aux records, fan out to N workers running xmatch().
 // One pass updates all selected catalogs at once via the existing 1×N xmatch.
@@ -97,6 +336,8 @@ async fn run_objects_driven(
     db: mongodb::Database,
     batch_size: usize,
     processes: usize,
+    concurrency: usize,
+    skip_existing: bool,
 ) -> Result<(), mongodb::error::Error> {
     let aux_collection: mongodb::Collection<AuxIdAndCoords> =
         db.collection(&format!("{}_alerts_aux", survey));
@@ -106,7 +347,9 @@ async fn run_objects_driven(
         .map(|c| c.catalog.as_str())
         .collect::<Vec<_>>()
         .join(",");
-    let pb = make_progress_bar(estimated, format!("objects→{}", label));
+    let label = format!("objects→{}", label);
+    let pb = make_progress_bar(estimated, label.clone());
+    let logger = spawn_progress_logger(pb.clone(), label);
 
     let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
     let (tx, rx) = async_channel::bounded::<AuxIdAndCoords>(queue_capacity);
@@ -119,14 +362,25 @@ async fn run_objects_driven(
         let db = db.clone();
         let catalogs = catalogs.clone();
         workers.push(tokio::spawn(async move {
-            objects_worker(survey, db, catalogs, rx, batch_size, pb).await
+            objects_worker(survey, db, catalogs, rx, batch_size, concurrency, pb).await
         }));
     }
     drop(rx);
 
+    let find_filter = if skip_existing {
+        let missing: Vec<Document> = catalogs
+            .iter()
+            .map(|c| doc! { format!("cross_matches.{}", c.catalog): { "$exists": false } })
+            .collect();
+        doc! { "$or": missing }
+    } else {
+        doc! {}
+    };
+
     let mut cursor = aux_collection
-        .find(doc! {})
+        .find(find_filter)
         .projection(doc! { "_id": 1, "coordinates": 1 })
+        .batch_size(CURSOR_BATCH_SIZE)
         .no_cursor_timeout(true)
         .await?;
     while let Some(d) = cursor.try_next().await? {
@@ -149,6 +403,7 @@ async fn run_objects_driven(
             }
         }
     }
+    logger.abort();
     pb.finish();
     if let Some(e) = first_err {
         return Err(e);
@@ -162,6 +417,7 @@ async fn objects_worker(
     catalogs: Vec<CatalogXmatchConfig>,
     rx: async_channel::Receiver<AuxIdAndCoords>,
     batch_size: usize,
+    concurrency: usize,
     pb: ProgressBar,
 ) -> Result<(), mongodb::error::Error> {
     let client = db.client().clone();
@@ -173,15 +429,36 @@ async fn objects_worker(
     while let Ok(item) = rx.recv().await {
         batch.push(item);
         if batch.len() >= batch_size {
-            flush_objects_batch(&db, &client, &aux_ns, &survey, &catalogs, &mut batch, &pb).await?;
+            flush_objects_batch(
+                &db,
+                &client,
+                &aux_ns,
+                &survey,
+                &catalogs,
+                &mut batch,
+                concurrency,
+                &pb,
+            )
+            .await?;
         }
     }
     if !batch.is_empty() {
-        flush_objects_batch(&db, &client, &aux_ns, &survey, &catalogs, &mut batch, &pb).await?;
+        flush_objects_batch(
+            &db,
+            &client,
+            &aux_ns,
+            &survey,
+            &catalogs,
+            &mut batch,
+            concurrency,
+            &pb,
+        )
+        .await?;
     }
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn flush_objects_batch(
     db: &mongodb::Database,
     client: &mongodb::Client,
@@ -189,35 +466,41 @@ async fn flush_objects_batch(
     survey: &Survey,
     catalogs: &[CatalogXmatchConfig],
     batch: &mut Vec<AuxIdAndCoords>,
+    concurrency: usize,
     pb: &ProgressBar,
 ) -> Result<(), mongodb::error::Error> {
-    let mut writes = Vec::with_capacity(batch.len());
-    for obj in batch.drain(..) {
-        let (ra, dec) = obj.coordinates.get_radec();
-        let xmatches = match xmatch(ra, dec, &obj.object_id, survey, catalogs, db).await {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(object_id = %obj.object_id, error = %e, "xmatch failed, skipping");
-                pb.inc(1);
-                continue;
+    let writes: Vec<WriteModel> = futures::stream::iter(batch.drain(..))
+        .map(|obj| async move {
+            let (ra, dec) = obj.coordinates.get_radec();
+            let result = xmatch(ra, dec, &obj.object_id, survey, catalogs, db).await;
+            pb.inc(1);
+            let mut xmatches = match result {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(object_id = %obj.object_id, error = %e, "xmatch failed, skipping");
+                    return None;
+                }
+            };
+            let mut set_doc = Document::new();
+            for cat in catalogs {
+                let matches = xmatches.remove(&cat.catalog).unwrap_or_default();
+                set_doc.insert(format!("cross_matches.{}", cat.catalog), matches);
             }
-        };
-        let mut set_doc = Document::new();
-        for cat in catalogs {
-            let matches = xmatches.get(&cat.catalog).cloned().unwrap_or_default();
-            set_doc.insert(format!("cross_matches.{}", cat.catalog), matches);
-        }
-        writes.push(WriteModel::UpdateOne(
-            UpdateOneModel::builder()
-                .namespace(aux_ns.clone())
-                .filter(doc! { "_id": obj.object_id })
-                .update(doc! { "$set": set_doc })
-                .build(),
-        ));
-        pb.inc(1);
-    }
+            Some(WriteModel::UpdateOne(
+                UpdateOneModel::builder()
+                    .namespace(aux_ns.clone())
+                    .filter(doc! { "_id": obj.object_id })
+                    .update(doc! { "$set": set_doc })
+                    .build(),
+            ))
+        })
+        .buffer_unordered(concurrency)
+        .filter_map(|w| async move { w })
+        .collect()
+        .await;
+
     if !writes.is_empty() {
-        client.bulk_write(writes).await?;
+        client.bulk_write(writes).ordered(false).await?;
     }
     Ok(())
 }
@@ -239,7 +522,9 @@ async fn run_watchlist_driven(
 ) -> Result<(), mongodb::error::Error> {
     let wl_collection: mongodb::Collection<Document> = db.collection(&watchlist_config.catalog);
     let estimated = wl_collection.estimated_document_count().await.unwrap_or(0);
-    let pb = make_progress_bar(estimated, format!("watchlist→{}", watchlist_config.catalog));
+    let label = format!("watchlist→{}", watchlist_config.catalog);
+    let pb = make_progress_bar(estimated, label.clone());
+    let logger = spawn_progress_logger(pb.clone(), label);
 
     let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
     let (tx, rx) = async_channel::bounded::<Document>(queue_capacity);
@@ -262,6 +547,7 @@ async fn run_watchlist_driven(
     let mut cursor = wl_collection
         .find(doc! {})
         .projection(doc! { "_id": 1, "coordinates": 1 })
+        .batch_size(CURSOR_BATCH_SIZE)
         .no_cursor_timeout(true)
         .await?;
     while let Some(d) = cursor.try_next().await? {
@@ -284,6 +570,7 @@ async fn run_watchlist_driven(
             }
         }
     }
+    logger.abort();
     pb.finish();
     if let Some(e) = first_err {
         return Err(e);
@@ -347,6 +634,7 @@ async fn process_watchlist_doc(
     let mut aux_cursor = aux_collection
         .find(aux_filter)
         .projection(doc! { "_id": 1 })
+        .batch_size(CURSOR_BATCH_SIZE)
         .await?;
 
     let mut object_ids: Vec<mongodb::bson::Bson> = Vec::new();
@@ -380,12 +668,16 @@ async fn process_watchlist_doc(
 // Without this guard, the final `$set live = $temp` would overwrite a new record's
 // field with a missing/partial temp and silently delete it.
 // -----------------------------------------------------------------------------
+#[allow(clippy::too_many_arguments)]
 async fn run_catalog_driven(
     survey: &Survey,
     catalog_config: CatalogXmatchConfig,
     db: mongodb::Database,
     batch_size: usize,
     processes: usize,
+    concurrency: usize,
+    skip_empty: bool,
+    reset_temp: bool,
 ) -> Result<(), mongodb::error::Error> {
     let aux_collection: mongodb::Collection<Document> =
         db.collection(&format!("{}_alerts_aux", survey));
@@ -393,25 +685,47 @@ async fn run_catalog_driven(
     let live_field = format!("cross_matches.{}", catalog_config.catalog);
     let temp_field = format!("cross_matches.{}_temp", catalog_config.catalog);
     let run_start_jd = Time::now().to_jd();
-    let existing_records = doc! { "created_at": { "$lt": run_start_jd } };
-
-    // Phase 1: clear temp field on every alerts_aux record that existed at run start
-    // so we start from a known empty state. Records inserted later are skipped.
+    let shard_field = shard_field(&aux_collection).await;
+    let shards = range_shards(&aux_collection, processes, shard_field).await;
     info!(
-        "[catalog→{}] phase 1/4: cleaning temp field",
-        catalog_config.catalog
+        "[catalog\u{2192}{}] cleanup passes sharded on '{}' into {} ranges",
+        catalog_config.catalog,
+        shard_field,
+        shards.len()
     );
-    let empty: Vec<Document> = Vec::new();
-    aux_collection
-        .update_many(
-            existing_records.clone(),
-            doc! { "$set": { &temp_field: empty } },
+
+    // Phase 1: drop temp left behind by an interrupted run. Nothing can be left behind
+    // after a run that reached phase 3, so the scan is skipped on the normal path.
+    let state_id = format!("{}_alerts_aux:{}", survey, catalog_config.catalog);
+    if reset_temp || temp_needs_reset(&db, &aux_collection, &state_id, &temp_field).await? {
+        info!(
+            "[catalog→{}] phase 1/3: clearing leftover temp field ({} shards)",
+            catalog_config.catalog,
+            shards.len()
+        );
+        let cleared = sharded_update_many(
+            &aux_collection,
+            &shards,
+            &doc! { &temp_field: { "$exists": true } },
+            UpdateModifications::Document(doc! { "$unset": { &temp_field: "" } }),
+            &format!("catalog→{} phase 1", catalog_config.catalog),
         )
         .await?;
+        info!(
+            "[catalog→{}] phase 1/3: cleared {} leftover temp fields",
+            catalog_config.catalog, cleared
+        );
+    } else {
+        info!(
+            "[catalog→{}] phase 1/3: no interrupted run to clean up, skipping the reset scan",
+            catalog_config.catalog
+        );
+    }
+    set_reprocess_state(&db, &state_id, STATUS_MATCHING).await?;
 
     // Phase 2: stream catalog rows through a worker pool, $push matches to temp.
     info!(
-        "[catalog→{}] phase 2/4: streaming catalog rows",
+        "[catalog→{}] phase 2/3: streaming catalog rows",
         catalog_config.catalog
     );
     let mut cat_projection = catalog_config.projection.clone();
@@ -423,7 +737,9 @@ async fn run_catalog_driven(
     }
 
     let cat_estimated = cat_collection.estimated_document_count().await.unwrap_or(0);
-    let pb = make_progress_bar(cat_estimated, format!("catalog→{}", catalog_config.catalog));
+    let label = format!("catalog→{}", catalog_config.catalog);
+    let pb = make_progress_bar(cat_estimated, label.clone());
+    let logger = spawn_progress_logger(pb.clone(), label);
     let queue_capacity = processes * batch_size * QUEUE_MULTIPLIER;
     let (tx, rx) = async_channel::bounded::<Document>(queue_capacity);
 
@@ -444,6 +760,7 @@ async fn run_catalog_driven(
                 run_start_jd,
                 rx,
                 batch_size,
+                concurrency,
                 pb,
             )
             .await
@@ -454,6 +771,7 @@ async fn run_catalog_driven(
     let mut cursor = cat_collection
         .find(doc! {})
         .projection(cat_projection)
+        .batch_size(CURSOR_BATCH_SIZE)
         .no_cursor_timeout(true)
         .await?;
     while let Some(d) = cursor.try_next().await? {
@@ -475,49 +793,43 @@ async fn run_catalog_driven(
             }
         }
     }
+    logger.abort();
     pb.finish();
     if let Some(e) = first_err {
-        // CRITICAL: phase 1 cleared temp on every existing record. If phase 2 partially failed,
-        // some records have empty temp; running phase 4 would overwrite their valid live
-        // cross_matches with that empty temp. Abort before phase 3 to preserve existing data.
-        // The next run's phase 1 will reset temp to [] on every existing record before phase 4 unsets it.
+        // CRITICAL: temp holds a partial result; committing it would overwrite valid
+        // live cross_matches with an incomplete list. The next run's phase 1 clears it.
         return Err(e);
     }
 
-    // Phase 3: sort + trim of accumulated matches per alerts_aux record.
+    // Phase 3: sort, trim and commit in a single pass. $ifNull gives records with no
+    // match the empty array that phase 1 used to pre-write on every record.
     info!(
-        "[catalog→{}] phase 3/4: sorting and trimming temp",
-        catalog_config.catalog
+        "[catalog→{}] phase 3/3: sorting, trimming and swapping temp into live ({} shards)",
+        catalog_config.catalog,
+        shards.len()
     );
-    aux_collection
-        .update_many(
-            doc! {
-                "created_at": { "$lt": run_start_jd },
-                format!("{}.0", &temp_field): { "$exists": true },
-            },
-            make_sort_trim_pipeline(&catalog_config, &temp_field),
-        )
-        .await?;
-
-    // Phase 4: copy temp to live field, then clear temp.
-    // Gated on created_at to avoid overwriting new records that arrived during the run.
-    info!(
-        "[catalog→{}] phase 4/4: swapping temp into live",
-        catalog_config.catalog
-    );
-    aux_collection
-        .update_many(
-            existing_records,
-            vec![
-                doc! { "$set": { &live_field: format!("${}", &temp_field) } },
-                doc! { "$unset": &temp_field },
-            ],
-        )
-        .await?;
+    let mut commit_filter = doc! { "created_at": { "$lt": run_start_jd } };
+    if skip_empty {
+        commit_filter.insert(&temp_field, doc! { "$exists": true });
+    }
+    sharded_update_many(
+        &aux_collection,
+        &shards,
+        &commit_filter,
+        UpdateModifications::Pipeline(make_commit_pipeline(
+            &catalog_config,
+            &temp_field,
+            &live_field,
+        )),
+        &format!("catalog→{} phase 3", catalog_config.catalog),
+    )
+    .await?;
+    set_reprocess_state(&db, &state_id, STATUS_CLEAN).await?;
 
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn catalog_worker(
     survey: Survey,
     db: mongodb::Database,
@@ -526,6 +838,7 @@ async fn catalog_worker(
     run_start_jd: f64,
     rx: async_channel::Receiver<Document>,
     batch_size: usize,
+    concurrency: usize,
     pb: ProgressBar,
 ) -> Result<(), mongodb::error::Error> {
     let client = db.client().clone();
@@ -533,29 +846,78 @@ async fn catalog_worker(
         db.collection(&format!("{}_alerts_aux", survey));
     let aux_ns = aux_collection.namespace();
 
-    let mut pending: HashMap<String, Vec<Document>> = HashMap::new();
-    let mut cat_count = 0u64;
-
+    let mut rows = Vec::with_capacity(batch_size);
     while let Ok(cat_doc) = rx.recv().await {
-        cat_count += 1;
-        pb.inc(1);
-        if let Err(e) = process_cat_doc(
-            &aux_collection,
-            &catalog_config,
-            run_start_jd,
-            &cat_doc,
-            &mut pending,
-        )
-        .await
-        {
-            warn!(error = %e, "catalog row processing failed, skipping");
-        }
-        if cat_count % (batch_size as u64) == 0 && !pending.is_empty() {
-            flush_pending(&client, &aux_ns, &temp_field, &mut pending).await?;
+        rows.push(cat_doc);
+        if rows.len() >= batch_size {
+            flush_catalog_batch(
+                &aux_collection,
+                &client,
+                &aux_ns,
+                &catalog_config,
+                &temp_field,
+                run_start_jd,
+                &mut rows,
+                concurrency,
+                &pb,
+            )
+            .await?;
         }
     }
+    if !rows.is_empty() {
+        flush_catalog_batch(
+            &aux_collection,
+            &client,
+            &aux_ns,
+            &catalog_config,
+            &temp_field,
+            run_start_jd,
+            &mut rows,
+            concurrency,
+            &pb,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn flush_catalog_batch(
+    aux_collection: &mongodb::Collection<Document>,
+    client: &mongodb::Client,
+    aux_ns: &Namespace,
+    catalog_config: &CatalogXmatchConfig,
+    temp_field: &str,
+    run_start_jd: f64,
+    rows: &mut Vec<Document>,
+    concurrency: usize,
+    pb: &ProgressBar,
+) -> Result<(), mongodb::error::Error> {
+    let mut stream = futures::stream::iter(rows.drain(..))
+        .map(|cat_doc| async move {
+            let result =
+                process_cat_doc(aux_collection, catalog_config, run_start_jd, &cat_doc).await;
+            pb.inc(1);
+            match result {
+                Ok(matches) => matches,
+                Err(e) => {
+                    warn!(error = %e, "catalog row processing failed, skipping");
+                    Vec::new()
+                }
+            }
+        })
+        .buffer_unordered(concurrency);
+
+    let mut pending: HashMap<String, Vec<Document>> = HashMap::new();
+    while let Some(matches) = stream.next().await {
+        for (aux_id, match_doc) in matches {
+            pending.entry(aux_id).or_default().push(match_doc);
+        }
+    }
+    drop(stream);
+
     if !pending.is_empty() {
-        flush_pending(&client, &aux_ns, &temp_field, &mut pending).await?;
+        flush_pending(client, aux_ns, temp_field, &mut pending).await?;
     }
     Ok(())
 }
@@ -565,17 +927,19 @@ async fn process_cat_doc(
     catalog_config: &CatalogXmatchConfig,
     run_start_jd: f64,
     cat_doc: &Document,
-    pending: &mut HashMap<String, Vec<Document>>,
-) -> Result<(), mongodb::error::Error> {
+) -> Result<Vec<(String, Document)>, mongodb::error::Error> {
     let cat_ra = match get_f64_from_doc(cat_doc, "ra") {
         Some(v) => v,
-        None => return Ok(()),
+        None => return Ok(Vec::new()),
     };
     let cat_dec = match get_f64_from_doc(cat_doc, "dec") {
         Some(v) => v,
-        None => return Ok(()),
+        None => return Ok(Vec::new()),
     };
 
+    // A `use_distance` row's effective radius depends only on its own redshift, so query
+    // that instead of the configured maximum and discarding most of what comes back.
+    let mut search_radius = catalog_config.radius;
     let use_distance_data: Option<(f64, f64)> = if catalog_config.use_distance {
         let dk = catalog_config
             .distance_key
@@ -583,31 +947,38 @@ async fn process_cat_doc(
             .expect("validated in config");
         let z = match get_f64_from_doc(cat_doc, dk) {
             Some(v) => v,
-            None => return Ok(()),
+            None => return Ok(Vec::new()),
         };
         let dmax = catalog_config.distance_max.expect("validated in config");
         let dmax_near = catalog_config
             .distance_max_near
             .expect("validated in config");
-        Some((z, cm_radius_arcsec(z, dmax, dmax_near)))
+        let cm_radius = cm_radius_arcsec(z, dmax, dmax_near);
+        search_radius = search_radius.min(cm_radius * ARCSEC_TO_RAD);
+        Some((z, cm_radius))
     } else {
         None
     };
+    if search_radius <= 0.0 {
+        return Ok(Vec::new());
+    }
 
     let cat_ra_geojson = cat_ra - 180.0;
     let aux_filter = doc! {
         "coordinates.radec_geojson": {
             "$geoWithin": {
-                "$centerSphere": [[cat_ra_geojson, cat_dec], catalog_config.radius]
+                "$centerSphere": [[cat_ra_geojson, cat_dec], search_radius]
             }
         },
         "created_at": { "$lt": run_start_jd },
     };
     let mut aux_cursor = aux_collection
         .find(aux_filter)
-        .projection(doc! { "_id": 1, "coordinates": 1 })
+        .projection(aux_match_projection())
+        .batch_size(CURSOR_BATCH_SIZE)
         .await?;
 
+    let mut matches = Vec::new();
     while let Some(aux_doc) = aux_cursor.try_next().await? {
         let aux_id = match aux_doc.get_str("_id") {
             Ok(s) => s.to_string(),
@@ -629,9 +1000,9 @@ async fn process_cat_doc(
             match_doc.insert("distance_kpc", distance_kpc_from_arcsec(distance_arcsec, z));
         }
 
-        pending.entry(aux_id).or_default().push(match_doc);
+        matches.push((aux_id, match_doc));
     }
-    Ok(())
+    Ok(matches)
 }
 
 async fn flush_pending(
@@ -654,7 +1025,7 @@ async fn flush_pending(
         })
         .collect();
     if !models.is_empty() {
-        client.bulk_write(models).await?;
+        client.bulk_write(models).ordered(false).await?;
     }
     Ok(())
 }
@@ -681,21 +1052,29 @@ fn extract_radec(doc: &Document) -> Option<(f64, f64)> {
 
 /// Mongo-aggregation mirror of the in-Rust sort/trim performed by
 /// `utils::spatial::xmatch` (see that function for the source of truth on
-/// ordering semantics). `use_distance` and `max_results` are mutually
-/// exclusive at config load.
-fn make_sort_trim_pipeline(catalog_config: &CatalogXmatchConfig, field: &str) -> Vec<Document> {
+/// ordering semantics), followed by the swap of the temp buffer into the live
+/// field. `use_distance` and `max_results` are mutually exclusive at config load.
+fn make_commit_pipeline(
+    catalog_config: &CatalogXmatchConfig,
+    temp_field: &str,
+    live_field: &str,
+) -> Vec<Document> {
     let sort_by = if catalog_config.use_distance {
         doc! { "distance_kpc": 1, "distance_arcsec": 1 }
     } else {
         doc! { "distance_arcsec": 1 }
     };
-    let sorted = doc! { "$sortArray": { "input": format!("${}", field), "sortBy": sort_by } };
+    let input = doc! { "$ifNull": [format!("${}", temp_field), []] };
+    let sorted = doc! { "$sortArray": { "input": input, "sortBy": sort_by } };
     let final_value: Document = if let Some(max) = catalog_config.max_results {
         doc! { "$slice": [sorted, max as i64] }
     } else {
         sorted
     };
-    vec![doc! { "$set": { field: final_value } }]
+    vec![
+        doc! { "$set": { live_field: final_value } },
+        doc! { "$unset": temp_field },
+    ]
 }
 
 async fn pick_direction(
@@ -712,7 +1091,7 @@ async fn pick_direction(
         "auto: catalog '{}' ~{} rows, '{}_alerts_aux' ~{} rows",
         catalog_config.catalog, cat_count, survey, aux_count
     );
-    if cat_count < aux_count {
+    if cat_count.saturating_mul(CATALOG_DRIVEN_MARGIN) < aux_count {
         Direction::Catalog
     } else {
         Direction::Objects
@@ -743,6 +1122,15 @@ async fn main() {
         }
     };
 
+    let in_flight = args.processes * args.concurrency;
+    if in_flight > config.database.max_pool_size as usize {
+        warn!(
+            "processes × concurrency = {} exceeds database.max_pool_size = {}; \
+             workers will queue on the connection pool",
+            in_flight, config.database.max_pool_size
+        );
+    }
+
     let db = match config.build_db().await {
         Ok(db) => db,
         Err(e) => {
@@ -765,6 +1153,13 @@ async fn main() {
     };
     let mut resolved: Vec<CatalogXmatchConfig> = Vec::with_capacity(args.catalogs.len());
     for name in &args.catalogs {
+        if resolved.iter().any(|c| &c.catalog == name) {
+            warn!(
+                "catalog '{}' listed more than once, ignoring the copy",
+                name
+            );
+            continue;
+        }
         match survey_configs.iter().find(|c| &c.catalog == name) {
             Some(c) => resolved.push(c.clone()),
             None => {
@@ -807,13 +1202,24 @@ async fn main() {
     }
 
     info!(
-        "starting reprocess: survey={} processes={} batch_size={} objects_driven={:?} catalogs_driven={:?} watchlist_driven={:?}",
+        "starting reprocess: survey={} processes={} concurrency={} in_flight={} batch_size={} objects_driven={:?} catalogs_driven={:?} watchlist_driven={:?}",
         args.survey,
         args.processes,
+        args.concurrency,
+        in_flight,
         args.batch_size,
-        objects_catalogs.iter().map(|c| &c.catalog).collect::<Vec<_>>(),
-        catalog_catalogs.iter().map(|c| &c.catalog).collect::<Vec<_>>(),
-        watchlist_catalogs.iter().map(|c| &c.catalog).collect::<Vec<_>>(),
+        objects_catalogs
+            .iter()
+            .map(|c| &c.catalog)
+            .collect::<Vec<_>>(),
+        catalog_catalogs
+            .iter()
+            .map(|c| &c.catalog)
+            .collect::<Vec<_>>(),
+        watchlist_catalogs
+            .iter()
+            .map(|c| &c.catalog)
+            .collect::<Vec<_>>(),
     );
 
     for cat in watchlist_catalogs {
@@ -839,6 +1245,8 @@ async fn main() {
             db.clone(),
             args.batch_size,
             args.processes,
+            args.concurrency,
+            args.skip_existing,
         )
         .await
         {
@@ -855,6 +1263,9 @@ async fn main() {
             db.clone(),
             args.batch_size,
             args.processes,
+            args.concurrency,
+            args.skip_empty,
+            args.reset_temp,
         )
         .await
         {


### PR DESCRIPTION
- Workers now keep --concurrency queries in flight, and the catalog-driven cleanup passes are sharded into --processes ranges.
- The temp reset, sort and swap collapse into one commit pass, skipped unless a state marker shows the previous run was interrupted.
- Adds --skip-existing, --skip-empty and --reset-temp, and queries only the radius a use_distance row actually needs.