### PR TITLE
Adding missing docker configs for Milvus NRP pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ RUN ORT_CAPI_DIR="$('/opt/ort-py/bin/python' -c 'import pathlib, onnxruntime as 
     rm -rf /opt/ort-py && ln -sf /opt/ort/libonnxruntime.so.${ONNXRUNTIME_GPU_VERSION} /opt/ort/libonnxruntime.so
 
 COPY apache-avro-macros /app/apache-avro-macros
-COPY Cargo.toml Cargo.lock /app/
+COPY Cargo.toml Cargo.lock build.rs /app/
+# build.rs generates the Milvus gRPC bindings from these vendored protos into
+# OUT_DIR; without them src/milvus/proto.rs has nothing to include!().
+COPY ./proto /app/proto
 COPY ./src /app/src
 
 # BuildKit cache mounts keep the compiled crates (target/) and the fetched
@@ -68,6 +71,13 @@ RUN --mount=type=cache,target=/app/target,sharing=locked \
 FROM builder AS dev
 
 RUN cargo install --locked cargo-watch
+
+# On Linux `ort` is built with the `load-dynamic` feature (see Cargo.toml), so
+# libonnxruntime.so is dlopen'd at runtime rather than linked in. The `app`
+# stage sets these as well; without them here the enrichment workers hang
+# during SharedModels::load and never reach their queue loop.
+ENV ORT_DYLIB_PATH=/opt/ort/libonnxruntime.so
+ENV LD_LIBRARY_PATH=/opt/ort
 
 CMD ["cargo", "watch", "-x", "run --bin api"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,10 @@ FROM builder AS dev
 
 RUN cargo install --locked cargo-watch
 
-# On Linux `ort` is built with the `load-dynamic` feature (see Cargo.toml), so
-# libonnxruntime.so is dlopen'd at runtime rather than linked in. The `app`
-# stage sets these as well; without them here the enrichment workers hang
-# during SharedModels::load and never reach their queue loop.
+# On Linux, `ort` uses the `load-dynamic` feature (Cargo.toml), so it looks up
+# libonnxruntime.so at runtime instead of linking it in. These tell it where.
+# The `app` stage repeats them; without them here the enrichment workers hang
+# in SharedModels::load and never reach their queue loop.
 ENV ORT_DYLIB_PATH=/opt/ort/libonnxruntime.so
 ENV LD_LIBRARY_PATH=/opt/ort
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -30,7 +30,10 @@ RUN ORT_CAPI_DIR="$('/opt/ort-py/bin/python' -c 'import pathlib, onnxruntime as 
 
 COPY data/models/btsbot-v1.0.1.onnx /app/data/models/btsbot-v1.0.1.onnx
 COPY apache-avro-macros /app/apache-avro-macros
-COPY Cargo.toml Cargo.lock /app/
+COPY Cargo.toml Cargo.lock build.rs /app/
+# build.rs generates the Milvus gRPC bindings from these vendored protos into
+# OUT_DIR; without them src/milvus/proto.rs has nothing to include!().
+COPY ./proto /app/proto
 COPY ./src /app/src
 
 # BuildKit cache mounts keep compiled crates (target/) and fetched deps between

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ milvus:
   database: "" # Set via BOOM_MILVUS__DATABASE environment variable
   timeout_seconds: 30
   collection:
-    name: ztf_fusion_embeddings
+    name: boom_ztf_fusion_embeddings
     # The CIDER fusion model (data/models/cider_fusion_plus_embedding.onnx)
     # emits 384 floats, L2-normalized -- so COSINE and IP are equivalent.
     dim: 384

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -51,7 +51,7 @@ milvus:
   database: "" # Set via BOOM_MILVUS__DATABASE environment variable
   timeout_seconds: 30
   collection:
-    name: ztf_fusion_embeddings
+    name: boom_ztf_fusion_embeddings
     # The CIDER fusion model (data/models/cider_fusion_plus_embedding.onnx)
     # emits 384 floats, L2-normalized -- so COSINE and IP are equivalent.
     dim: 384

--- a/docker-compose.milvus.yaml
+++ b/docker-compose.milvus.yaml
@@ -85,6 +85,12 @@ services:
   attu:
     container_name: milvus-attu
     image: zilliz/attu:v2.5
+    # The arm64 build of this image ships a broken node_modules (iconv-lite is
+    # missing its `encodings` directory), so any request with a body -- i.e. the
+    # login POST -- dies with "Cannot find module '../encodings'". The amd64
+    # build is fine; on Apple Silicon it runs under Rosetta, which is plenty for
+    # a small Node UI.
+    platform: linux/amd64
     environment:
       MILVUS_URL: standalone:19530
     ports:

--- a/docker-compose.milvus.yaml
+++ b/docker-compose.milvus.yaml
@@ -85,11 +85,7 @@ services:
   attu:
     container_name: milvus-attu
     image: zilliz/attu:v2.5
-    # The arm64 build of this image ships a broken node_modules (iconv-lite is
-    # missing its `encodings` directory), so any request with a body -- i.e. the
-    # login POST -- dies with "Cannot find module '../encodings'". The amd64
-    # build is fine; on Apple Silicon it runs under Rosetta, which is plenty for
-    # a small Node UI.
+    # The arm64 build is broken, so using the amd64, which runs under Rosetta on Apple Silicon
     platform: linux/amd64
     environment:
       MILVUS_URL: standalone:19530

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -186,9 +186,9 @@ services:
       - .env
     environment:
       BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
-      # This service exists only here (the base file defines consumer-ztf-public
-      # / -partnership / -caltech), so unlike scheduler-ztf it inherits no base
-      # definition -- the network and service hostnames must be set explicitly.
+      # The base file has no consumer-ztf (only -public / -partnership /
+      # -caltech), so there is nothing to inherit from: the network and
+      # service hostnames have to be spelled out here.
       BOOM_DATABASE__HOST: mongo
       BOOM_CUTOUTS_STORAGE__HOST: mongo
       BOOM_REDIS__HOST: valkey

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -186,6 +186,14 @@ services:
       - .env
     environment:
       BOOM_KAFKA__CONSUMER__ZTF__SERVER: broker:29092
+      # This service exists only here (the base file defines consumer-ztf-public
+      # / -partnership / -caltech), so unlike scheduler-ztf it inherits no base
+      # definition -- the network and service hostnames must be set explicitly.
+      BOOM_DATABASE__HOST: mongo
+      BOOM_CUTOUTS_STORAGE__HOST: mongo
+      BOOM_REDIS__HOST: valkey
+    networks:
+      - boom
     profiles:
       - dev
     build:

--- a/src/bin/scheduler.rs
+++ b/src/bin/scheduler.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use boom::utils::gpu::validate_gpu_configuration_for_survey;
 use boom::{
     conf::{load_dotenv, AppConfig},
     enrichment::models::SharedModelPool,

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -853,7 +853,7 @@ fn default_milvus_timeout_seconds() -> u64 {
 }
 
 fn default_milvus_collection_name() -> String {
-    "ztf_fusion_embeddings".to_string()
+    "boom_ztf_fusion_embeddings".to_string()
 }
 
 fn default_milvus_dim() -> i64 {

--- a/src/milvus/collection.rs
+++ b/src/milvus/collection.rs
@@ -127,9 +127,7 @@ impl MilvusClient {
             %collection,
             missing = %missing.join(", "),
             found = %present.join(", "),
-            "collection schema does not match what BOOM writes; every upsert \
-             will fail. Point milvus.collection.name at a collection created by \
-             `milvus_check --create-collection`."
+            "collection is missing fields BOOM writes to Milvus, so every upsert will fail."
         );
     }
 

--- a/src/milvus/collection.rs
+++ b/src/milvus/collection.rs
@@ -48,11 +48,10 @@ impl MilvusClient {
 
         if self.has_collection(&collection_name).await? {
             info!(collection = %collection_name, "collection already exists");
-            // Existing is not the same as compatible: a collection provisioned
-            // by hand or by another project can carry an unrelated schema, in
-            // which case every upsert fails at runtime with "fieldName ... not
-            // exist in collection schema". Warn rather than abort, so a partial
-            // mismatch does not take down alert ingestion.
+            // A collection that exists is not necessarily one we can write to:
+            // if it was created by hand or by another project, its schema may
+            // not match ours and every upsert will fail. Warn rather than
+            // abort, so a mismatch does not take down alert ingestion.
             self.warn_on_schema_mismatch().await;
             return Ok(false);
         }
@@ -101,11 +100,7 @@ impl MilvusClient {
         Ok(response.value)
     }
 
-    /// Compare the server's schema against the fields [`super::insert`] writes
-    /// and log a warning describing any mismatch.
-    ///
-    /// Deliberately infallible: this is a diagnostic, so a failure to describe
-    /// the collection must not stop the caller from starting up.
+    /// Warn if the collection is missing any field [`super::insert`] writes.
     async fn warn_on_schema_mismatch(&mut self) {
         let collection = self.config().collection.name.clone();
 

--- a/src/milvus/collection.rs
+++ b/src/milvus/collection.rs
@@ -11,12 +11,13 @@
 //! ingested embedding. `candid` and `jd` record which alert that was.
 
 use prost::Message;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use super::client::{check_status, MilvusClient, MilvusError};
 use super::proto::common::KeyValuePair;
 use super::proto::milvus::{
-    CreateCollectionRequest, CreateIndexRequest, HasCollectionRequest, LoadCollectionRequest,
+    CreateCollectionRequest, CreateIndexRequest, DescribeCollectionRequest, HasCollectionRequest,
+    LoadCollectionRequest,
 };
 use super::proto::schema::{CollectionSchema, DataType, FieldSchema};
 
@@ -31,6 +32,10 @@ pub const FIELD_JD: &str = "jd";
 
 const INDEX_NAME: &str = "embedding_idx";
 
+/// Every field an upsert sends. A collection missing any of these cannot accept
+/// BOOM's writes.
+const REQUIRED_FIELDS: [&str; 4] = [FIELD_OBJECT_ID, FIELD_EMBEDDING, FIELD_CANDID, FIELD_JD];
+
 impl MilvusClient {
     /// Create the embeddings collection, its vector index, and load it into
     /// memory. Does nothing if the collection already exists.
@@ -43,6 +48,12 @@ impl MilvusClient {
 
         if self.has_collection(&collection_name).await? {
             info!(collection = %collection_name, "collection already exists");
+            // Existing is not the same as compatible: a collection provisioned
+            // by hand or by another project can carry an unrelated schema, in
+            // which case every upsert fails at runtime with "fieldName ... not
+            // exist in collection schema". Warn rather than abort, so a partial
+            // mismatch does not take down alert ingestion.
+            self.warn_on_schema_mismatch().await;
             return Ok(false);
         }
 
@@ -88,6 +99,69 @@ impl MilvusClient {
         check_status(response.status.as_ref(), "HasCollection")?;
 
         Ok(response.value)
+    }
+
+    /// Compare the server's schema against the fields [`super::insert`] writes
+    /// and log a warning describing any mismatch.
+    ///
+    /// Deliberately infallible: this is a diagnostic, so a failure to describe
+    /// the collection must not stop the caller from starting up.
+    async fn warn_on_schema_mismatch(&mut self) {
+        let collection = self.config().collection.name.clone();
+
+        let schema = match self.describe_collection().await {
+            Ok(schema) => schema,
+            Err(error) => {
+                warn!(%collection, %error, "could not verify collection schema");
+                return;
+            }
+        };
+
+        let present: Vec<&str> = schema.fields.iter().map(|f| f.name.as_str()).collect();
+        let missing: Vec<&str> = REQUIRED_FIELDS
+            .iter()
+            .copied()
+            .filter(|name| !present.contains(name))
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        warn!(
+            %collection,
+            missing = %missing.join(", "),
+            found = %present.join(", "),
+            "collection schema does not match what BOOM writes; every upsert \
+             will fail. Point milvus.collection.name at a collection created by \
+             `milvus_check --create-collection`."
+        );
+    }
+
+    /// The schema the server actually holds for the configured collection.
+    ///
+    /// Useful when a collection was provisioned by an older version of BOOM (or
+    /// by hand): the field names here must match what [`super::insert`] sends,
+    /// or every upsert fails with "fieldName ... not exist in collection schema".
+    #[instrument(skip_all, err)]
+    pub async fn describe_collection(&mut self) -> Result<CollectionSchema, MilvusError> {
+        let config = self.config().clone();
+        let request = DescribeCollectionRequest {
+            db_name: config.database.clone(),
+            collection_name: config.collection.name.clone(),
+            ..Default::default()
+        };
+
+        let response = self
+            .service()
+            .describe_collection(request)
+            .await?
+            .into_inner();
+        check_status(response.status.as_ref(), "DescribeCollection")?;
+
+        response
+            .schema
+            .ok_or(MilvusError::MissingStatus("DescribeCollection"))
     }
 
     /// Build the vector index on the embedding field.


### PR DESCRIPTION
- Copy `build.rs` and `proto/` into the Docker images so the Milvus gRPC bindings actually generate at build time
- Set `ORT_DYLIB_PATH` / `LD_LIBRARY_PATH` in the `dev` stage, so enrichment workers don't hang loading ONNX
- Fix dev compose: give `consumer-ztf` its network and service hostnames, pin Attu to amd64
- Rename the collection/table for embeddings as `boom_ztf_fusion_embeddings`
- Warn at startup if an existing Milvus collection is missing required fields that BOOM writes, instead of failing every upsert silently later 
