### PR TITLE
fit the recent light curve

### DIFF
--- a/src/utils/lightcurves.rs
+++ b/src/utils/lightcurves.rs
@@ -96,6 +96,92 @@ pub struct BandRateProperties {
     pub dt: f32,
 }
 
+/// Window, in days before the object's latest detection, that `recent` covers.
+///
+/// The unbounded fit spans the whole light curve -- a median of ~1400 days in
+/// production -- so its rate describes a line drawn across years rather than
+/// what the object is doing now. Measured against real cadence, 7, 30 and 60 day
+/// windows all yield a fittable band for about a tenth of alerts, so the exact
+/// value matters far less than having a bound at all.
+pub const RECENT_WINDOW_DAYS: f64 = 30.0;
+
+/// Fit one monotonic segment, returning `None` when it cannot support a line.
+///
+/// Rejects a segment whose spread sits inside its own error bars: a fit through
+/// noise produces a confident-looking rate that means nothing.
+fn fit_segment(segment: &[&PhotometryMag]) -> Option<BandRateProperties> {
+    if segment.len() < 2 {
+        return None;
+    }
+    let t0 = segment[0].time;
+    if segment.last()?.time - t0 <= 0.01 {
+        return None;
+    }
+
+    let mut time = Vec::with_capacity(segment.len());
+    let mut mag = Vec::with_capacity(segment.len());
+    let mut mag_err = Vec::with_capacity(segment.len());
+    let (mut min_mag, mut min_mag_err) = (f32::INFINITY, f32::INFINITY);
+    let (mut max_mag, mut max_mag_err) = (f32::NEG_INFINITY, f32::NEG_INFINITY);
+
+    for m in segment {
+        time.push((m.time - t0) as f32);
+        mag.push(m.mag);
+        mag_err.push(m.mag_err);
+        if m.mag < min_mag {
+            min_mag = m.mag;
+            min_mag_err = m.mag_err;
+        }
+        if m.mag > max_mag {
+            max_mag = m.mag;
+            max_mag_err = m.mag_err;
+        }
+    }
+
+    if min_mag + min_mag_err >= max_mag - max_mag_err {
+        return None;
+    }
+    weighted_least_squares_centered(&time, &mag, &mag_err)
+}
+
+/// Index of the brightest (numerically smallest magnitude) point.
+fn brightest_index(mags: &[&PhotometryMag]) -> Option<usize> {
+    (!mags.is_empty()).then(|| {
+        mags.iter().enumerate().fold(
+            0,
+            |best, (i, m)| if m.mag < mags[best].mag { i } else { best },
+        )
+    })
+}
+
+/// Split a band's points at its brightest and fit each side.
+fn fit_rising_and_fading(
+    mags: &[&PhotometryMag],
+) -> (Option<BandRateProperties>, Option<BandRateProperties>) {
+    let Some(peak) = brightest_index(mags) else {
+        return (None, None);
+    };
+    (fit_segment(&mags[0..=peak]), fit_segment(&mags[peak..]))
+}
+
+/// Fits over the last [`RECENT_WINDOW_DAYS`] only.
+///
+/// Present whenever the window holds any detection, so "no recent data" (null)
+/// stays distinguishable from "recent data that cannot be fit" (present, with
+/// `rising` and `fading` null). Most objects in the alert stream are sampled too
+/// sparsely for a windowed fit; that is a fact about the cadence, and reporting
+/// it as absent is the honest outcome rather than a defect.
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, AvroSchema, ToSchema)]
+pub struct RecentProperties {
+    /// Width of the window in days, so a consumer need not assume the constant.
+    pub window_days: f32,
+    /// Detections inside the window.
+    pub nb_data: i32,
+    pub peak_jd: f64,
+    pub peak_mag: f32,
+    pub rising: Option<BandRateProperties>,
+    pub fading: Option<BandRateProperties>,
+}
 // TODO: avro serialization fail when we use skip_serializing_none,
 // since the optional fields are not just None but simply missing
 // (this needs to be fixed in the apache_avro-related crates)
