### PR TITLE
Enrich alerts with per-object detection_history for history-aware filters

### DIFF
--- a/src/enrichment/decam.rs
+++ b/src/enrichment/decam.rs
@@ -111,6 +111,7 @@ pub struct DecamAlertForEnrichment {
     #[serde(rename = "objectId")]
     pub object_id: String,
     pub candidate: DecamCandidate,
+    // Signed SNR is only needed here: detection history counts detections.
     pub prv_candidates: Vec<DecamPhotometry>,
     pub fp_hists: Vec<PhotometryMag>,
 }

--- a/src/enrichment/decam.rs
+++ b/src/enrichment/decam.rs
@@ -4,7 +4,8 @@ use crate::enrichment::{fetch_alerts, EnrichmentWorker, EnrichmentWorkerError};
 use crate::utils::db::{fetch_timeseries_op, mongify};
 use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, PerBandProperties, PhotometryMag,
+    analyze_photometry, prepare_photometry, Band, DetectionHistory, PerBandProperties,
+    PhotometryMag,
 };
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
@@ -73,6 +74,33 @@ pub fn create_decam_alert_pipeline() -> Vec<Document> {
     ]
 }
 
+/// DECAM prv_candidate for enrichment: the magnitude fields feed the light-curve
+/// stats (mirrors `PhotometryMag`, also accepting DECam's `magap`/`sigmagap`
+/// keys), the signed `snr` feeds the detection-history sign.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct DecamPhotometry {
+    #[serde(alias = "jd")]
+    pub time: f64,
+    #[serde(alias = "magpsf", alias = "magap")]
+    pub mag: f32,
+    #[serde(alias = "sigmapsf", alias = "sigmagap")]
+    pub mag_err: f32,
+    pub band: Band,
+    #[serde(default)]
+    pub snr: Option<f64>,
+}
+
+impl DecamPhotometry {
+    fn to_photometry_mag(&self) -> PhotometryMag {
+        PhotometryMag {
+            time: self.time,
+            mag: self.mag,
+            mag_err: self.mag_err,
+            band: self.band.clone(),
+        }
+    }
+}
+
 /// DECAM alert structure used to deserialize alerts
 /// from the database, used by the enrichment worker
 /// to compute features and ML scores
@@ -83,7 +111,7 @@ pub struct DecamAlertForEnrichment {
     #[serde(rename = "objectId")]
     pub object_id: String,
     pub candidate: DecamCandidate,
-    pub prv_candidates: Vec<PhotometryMag>,
+    pub prv_candidates: Vec<DecamPhotometry>,
     pub fp_hists: Vec<PhotometryMag>,
 }
 
