### PR TITLE
add GET /babamul/surveys/{survey}/villar-fit endpoint

### DIFF
--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -109,6 +109,7 @@ pub struct ApiDoc;
         routes::babamul::surveys::cutouts::get_cutouts,
         routes::babamul::surveys::alerts::get_alerts,
         routes::babamul::surveys::alerts::cone_search_alerts,
+        routes::babamul::surveys::villar_fit::get_villar_fit,
         routes::babamul::stats::collections::get_collection_stats,
         routes::babamul::stats::kafka::get_kafka_stats,
         routes::babamul::stats::nightly::get_nightly_stats,

--- a/src/api/routes/babamul/surveys/mod.rs
+++ b/src/api/routes/babamul/surveys/mod.rs
@@ -2,6 +2,7 @@ pub mod alerts;
 pub mod cutouts;
 pub mod objects;
 pub mod schemas;
+pub mod villar_fit;
 
 pub use alerts::cone_search_alerts;
 pub use alerts::get_alerts;
@@ -13,3 +14,4 @@ pub use objects::get_objects;
 pub use objects::get_objects_xmatches;
 pub use schemas::get_babamul_schema;
 pub use schemas::BabamulAvroSchemas;
+pub use villar_fit::get_villar_fit;

--- a/src/api/routes/babamul/surveys/villar_fit.rs
+++ b/src/api/routes/babamul/surveys/villar_fit.rs
@@ -99,10 +99,7 @@ pub async fn get_villar_fit(
         {
             Ok(Some(alert)) => alert.candid,
             Ok(None) => {
-                return response::not_found(&format!(
-                    "no alerts found for objectId {}",
-                    object_id
-                ));
+                return response::not_found(&format!("no alerts found for objectId {}", object_id));
             }
             Err(error) => {
                 return response::internal_error(&format!("error getting documents: {}", error));

--- a/src/api/routes/babamul/surveys/villar_fit.rs
+++ b/src/api/routes/babamul/surveys/villar_fit.rs
@@ -1,0 +1,164 @@
+use crate::api::cutouts::{AlertCandidOnly, WhichCutouts};
+use crate::api::models::response;
+use crate::api::routes::babamul::BabamulUser;
+use crate::utils::enums::Survey;
+use actix_web::{get, web, HttpResponse};
+use mongodb::{bson::doc, Collection, Database};
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct VillarFitQuery {
+    pub candid: Option<i64>,
+    #[serde(rename = "objectId")]
+    pub object_id: Option<String>,
+    pub which: Option<WhichCutouts>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct VillarFitResponse {
+    pub candid: i64,
+    /// Reduced chi-squared of the fit. `null` if no fit could be produced for this alert.
+    pub reduced_chi2: Option<f64>,
+    /// Villar model parameters, keyed as `{param}_{filter}` (e.g. `amplitude_g`).
+    /// Values are `null` where a fit could not be produced.
+    pub params: HashMap<String, f64>,
+}
+
+/// Fetch the GPU-computed Villar light curve fit for a ZTF alert
+#[utoipa::path(
+    get,
+    path = "/babamul/surveys/{survey}/villar-fit",
+    params(
+        ("survey" = Survey, Path, description = "Name of the survey (currently only ztf is supported)"),
+        ("candid" = Option<i64>, Query, description = "Candid of the alert to retrieve the Villar fit for"),
+        ("objectId" = Option<String>, Query, description = "Object ID to retrieve the Villar fit for"),
+        ("which" = Option<WhichCutouts>, Query, description = "Which alert to use if multiple match the objectId (first, last, brightest, faintest); defaults to last"),
+    ),
+    responses(
+        (status = 200, description = "Villar fit found", body = VillarFitResponse),
+        (status = 400, description = "Invalid survey or missing candid/objectId"),
+        (status = 404, description = "No alert or Villar fit found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tags=["Surveys"]
+)]
+#[get("/surveys/{survey}/villar-fit")]
+pub async fn get_villar_fit(
+    path: web::Path<Survey>,
+    query: web::Query<VillarFitQuery>,
+    current_user: Option<web::ReqData<BabamulUser>>,
+    db: web::Data<Database>,
+) -> HttpResponse {
+    // TODO: implement permissions for Babamul users, so we
+    // can constrain access to certain surveys' datapoints
+    let _current_user = match current_user {
+        Some(user) => user,
+        None => {
+            return HttpResponse::Unauthorized().body("Unauthorized");
+        }
+    };
+
+    let survey = path.into_inner();
+    if survey != Survey::Ztf {
+        return response::bad_request(&format!(
+            "Unsupported survey: {}. Villar fits are currently only computed for ztf",
+            survey
+        ));
+    }
+
+    let candid = if let Some(candid) = query.candid {
+        candid
+    } else if let Some(object_id) = &query.object_id {
+        let candid_collection: Collection<AlertCandidOnly> =
+            db.collection(&format!("{}_alerts", survey));
+        let which = query.which.clone().unwrap_or(WhichCutouts::Last);
+        let find_options = match which {
+            WhichCutouts::First => mongodb::options::FindOneOptions::builder()
+                .sort(doc! { "candidate.jd": 1 })
+                .build(),
+            WhichCutouts::Last => mongodb::options::FindOneOptions::builder()
+                .sort(doc! { "candidate.jd": -1 })
+                .build(),
+            WhichCutouts::Brightest => mongodb::options::FindOneOptions::builder()
+                .sort(doc! { "candidate.magpsf": 1 })
+                .build(),
+            WhichCutouts::Faintest => mongodb::options::FindOneOptions::builder()
+                .sort(doc! { "candidate.magpsf": -1 })
+                .build(),
+        };
+
+        match candid_collection
+            .find_one(doc! {
+                "objectId": object_id,
+                "candidate.programid": 1, // Babamul only returns public ZTF alerts
+            })
+            .projection(doc! { "_id": 1 })
+            .with_options(find_options)
+            .await
+        {
+            Ok(Some(alert)) => alert.candid,
+            Ok(None) => {
+                return response::not_found(&format!(
+                    "no alerts found for objectId {}",
+                    object_id
+                ));
+            }
+            Err(error) => {
+                return response::internal_error(&format!("error getting documents: {}", error));
+            }
+        }
+    } else {
+        return response::bad_request("candid or objectId query parameter must be provided");
+    };
+
+    let alert_collection: Collection<mongodb::bson::Document> =
+        db.collection(&format!("{}_alerts", survey));
+    let alert_doc = match alert_collection
+        .find_one(doc! {
+            "_id": candid,
+            "candidate.programid": 1, // Babamul only returns public ZTF alerts
+        })
+        .projection(doc! { "_id": 1, "villar_fit": 1 })
+        .await
+    {
+        Ok(Some(doc)) => doc,
+        Ok(None) => {
+            return response::not_found(&format!("no alert found for candid {}", candid));
+        }
+        Err(error) => {
+            return response::internal_error(&format!("error getting documents: {}", error));
+        }
+    };
+
+    let villar_fit_doc = match alert_doc.get_document("villar_fit") {
+        Ok(doc) => doc,
+        Err(_) => {
+            return response::not_found(&format!(
+                "no Villar fit found for candid {} (alert may not have been processed by the GPU enrichment worker yet)",
+                candid
+            ));
+        }
+    };
+
+    let mut reduced_chi2 = None;
+    let mut params = HashMap::new();
+    for (key, value) in villar_fit_doc.iter() {
+        let value = match value.as_f64() {
+            Some(v) => v,
+            None => continue,
+        };
+        if key == "reduced_chi2" {
+            reduced_chi2 = Some(value);
+        } else {
+            params.insert(key.clone(), value);
+        }
+    }
+
+    let response = VillarFitResponse {
+        candid,
+        reduced_chi2,
+        params,
+    };
+    response::ok_ser(&format!("found Villar fit for candid {}", candid), response)
+}

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -119,6 +119,7 @@ async fn main() -> std::io::Result<()> {
                     .service(routes::babamul::surveys::get_cutouts)
                     .service(routes::babamul::surveys::get_alerts)
                     .service(routes::babamul::surveys::cone_search_alerts)
+                    .service(routes::babamul::surveys::get_villar_fit)
                     .service(routes::babamul::stats::get_nightly_stats)
                     .service(routes::babamul::stats::get_collection_stats)
                     .service(routes::babamul::stats::get_kafka_stats)

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -3310,7 +3310,10 @@ mod tests {
 
         // Lookup by candid
         let req = test::TestRequest::get()
-            .uri(&format!("/babamul/surveys/ztf/villar-fit?candid={}", candid))
+            .uri(&format!(
+                "/babamul/surveys/ztf/villar-fit?candid={}",
+                candid
+            ))
             .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
             .to_request();
         let resp = test::call_service(&app, req).await;
@@ -3323,7 +3326,10 @@ mod tests {
         let body = read_json_response(resp).await;
         assert_eq!(body["data"]["candid"].as_i64().unwrap(), candid);
         assert_eq!(body["data"]["reduced_chi2"].as_f64().unwrap(), 1.23);
-        assert_eq!(body["data"]["params"]["amplitude_g"].as_f64().unwrap(), 4.56);
+        assert_eq!(
+            body["data"]["params"]["amplitude_g"].as_f64().unwrap(),
+            4.56
+        );
         assert!(
             body["data"]["params"]["amplitude_r"].is_null(),
             "NaN values should serialize to null"
@@ -3349,7 +3355,10 @@ mod tests {
 
         // Unsupported survey
         let req = test::TestRequest::get()
-            .uri(&format!("/babamul/surveys/lsst/villar-fit?candid={}", candid))
+            .uri(&format!(
+                "/babamul/surveys/lsst/villar-fit?candid={}",
+                candid
+            ))
             .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
             .to_request();
         let resp = test::call_service(&app, req).await;
@@ -3374,7 +3383,10 @@ mod tests {
             .expect("Failed to set programid");
 
         let req = test::TestRequest::get()
-            .uri(&format!("/babamul/surveys/ztf/villar-fit?candid={}", candid))
+            .uri(&format!(
+                "/babamul/surveys/ztf/villar-fit?candid={}",
+                candid
+            ))
             .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
             .to_request();
         let resp = test::call_service(&app, req).await;

--- a/tests/api/test_babamul.rs
+++ b/tests/api/test_babamul.rs
@@ -3261,4 +3261,146 @@ mod tests {
             col.delete_one(doc! { "_id": id }).await.unwrap();
         }
     }
+
+    /// Test GET /babamul/surveys/ztf/villar-fit
+    #[actix_rt::test]
+    async fn test_get_villar_fit() {
+        load_dotenv();
+        let database: Database = get_test_db_api().await;
+        let auth_app_data = get_test_auth(&database).await.unwrap();
+        let test_user = TestUser::create(&database, &auth_app_data).await;
+
+        let mut alert_worker = ztf_alert_worker().await;
+        let (candid, object_id, _, _, bytes_content) =
+            AlertRandomizer::new_randomized(Survey::Ztf).get().await;
+        let status = alert_worker.process_alert(&bytes_content).await.unwrap();
+        assert_eq!(status, ProcessAlertStatus::Added(candid));
+        let mut enrichment_worker = ZtfEnrichmentWorker::new(TEST_CONFIG_FILE, None)
+            .await
+            .unwrap();
+        let result = enrichment_worker.process_alerts(&[candid]).await;
+        assert!(result.is_ok(), "Enrichment failed: {:?}", result.err());
+
+        // Simulate what the GPU-enabled enrichment worker writes, since the
+        // `gpu` feature isn't necessarily enabled for this test run.
+        let alert_collection: mongodb::Collection<mongodb::bson::Document> =
+            database.collection("ZTF_alerts");
+        alert_collection
+            .update_one(
+                doc! { "_id": candid },
+                doc! { "$set": {
+                    "villar_fit.reduced_chi2": 1.23,
+                    "villar_fit.amplitude_g": 4.56,
+                    "villar_fit.amplitude_r": f64::NAN,
+                }},
+            )
+            .await
+            .expect("Failed to set villar_fit");
+
+        let app = test::init_service(
+            App::new().service(
+                actix_web::web::scope("/babamul")
+                    .app_data(web::Data::new(database.clone()))
+                    .app_data(web::Data::new(auth_app_data.clone()))
+                    .wrap(from_fn(babamul_auth_middleware))
+                    .service(routes::babamul::surveys::get_villar_fit),
+            ),
+        )
+        .await;
+
+        // Lookup by candid
+        let req = test::TestRequest::get()
+            .uri(&format!("/babamul/surveys/ztf/villar-fit?candid={}", candid))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Should successfully retrieve villar fit by candid (error: {})",
+            read_str_response(resp).await
+        );
+        let body = read_json_response(resp).await;
+        assert_eq!(body["data"]["candid"].as_i64().unwrap(), candid);
+        assert_eq!(body["data"]["reduced_chi2"].as_f64().unwrap(), 1.23);
+        assert_eq!(body["data"]["params"]["amplitude_g"].as_f64().unwrap(), 4.56);
+        assert!(
+            body["data"]["params"]["amplitude_r"].is_null(),
+            "NaN values should serialize to null"
+        );
+
+        // Lookup by objectId
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/babamul/surveys/ztf/villar-fit?objectId={}&which=last",
+                object_id
+            ))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Should successfully retrieve villar fit by objectId (error: {})",
+            read_str_response(resp).await
+        );
+        let body = read_json_response(resp).await;
+        assert_eq!(body["data"]["candid"].as_i64().unwrap(), candid);
+
+        // Unsupported survey
+        let req = test::TestRequest::get()
+            .uri(&format!("/babamul/surveys/lsst/villar-fit?candid={}", candid))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // Non-existent candid
+        let req = test::TestRequest::get()
+            .uri("/babamul/surveys/ztf/villar-fit?candid=999999999999")
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // Private-program alerts (programid != 1) must not be exposed via Babamul,
+        // same as every other Babamul survey endpoint.
+        alert_collection
+            .update_one(
+                doc! { "_id": candid },
+                doc! { "$set": { "candidate.programid": 2 } },
+            )
+            .await
+            .expect("Failed to set programid");
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/babamul/surveys/ztf/villar-fit?candid={}", candid))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "private-program alert must not be retrievable by candid via Babamul"
+        );
+
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/babamul/surveys/ztf/villar-fit?objectId={}",
+                object_id
+            ))
+            .insert_header(("Authorization", format!("Bearer {}", test_user.token)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "private-program alert must not be retrievable by objectId via Babamul"
+        );
+
+        // Clean up
+        drop_alert_from_collections(candid, &Survey::Ztf)
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve GPU-computed Villar light curve fits for ZTF alerts in Babamul. The endpoint is fully integrated into routing, documented, and covered by comprehensive tests. The most important changes are as follows:

### New Villar Fit Endpoint

* Added the `get_villar_fit` endpoint in `src/api/routes/babamul/surveys/villar_fit.rs`, which allows authenticated users to fetch Villar light curve fits for ZTF alerts by `candid` or `objectId`. The endpoint only supports the ZTF survey and ensures only public alerts (programid == 1) are exposed.
* Registered the new Villar fit route in the API documentation (`ApiDoc`), route module (`mod.rs`), and main server application, making it available and discoverable via OpenAPI and the HTTP server. 

### Testing

* Added comprehensive integration tests for the Villar fit endpoint in `tests/api/test_babamul.rs`. Tests cover successful lookups by `candid` and `objectId`, handling of unsupported surveys, non-existent alerts, and enforcement of public-only alert access.