### PR TITLE
add lsdr10 and ps1_dr2 catalogs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -283,14 +283,14 @@ crossmatch:
         z_phot_err: 1
         photo_z_type: 1
     - catalog: PS1_DR2
-      radius: 2.0 
+      radius: 2.0
       use_distance: false
       projection:
         _id: 1
         ra: 1
         dec: 1
-    - catalog: lsdr10 
-      radius: 30.0 
+    - catalog: lsdr10
+      radius: 30.0
       use_distance: false
       projection:
         _id: 1

--- a/config.yaml
+++ b/config.yaml
@@ -282,6 +282,20 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0 
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+    - catalog: lsdr10 
+      radius: 30.0 
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0 # 30 arcseconds
@@ -354,6 +368,20 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
   decam: []
   winter:
     - catalog: Gaia_DR3
@@ -449,3 +477,17 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1

--- a/config.yaml
+++ b/config.yaml
@@ -333,6 +333,9 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0 # 30 arcseconds
@@ -456,6 +459,9 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   decam: []
   winter:
     - catalog: Gaia_DR3
@@ -602,3 +608,6 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1

--- a/config.yaml
+++ b/config.yaml
@@ -287,8 +287,25 @@ crossmatch:
       use_distance: false
       projection:
         _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
         ra: 1
         dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
       use_distance: false
@@ -296,6 +313,26 @@ crossmatch:
         _id: 1
         ra: 1
         dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0 # 30 arcseconds
@@ -373,8 +410,25 @@ crossmatch:
       use_distance: false
       projection:
         _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
         ra: 1
         dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
       use_distance: false
@@ -382,6 +436,26 @@ crossmatch:
         _id: 1
         ra: 1
         dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
   decam: []
   winter:
     - catalog: Gaia_DR3
@@ -482,8 +556,25 @@ crossmatch:
       use_distance: false
       projection:
         _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
         ra: 1
         dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
       use_distance: false
@@ -491,3 +582,23 @@ crossmatch:
         _id: 1
         ra: 1
         dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1

--- a/config.yaml
+++ b/config.yaml
@@ -309,6 +309,9 @@ crossmatch:
     - catalog: lsdr10
       radius: 30.0
       use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1
@@ -435,6 +438,9 @@ crossmatch:
     - catalog: lsdr10
       radius: 30.0
       use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1
@@ -584,6 +590,9 @@ crossmatch:
     - catalog: lsdr10
       radius: 30.0
       use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1

--- a/config.yaml
+++ b/config.yaml
@@ -267,21 +267,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -306,7 +291,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"
@@ -396,21 +381,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -435,7 +405,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"
@@ -548,21 +518,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -587,7 +542,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"

--- a/config.yaml
+++ b/config.yaml
@@ -308,7 +308,7 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
       projection:
         _id: 1
         ra: 1
@@ -434,7 +434,7 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
       projection:
         _id: 1
         ra: 1
@@ -583,7 +583,7 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
       projection:
         _id: 1
         ra: 1

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -369,6 +369,57 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0
@@ -559,6 +610,57 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
   decam: []
   winter:
     - catalog: Gaia_DR3
@@ -654,3 +756,54 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -354,21 +354,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -393,7 +378,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"
@@ -601,21 +586,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -640,7 +610,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"
@@ -753,21 +723,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -792,7 +747,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -395,7 +395,10 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1
@@ -639,7 +642,10 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1
@@ -788,7 +794,10 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -420,6 +420,9 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0
@@ -661,6 +664,9 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   decam: []
   winter:
     - catalog: Gaia_DR3
@@ -807,3 +813,6 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1

--- a/config/prod/caltech/overrides.yaml
+++ b/config/prod/caltech/overrides.yaml
@@ -229,8 +229,25 @@ crossmatch:
       use_distance: false
       projection:
         _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
         ra: 1
         dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
       use_distance: false
@@ -238,6 +255,26 @@ crossmatch:
         _id: 1
         ra: 1
         dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
   ztf:
     - catalog: Gaia_DR3
       radius: 2.0
@@ -423,8 +460,25 @@ crossmatch:
       use_distance: false
       projection:
         _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
         ra: 1
         dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
       use_distance: false
@@ -432,3 +486,23 @@ crossmatch:
         _id: 1
         ra: 1
         dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1

--- a/config/prod/caltech/overrides.yaml
+++ b/config/prod/caltech/overrides.yaml
@@ -224,6 +224,20 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
   ztf:
     - catalog: Gaia_DR3
       radius: 2.0
@@ -404,3 +418,17 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1

--- a/config/prod/caltech/overrides.yaml
+++ b/config/prod/caltech/overrides.yaml
@@ -250,7 +250,7 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
       projection:
         _id: 1
         ra: 1
@@ -484,7 +484,7 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
       projection:
         _id: 1
         ra: 1

--- a/config/prod/caltech/overrides.yaml
+++ b/config/prod/caltech/overrides.yaml
@@ -209,21 +209,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -248,7 +233,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"
@@ -446,21 +431,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -485,7 +455,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"

--- a/config/prod/caltech/overrides.yaml
+++ b/config/prod/caltech/overrides.yaml
@@ -275,6 +275,9 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   ztf:
     - catalog: Gaia_DR3
       radius: 2.0
@@ -506,3 +509,6 @@ crossmatch:
         shape_r: 1
         shape_e1: 1
         shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1