@@ -93,6 +121,10 @@ pub struct DecamAlertForEnrichment {
 pub struct DecamAlertProperties {
     pub stationary: bool,
     pub photstats: PerBandProperties,
+    /// Per-object detection-history summary for history-aware filters.
+    /// `None` on alerts enriched before this field existed.
+    #[serde(default)]
+    pub detection_history: Option<DetectionHistory>,
 }
 
 pub struct DecamEnrichmentWorker {
@@ -202,7 +234,11 @@ impl DecamEnrichmentWorker {
         &self,
         alert: &DecamAlertForEnrichment,
     ) -> Result<DecamAlertProperties, EnrichmentWorkerError> {
-        let prv_candidates = alert.prv_candidates.clone();
+        let prv_candidates: Vec<PhotometryMag> = alert
+            .prv_candidates
+            .iter()
+            .map(DecamPhotometry::to_photometry_mag)
+            .collect();
         let fp_hists = alert.fp_hists.clone();
 
         // lightcurve is prv_candidates + fp_hists, no need for parse_photometry here
@@ -211,9 +247,19 @@ impl DecamEnrichmentWorker {
         prepare_photometry(&mut lightcurve);
         let (photstats, _, stationary) = analyze_photometry(&lightcurve);
 
+        // Per-object detection history for history-aware filters (sign from signed snr).
+        let detection_history = DetectionHistory::from_points(
+            alert
+                .prv_candidates
+                .iter()
+                .map(|p| (p.time, p.snr.filter(|s| !s.is_nan()).map(|s| s < 0.0))),
+            alert.candidate.jd,
+        );
+
         Ok(DecamAlertProperties {
             stationary,
             photstats,
+            detection_history: Some(detection_history),
         })
     }
 }

--- a/src/enrichment/lsst.rs
+++ b/src/enrichment/lsst.rs
@@ -7,7 +7,8 @@ use crate::enrichment::{
 use crate::utils::db::mongify;
 use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, ActivityMetrics, Band, PerBandProperties, PhotometryMag,
+    analyze_photometry, prepare_photometry, ActivityMetrics, Band, DetectionHistory,
+    PerBandProperties, PhotometryMag,
 };
 use apache_avro_derive::AvroSchema;
 use apache_avro_macros::serdavro;
@@ -273,6 +274,10 @@ pub struct LsstAlertProperties {
     /// `None` on alerts enriched before this existed.
     #[serde(default)]
     pub activity: Option<ActivityMetrics>,
+    /// Per-object detection-history summary for history-aware filters.
+    /// `None` on alerts enriched before this field existed.
+    #[serde(default)]
+    pub detection_history: Option<DetectionHistory>,
 }
 
 pub struct LsstEnrichmentWorker {
@@ -551,6 +556,16 @@ impl LsstEnrichmentWorker {
             photstats.clone()
         };
 
+        // Per-object detection history for history-aware filters (positive/negative
+        // by psfFlux sign; LSST difference psfFlux is signed natively).
+        let detection_history = DetectionHistory::from_points(
+            alert
+                .prv_candidates
+                .iter()
+                .map(|p| (p.jd, p.flux.filter(|f| !f.is_nan()).map(|f| f < 0.0))),
+            alert.candidate.jd,
+        );
+
         Ok(LsstAlertProperties {
             rock: is_rock,
             sso: Some(sso),
@@ -560,6 +575,7 @@ impl LsstEnrichmentWorker {
             stationary,
             photstats,
             multisurvey_photstats,
+            detection_history: Some(detection_history),
         })
     }
 }

--- a/src/enrichment/winter.rs
+++ b/src/enrichment/winter.rs
@@ -4,7 +4,8 @@ use crate::enrichment::{fetch_alerts, EnrichmentWorker, EnrichmentWorkerError};
 use crate::utils::db::{fetch_timeseries_op, mongify};
 use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, PerBandProperties, PhotometryMag,
+    analyze_photometry, prepare_photometry, Band, DetectionHistory, PerBandProperties,
+    PhotometryMag,
 };
 use mongodb::bson::{doc, Document};
 use mongodb::options::{UpdateOneModel, WriteModel};
@@ -51,9 +52,36 @@ pub fn create_winter_alert_pipeline() -> Vec<Document> {
                 "prv_candidates.magpsf": 1,
                 "prv_candidates.sigmapsf": 1,
                 "prv_candidates.band": 1,
+                "prv_candidates.isdiffpos": 1,
             }
         },
     ]
+}
+
+/// WINTER prv_candidate for enrichment: the magnitude fields feed the light-curve
+/// stats, `isdiffpos` feeds the detection-history sign.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WinterPhotometry {
+    #[serde(alias = "jd")]
+    pub time: f64,
+    #[serde(alias = "magpsf")]
+    pub mag: f32,
+    #[serde(alias = "sigmapsf")]
+    pub mag_err: f32,
+    pub band: Band,
+    #[serde(default)]
+    pub isdiffpos: Option<bool>,
+}
+
+impl WinterPhotometry {
+    fn to_photometry_mag(&self) -> PhotometryMag {
+        PhotometryMag {
+            time: self.time,
+            mag: self.mag,
+            mag_err: self.mag_err,
+            band: self.band.clone(),
+        }
+    }
 }
 
 /// WINTER alert structure used to deserialize alerts from the database, used by
@@ -65,7 +93,7 @@ pub struct WinterAlertForEnrichment {
     #[serde(rename = "objectId")]
     pub object_id: String,
     pub candidate: WinterCandidate,
-    pub prv_candidates: Vec<PhotometryMag>,
+    pub prv_candidates: Vec<WinterPhotometry>,
 }
 
 /// WINTER alert properties computed during enrichment and inserted back into the