@@ -107,8 +193,14 @@ pub struct BandProperties {
     pub peak_mag: f32,
     pub peak_mag_err: f32,
     pub dt: f32,
+    /// Fits over the whole light curve. The window is unbounded, so on an object
+    /// with years of history these describe a line across all of it rather than
+    /// current behaviour -- see `recent` for that.
     pub rising: Option<BandRateProperties>,
     pub fading: Option<BandRateProperties>,
+    /// The same fits restricted to the last [`RECENT_WINDOW_DAYS`], or null when
+    /// the window holds no detection in this band.
+    pub recent: Option<RecentProperties>,
 }
 
 /// Morphological indicators of cometary activity, computed per survey but expressed
@@ -407,92 +499,26 @@ pub fn analyze_photometry(
             global_faintest_band = band.clone();
         }
 
-        let mut rising_properties = None;
-        let mut fading_properties = None;
-
-        // before is from 0 to peak_index inclusive, after is from peak_index inclusive to the end
-        let before = &mags[0..=peak_index];
-        let after = &mags[peak_index..];
-
-        // if there isn't enough time separation between the first and last point, we cannot do a linear fit
-        // so we will just return empty arrays
-        if before.len() > 1 && before.last().unwrap().time - before.first().unwrap().time > 0.01 {
-            let mut before_time = Vec::new();
-            let mut before_mag = Vec::new();
-            let mut before_mag_err = Vec::new();
-            let mut min_mag = f32::INFINITY;
-            let mut min_mag_err = f32::INFINITY;
-            let mut max_mag = f32::NEG_INFINITY;
-            let mut max_mag_err = f32::NEG_INFINITY;
-
-            // get the min time for the before and after segments
-            let before_min_time = before[0].time;
-
-            for m in before {
-                before_time.push((m.time - before_min_time) as f32);
-                before_mag.push(m.mag);
-                before_mag_err.push(m.mag_err);
-                if m.mag < min_mag {
-                    min_mag = m.mag;
-                    min_mag_err = m.mag_err;
-                }
-                if m.mag > max_mag {
-                    max_mag = m.mag;
-                    max_mag_err = m.mag_err;
-                }
-            }
-            // if min_mag + min_mag_err >= max_mag - max_mag_err, then we cannot do a linear fit
-            // as the data is just within the noise
-            // so when that happens, empty the before arrays
-            if min_mag + min_mag_err >= max_mag - max_mag_err {
-                before_time.clear();
-                before_mag.clear();
-                before_mag_err.clear();
-            }
-
-            rising_properties =
-                weighted_least_squares_centered(&before_time, &before_mag, &before_mag_err);
-        }
-
-        // same for after
-        if after.len() > 1 && after.last().unwrap().time - after.first().unwrap().time > 0.01 {
-            let mut after_time = Vec::new();
-            let mut after_mag = Vec::new();
-            let mut after_mag_err = Vec::new();
-            let mut min_mag = f32::INFINITY;
-            let mut min_mag_err = f32::INFINITY;
-            let mut max_mag = f32::NEG_INFINITY;
-            let mut max_mag_err = f32::NEG_INFINITY;
-
-            let after_min_time = after[0].time;
-
-            for m in after {
-                after_time.push((m.time - after_min_time) as f32);
-                after_mag.push(m.mag);
-                after_mag_err.push(m.mag_err);
-                if m.mag < min_mag {
-                    min_mag = m.mag;
-                    min_mag_err = m.mag_err;
-                }
-                if m.mag > max_mag {
-                    max_mag = m.mag;
-                    max_mag_err = m.mag_err;
-                }
-            }
-            // if min_mag + min_mag_err >= max_mag - max_mag_err, then we cannot do a linear fit
-            // as the data is just within the noise
-            // so when that happens, empty the after arrays
-            if min_mag + min_mag_err >= max_mag - max_mag_err {
-                after_time.clear();
-                after_mag.clear();
-                after_mag_err.clear();
-            }
-
-            fading_properties =
-                weighted_least_squares_centered(&after_time, &after_mag, &after_mag_err);
-        }
-
         let dt = (mags.last().unwrap().time - mags.first().unwrap().time) as f32;