--- a/config/prod/caltech/overrides.yaml
+++ b/config/prod/caltech/overrides.yaml
@@ -251,6 +251,9 @@ crossmatch:
     - catalog: lsdr10
       radius: 30.0
       use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1
@@ -485,6 +488,9 @@ crossmatch:
     - catalog: lsdr10
       radius: 30.0
       use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -359,21 +359,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: watchlist_supernovas
       radius: 2.0
       use_distance: false
@@ -384,6 +369,39 @@ crossmatch:
         redshift: 1
         distance_mpc: 1
         discovery_date: 1
+    - catalog: LSDR10
+      radius: 30.0
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0
@@ -553,21 +571,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: watchlist_supernovas
       radius: 2.0
       use_distance: false
@@ -578,6 +581,39 @@ crossmatch:
         redshift: 1
         distance_mpc: 1
         discovery_date: 1
+    - catalog: LSDR10
+      radius: 30.0
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   decam: []
   winter:
     - catalog: Gaia_DR3
@@ -658,21 +694,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0 # 30 arcseconds
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: PS1_DR2
       radius: 2.0
       use_distance: false
@@ -697,7 +718,7 @@ crossmatch:
         strm_uid: 1
         strm_z_phot: 1
         strm_z_phot_err: 1
-    - catalog: lsdr10
+    - catalog: LSDR10
       radius: 30.0
       use_distance: true
       distance_key: "z_phot_mean"

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -699,7 +699,10 @@ crossmatch:
         strm_z_phot_err: 1
     - catalog: lsdr10
       radius: 30.0
-      use_distance: false
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
       projection:
         _id: 1
         ra: 1

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -673,3 +673,57 @@ crossmatch:
         z_phot: 1
         z_phot_err: 1
         photo_z_type: 1
+    - catalog: PS1_DR2
+      radius: 2.0
+      use_distance: false
+      projection:
+        _id: 1
+        gMeanPSFMag: 1
+        gMeanPSFMagErr: 1
+        rMeanPSFMag: 1
+        rMeanPSFMagErr: 1
+        iMeanPSFMag: 1
+        iMeanPSFMagErr: 1
+        zMeanPSFMag: 1
+        zMeanPSFMagErr: 1
+        yMeanPSFMag: 1
+        yMeanPSFMagErr: 1
+        ra: 1
+        dec: 1
+        strm_class: 1
+        strm_prob_galaxy: 1
+        strm_prob_qso: 1
+        strm_prob_star: 1
+        strm_uid: 1
+        strm_z_phot: 1
+        strm_z_phot_err: 1
+    - catalog: lsdr10
+      radius: 30.0
+      use_distance: false
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1

--- a/config/prod/umn/overrides.yaml
+++ b/config/prod/umn/overrides.yaml
@@ -196,21 +196,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: watchlist_supernovas
       radius: 2.0
       use_distance: false
@@ -221,6 +206,39 @@ crossmatch:
         redshift: 1
         distance_mpc: 1
         discovery_date: 1
+    - catalog: LSDR10
+      radius: 30.0
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1
   lsst:
     - catalog: LSPSC
       radius: 30.0
@@ -390,21 +408,6 @@ crossmatch:
         deltachi2: 1
         spectype: 1
         zcat_nspec: 1
-    - catalog: LS_DR10_PHOTOZ
-      radius: 30.0
-      use_distance: true
-      distance_key: "z_phot"
-      distance_max: 60.0
-      distance_max_near: 300.0
-      projection:
-        _id: 1
-        ra: 1
-        dec: 1
-        ra_err: 1
-        dec_err: 1
-        z_phot: 1
-        z_phot_err: 1
-        photo_z_type: 1
     - catalog: watchlist_supernovas
       radius: 2.0
       use_distance: false
@@ -415,3 +418,36 @@ crossmatch:
         redshift: 1
         distance_mpc: 1
         discovery_date: 1
+    - catalog: LSDR10
+      radius: 30.0
+      use_distance: true
+      distance_key: "z_phot_mean"
+      distance_max: 60.0
+      distance_max_near: 300.0
+      projection:
+        _id: 1
+        ra: 1
+        dec: 1
+        objtype: 1
+        ebv: 1
+        z_spec: 1
+        survey: 1
+        z_phot_mean: 1
+        z_phot_median: 1
+        z_phot_std: 1
+        z_phot_l95: 1
+        z_phot_u95: 1
+        flux_g: 1
+        flux_r: 1
+        flux_i: 1
+        flux_z: 1
+        flux_w1: 1
+        flux_w2: 1
+        flux_w3: 1
+        flux_w4: 1
+        shape_r: 1
+        shape_e1: 1
+        shape_e2: 1
+        sersic: 1
+        flux_ivar_r: 1
+        fracflux_r: 1


### PR DESCRIPTION
This pull request updates the crossmatch configuration to include two new catalogs, `PS1_DR2` and `lsdr10`, across multiple survey sections in both `config.yaml` and `config/prod/caltech/overrides.yaml`. These additions specify matching parameters and projection fields for each catalog, enabling their use in crossmatching operations.

**Catalog Integration Updates:**

* Added `PS1_DR2` and `lsdr10` as crossmatch catalogs with specified `radius`, `use_distance`, and `projection` fields to several survey sections in `config.yaml` (`crossmatch:`)
* Added `PS1_DR2` and `lsdr10` with matching parameters and projection fields to relevant survey sections in `config/prod/caltech/overrides.yaml` (`crossmatch:`)