@@ -74,6 +102,10 @@ pub struct WinterAlertForEnrichment {
 pub struct WinterAlertProperties {
     pub stationary: bool,
     pub photstats: PerBandProperties,
+    /// Per-object detection-history summary for history-aware filters.
+    /// `None` on alerts enriched before this field existed.
+    #[serde(default)]
+    pub detection_history: Option<DetectionHistory>,
 }
 
 pub struct WinterEnrichmentWorker {
@@ -183,14 +215,28 @@ impl WinterEnrichmentWorker {
         &self,
         alert: &WinterAlertForEnrichment,
     ) -> Result<WinterAlertProperties, EnrichmentWorkerError> {
-        let mut lightcurve = alert.prv_candidates.clone();
+        let mut lightcurve: Vec<PhotometryMag> = alert
+            .prv_candidates
+            .iter()
+            .map(WinterPhotometry::to_photometry_mag)
+            .collect();
 
         prepare_photometry(&mut lightcurve);
         let (photstats, _, stationary) = analyze_photometry(&lightcurve);
 
+        // Per-object detection history for history-aware filters (sign from isdiffpos).
+        let detection_history = DetectionHistory::from_points(
+            alert
+                .prv_candidates
+                .iter()
+                .map(|p| (p.time, p.isdiffpos.map(|d| !d))),
+            alert.candidate.jd,
+        );
+
         Ok(WinterAlertProperties {
             stationary,
             photstats,
+            detection_history: Some(detection_history),
         })
     }
 }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -10,8 +10,8 @@ use crate::utils::cutouts::{AlertCutout, CutoutStorage};
 use crate::utils::db::mongify;
 use crate::utils::enums::Survey;
 use crate::utils::lightcurves::{
-    analyze_photometry, prepare_photometry, ActivityMetrics, AllBandsProperties, Band, Outburst,
-    PerBandProperties, PhotometryMag, ZTF_ZP,
+    analyze_photometry, prepare_photometry, ActivityMetrics, AllBandsProperties, Band,
+    DetectionHistory, Outburst, PerBandProperties, PhotometryMag, ZTF_ZP,
 };
 use crate::utils::mpcorb::{elements_from_document, normalize_ztf_ssnamenr, ORBITS_COLLECTION};
 use crate::utils::outburst::{Point, MAX_SEPARATION_ARCSEC};
@@ -542,6 +542,11 @@ pub struct ZtfAlertProperties {
     /// `None` on alerts enriched before this existed.
     #[serde(default)]
     pub activity: Option<ActivityMetrics>,
+    /// Per-object detection-history summary for history-aware filters (pos/neg
+    /// detection counts, first/last negative epoch, rolling 30-day counts).
+    /// `None` on alerts enriched before this field existed.
+    #[serde(default)]
+    pub detection_history: Option<DetectionHistory>,
 }
 
 /// ZTF alert ML classifier scores
@@ -1259,6 +1264,16 @@ impl ZtfEnrichmentWorker {
             photstats.clone()
         };
 
+        // Per-object detection history for history-aware filters, from the full
+        // accumulated light curve (positive/negative by psfFlux sign).
+        let detection_history = DetectionHistory::from_points(
+            alert
+                .prv_candidates
+                .iter()
+                .map(|p| (p.jd, p.flux.filter(|f| !f.is_nan()).map(|f| f < 0.0))),
+            candidate.jd,
+        );
+
         Ok((
             ZtfAlertProperties {
                 rock: is_rock,
@@ -1269,6 +1284,7 @@ impl ZtfEnrichmentWorker {
                 multisurvey_photstats: Some(multisurvey_photstats),
                 sso: Some(sso),
                 activity: Some(activity),
+                detection_history: Some(detection_history),
             },
             all_bands_properties,
             programid,
@@ -1591,6 +1607,10 @@ mod tests {
         assert!(
             props.sso.is_none(),
             "absent means never evaluated, not evaluated-and-negative"
+        );
+        assert!(
+            props.detection_history.is_none(),
+            "detection_history is absent on pre-existing alerts"
         );
     }
 

--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -439,6 +439,74 @@ impl ActivityMetrics {
     }
 }
 
+/// Per-object detection-history summary, computed at enrichment from the object's
+/// accumulated light curve and written onto every alert so filters can make
+/// history-aware cuts (e.g. "steady star that just started going negative") with a
+/// plain `$match`. BOOM filter pipelines are strictly per-alert and reject
+/// `$group`/`$unwind`/`$lookup`, so the history has to be precomputed here.
+///
+/// Each survey feeds `(jd, is_negative)` points from its own light curve — sign
+/// from the psfFlux sign (ZTF/LSST), `isdiffpos` (WINTER), or the signed SNR
+/// (DECam). Windows are measured back from the alert epoch, keeping the values
+/// deterministic per alert rather than dependent on wall-clock time at enrichment.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize, AvroSchema, ToSchema)]
+#[serde(default)]
+pub struct DetectionHistory {
+    /// Detections with a known sign in the object's history (`n_pos + n_neg`).
+    pub n_det: i32,
+    /// Positive-difference detections (source brighter than the reference).
+    pub n_pos: i32,
+    /// Negative-difference detections (source fainter than the reference).
+    pub n_neg: i32,
+    /// JD of the object's first-ever negative detection; `None` if it has none.
+    pub first_neg_jd: Option<f64>,
+    /// JD of the object's most recent negative detection; `None` if it has none.
+    pub last_neg_jd: Option<f64>,
+    /// Positive detections in the 30 days ending at the alert epoch.
+    pub n_pos_30d: i32,
+    /// Negative detections in the 30 days ending at the alert epoch.
+    pub n_neg_30d: i32,
+}
+
+impl DetectionHistory {
+    /// Summarise detection history from `(jd, is_negative)` points, with windows
+    /// measured back from the alert epoch `ref_jd`. Points after `ref_jd` (a
+    /// concurrently-ingested newer alert) and points whose sign is unknown (`None`,
+    /// e.g. pre-migration) are skipped, so `n_det == n_pos + n_neg`.
+    pub fn from_points<I>(points: I, ref_jd: f64) -> Self
+    where
+        I: IntoIterator<Item = (f64, Option<bool>)>,
+    {
+        let cutoff = ref_jd - 30.0;
+        let mut h = DetectionHistory::default();
+        for (jd, is_negative) in points {
+            if jd > ref_jd {
+                continue;
+            }
+            let is_negative = match is_negative {
+                Some(v) => v,
+                None => continue,
+            };
+            h.n_det += 1;
+            let recent = jd >= cutoff;
+            if is_negative {
+                h.n_neg += 1;
+                if recent {
+                    h.n_neg_30d += 1;
+                }
+                h.first_neg_jd = Some(h.first_neg_jd.map_or(jd, |j| j.min(jd)));
+                h.last_neg_jd = Some(h.last_neg_jd.map_or(jd, |j| j.max(jd)));
+            } else {
+                h.n_pos += 1;
+                if recent {
+                    h.n_pos_30d += 1;
+                }
+            }
+        }
+        h
+    }
+}
+
 // TODO: avro serialization fail when we use skip_serializing_none,
 // since the optional fields are not just None but simply missing
 // (this needs to be fixed in the apache_avro-related crates)
@@ -727,6 +795,42 @@ pub fn analyze_photometry(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // pos/neg counts, first/last-neg epochs, and the 30-day windows measured back
+    // from the alert epoch. A point after the epoch (concurrent newer alert) and a
+    // sign-unknown point (`None`) are both excluded, so n_det == n_pos + n_neg.
+    #[test]
+    fn test_detection_history_counts_and_windows() {
+        let ref_jd = 2_461_300.0;
+        let points = vec![
+            (ref_jd - 200.0, Some(false)), // old positive
+            (ref_jd - 100.0, Some(true)),  // old negative (first neg)
+            (ref_jd - 20.0, Some(false)),  // recent positive
+            (ref_jd - 10.0, Some(true)),   // recent negative
+            (ref_jd - 2.0, Some(true)),    // recent negative (last neg)
+            (ref_jd - 5.0, None),          // unknown sign -> skipped
+            (ref_jd + 5.0, Some(true)),    // after epoch -> skipped
+        ];
+
+        let h = DetectionHistory::from_points(points, ref_jd);
+        assert_eq!(h.n_det, 5);
+        assert_eq!(h.n_pos, 2);
+        assert_eq!(h.n_neg, 3);
+        assert_eq!(h.first_neg_jd, Some(ref_jd - 100.0));
+        assert_eq!(h.last_neg_jd, Some(ref_jd - 2.0));
+        assert_eq!(h.n_pos_30d, 1);
+        assert_eq!(h.n_neg_30d, 2);
+    }
+
+    #[test]
+    fn test_detection_history_empty_when_never_negative() {
+        let ref_jd = 2_461_300.0;
+        let h = DetectionHistory::from_points(vec![(ref_jd - 3.0, Some(false))], ref_jd);
+        assert_eq!(h.n_pos, 1);
+        assert_eq!(h.n_neg, 0);
+        assert!(h.first_neg_jd.is_none());
+        assert!(h.last_neg_jd.is_none());
+    }
 
     #[test]
     fn test_flux2mag() {

--- a/tests/test_babamul.rs
+++ b/tests/test_babamul.rs
@@ -190,6 +190,7 @@ fn create_mock_enriched_ztf_alert(candid: i64, object_id: &str, is_rock: bool) -
                 is_rock.then_some(18.1),
             )),
             activity: None,
+            detection_history: None,
         },
         survey_matches: BabamulSurveyMatches::default(),
     }


### PR DESCRIPTION
This PR enriches alerts with per-object detection_history for history-aware filters.