+        let (rising_properties, fading_properties) = fit_rising_and_fading(&mags);
+
+        // Anchored to the object's newest detection in any band, so every band
+        // covers the same interval and a colour comparison stays meaningful.
+        let cutoff = last_jd - RECENT_WINDOW_DAYS;
+        let window: Vec<&PhotometryMag> =
+            mags.iter().copied().filter(|m| m.time >= cutoff).collect();
+        let recent = brightest_index(&window).map(|peak| {
+            let (rising, fading) = fit_rising_and_fading(&window);
+            RecentProperties {
+                window_days: RECENT_WINDOW_DAYS as f32,
+                nb_data: window.len() as i32,
+                peak_jd: window[peak].time,
+                peak_mag: window[peak].mag,
+                rising,
+                fading,
+            }
+        });
+
         let band_properties = BandProperties {
             peak_jd,
             peak_mag,
@@ -500,6 +526,7 @@ pub fn analyze_photometry(
             dt,
             rising: rising_properties,
             fading: fading_properties,
+            recent,
         };
         match band {
             Band::G => results.g = Some(band_properties),
@@ -1161,5 +1188,182 @@ mod activity_tests {
     fn test_missing_magnitudes_yield_no_measurement() {
         let a = ActivityMetrics::from_magnitudes(Some(18.0), None);
         assert!(a.aperture_excess.is_none());
+    }
+}
+
+#[cfg(test)]
+mod recent_window_tests {
+    use super::*;
+
+    fn point(time: f64, mag: f32, band: Band) -> PhotometryMag {
+        PhotometryMag {
+            time,
+            mag,
+            mag_err: 0.05,
+            band,
+        }
+    }
+
+    /// Years of flat history, then a genuine rise in the last few days. This is
+    /// the case the unbounded fit gets wrong: it averages the real rise into a
+    /// baseline stretching back years and reports a rate near zero.
+    fn old_history_then_a_rise() -> Vec<PhotometryMag> {
+        let mut lc = Vec::new();
+        let mut t = 2_459_000.0;
+        while t < 2_459_000.0 + 1200.0 {
+            lc.push(point(t, 20.0, Band::G));
+            t += 20.0;
+        }
+        let last = 2_459_000.0 + 1200.0;
+        for (i, mag) in [19.5_f32, 19.0, 18.4, 17.9].iter().enumerate() {
+            lc.push(point(last + 2.0 * i as f64, *mag, Band::G));
+        }
+        lc.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
+        lc
+    }
+
+    #[test]
+    fn test_recent_rate_is_steeper_than_the_whole_history_rate() {
+        let (props, _, _) = analyze_photometry(&old_history_then_a_rise());
+        let g = props.g.expect("g band");
+
+        let whole = g.rising.expect("unbounded rising fit").rate;
+        let recent = g
+            .recent
+            .as_ref()
+            .expect("recent block")
+            .rising
+            .as_ref()
+            .expect("recent rising fit")
+            .rate;
+
+        // Magnitudes fall as the object brightens, so a rise is a negative rate.
+        assert!(
+            recent < whole,
+            "recent rate {recent} should be steeper than whole-history {whole}"
+        );
+        assert!(
+            recent.abs() > 10.0 * whole.abs(),
+            "the whole-history rate is diluted by the baseline: {whole} vs {recent}"
+        );
+    }
+
+    #[test]
+    fn test_recent_window_only_covers_the_configured_span() {
+        let (props, _, _) = analyze_photometry(&old_history_then_a_rise());
+        let recent = props.g.unwrap().recent.expect("recent block");
+        assert_eq!(recent.window_days, RECENT_WINDOW_DAYS as f32);
+        // 4 points in the burst plus the couple of baseline points inside 30 d.
+        assert!(
+            recent.nb_data >= 4 && recent.nb_data <= 8,
+            "got {}",
+            recent.nb_data
+        );
+    }
+
+    /// Absence has to mean "no recent data", distinct from "recent data that
+    /// cannot be fit" -- which is present with null fits.
+    #[test]
+    fn test_single_recent_point_reports_the_block_without_a_fit() {
+        let lc = vec![
+            point(2_459_000.0, 20.0, Band::G),
+            point(2_459_400.0, 19.0, Band::G),
+        ];
+        let (props, _, _) = analyze_photometry(&lc);
+        let recent = props
+            .g
+            .unwrap()
+            .recent
+            .expect("window holds the last point");
+        assert_eq!(recent.nb_data, 1);
+        assert!(recent.rising.is_none());
+        assert!(recent.fading.is_none());
+    }
+
+    /// A band with nothing in the window gets no block at all, rather than a
+    /// block full of nulls that reads as a failed fit.
+    #[test]
+    fn test_band_with_no_recent_detection_has_no_block() {
+        let lc = vec![
+            point(2_459_000.0, 20.0, Band::R),
+            point(2_459_002.0, 19.5, Band::R),
+            point(2_459_400.0, 19.0, Band::G),
+        ];
+        let (props, _, _) = analyze_photometry(&lc);
+        assert!(
+            props.r.unwrap().recent.is_none(),
+            "r band last seen 400 d ago, well outside the window"
+        );
+        assert!(props.g.unwrap().recent.is_some());
+    }
+
+    /// The window is anchored to the newest detection in any band, so bands
+    /// stay directly comparable.
+    #[test]
+    fn test_window_is_shared_across_bands() {
+        let lc = vec![
+            point(2_459_400.0, 19.0, Band::G),
+            point(2_459_405.0, 18.5, Band::G),
+            point(2_459_402.0, 19.2, Band::R),
+            point(2_459_404.0, 18.9, Band::R),
+        ];
+        let (props, _, _) = analyze_photometry(&lc);
+        let g = props.g.unwrap().recent.expect("g recent");
+        let r = props.r.unwrap().recent.expect("r recent");
+        assert_eq!(g.window_days, r.window_days);
+        assert_eq!(g.nb_data, 2);
+        assert_eq!(r.nb_data, 2);
+    }
+}
+
+#[cfg(test)]
+mod recent_avro_tests {
+    use super::*;
+    use crate::utils::derive_avro_schema::SerdavroWriter;
+    use apache_avro::{AvroSchema, Writer};
+
+    /// These reach Babamul through `append_serdavro`, which resolves every field
+    /// the schema declares by name, so a nested optional that serializes as
+    /// missing rather than null fails there while BSON stays happy. Cover both
+    /// a populated and an absent `recent` block.
+    #[test]
+    fn test_recent_block_serializes_through_the_babamul_path() {
+        let schema = PerBandProperties::get_schema();
+        let band = weighted_least_squares_centered(
+            &[0.0, 1.0, 2.0],
+            &[20.0, 19.5, 19.0],
+            &[0.05, 0.05, 0.05],
+        );
+        for (label, recent) in [
+            ("recent absent", None),
+            (
+                "recent populated",
+                Some(RecentProperties {
+                    window_days: RECENT_WINDOW_DAYS as f32,
+                    nb_data: 3,
+                    peak_jd: 2_460_000.0,
+                    peak_mag: 19.0,
+                    rising: band.clone(),
+                    fading: None,
+                }),
+            ),
+        ] {
+            let props = PerBandProperties {
+                g: Some(BandProperties {
+                    peak_jd: 2_460_000.0,
+                    peak_mag: 19.0,
+                    peak_mag_err: 0.05,
+                    dt: 2.0,
+                    rising: band.clone(),
+                    fading: None,
+                    recent,
+                }),
+                ..Default::default()
+            };
+            let mut writer = Writer::new(&schema, Vec::new());
+            writer
+                .append_serdavro(&props)
+                .unwrap_or_else(|e| panic!("{label} failed to serialize to avro: {e}"));
+        }
     }
 }


### PR DESCRIPTION
This PR adds a "recent" block covering features in the last 30 days (came up in a discussion where folks were trying to make sense of the linear fits over much longer time scales).