### PR TITLE
host the NED throughput fixture on a GitHub release

### DIFF
--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Download NED catalog
         run: |
           mkdir -p ./data/alerts
-          wget -q https://github.com/boom-astro/boom/releases/download/test-data-v1/kowalski.NED.json.gz -O ./data/alerts/kowalski.NED.json.gz
+          wget -q https://github.com/boom-astro/boom/releases/download/test-data-v1/BOOM.NED.json.gz -O ./data/alerts/BOOM.NED.json.gz
       - name: Download auxiliary ZTF alerts from Caltech Box
         run: wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
       - name: Run test

--- a/.github/workflows/test-throughput.yaml
+++ b/.github/workflows/test-throughput.yaml
@@ -56,10 +56,10 @@ jobs:
           BUILDX_BAKE_ENTITLEMENTS_FS: 0
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
-      - name: Download NED catalog from Google Drive
+      - name: Download NED catalog
         run: |
           mkdir -p ./data/alerts
-          uvx gdown https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB -O ./data/alerts/kowalski.NED.json.gz
+          wget -q https://github.com/boom-astro/boom/releases/download/test-data-v1/kowalski.NED.json.gz -O ./data/alerts/kowalski.NED.json.gz
       - name: Download auxiliary ZTF alerts from Caltech Box
         run: wget -q https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.gz -O ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz
       - name: Run test

--- a/README.md
+++ b/README.md
@@ -507,7 +507,11 @@ curl -sL https://caltech.box.com/shared/static/qdois5qq2lmvp02ri50fum80vzr54505.
 
 Download the NED catalog for crossmatching.
 ```
-uvx gdown "https://drive.google.com/uc?id=1BG46oLMbONXhIqiPrepSnhKim1xfiVbB" -O ./data/alerts/kowalski.NED.json.gz
+wget -q https://github.com/boom-astro/boom/releases/download/test-data-v1/BOOM.NED.json.gz -O ./data/alerts/BOOM.NED.json.gz
+```
+**For macOS:**
+```
+curl -sL https://github.com/boom-astro/boom/releases/download/test-data-v1/BOOM.NED.json.gz -o ./data/alerts/BOOM.NED.json.gz
 ```
 
 ### Start Benchmark

--- a/tests/throughput/_run.sh
+++ b/tests/throughput/_run.sh
@@ -184,7 +184,7 @@ echo "$(current_datetime) - Kafka consumer started in $STARTUP_TIME seconds"
 # If we are in LOW_STORAGE mode, clean up the downloaded files (producer files are not mounted)
 if [ "${LOW_STORAGE:-}" = "true" ]; then
     echo "$(current_datetime) - LOW_STORAGE mode enabled; cleaning up downloaded files to save space"
-    rm -rf ./data/alerts/kowalski.NED.json.gz || true
+    rm -rf ./data/alerts/BOOM.NED.json.gz || true
     rm -rf ./data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz || true
 fi
 

--- a/tests/throughput/compose.yaml
+++ b/tests/throughput/compose.yaml
@@ -33,7 +33,7 @@ services:
       - boom
     volumes:
       - ${BOOM_REPO_ROOT:?Variable not set}/tests/throughput/mongo-init.sh:/mongo-init.sh
-      - ${PWD}/data/alerts/kowalski.NED.json.gz:/kowalski.NED.json.gz
+      - ${PWD}/data/alerts/BOOM.NED.json.gz:/BOOM.NED.json.gz
       - ${PWD}/data/alerts/boom_throughput.ZTF_alerts_aux.dump.gz:/boom_throughput.ZTF_alerts_aux.dump.gz
       - ${BOOM_REPO_ROOT:?Variable not set}/tests/throughput/cats150.filter.json:/cats150.filter.json
     environment:

--- a/tests/throughput/mongo-init.sh
+++ b/tests/throughput/mongo-init.sh
@@ -28,7 +28,7 @@ if [ "$NED_COLLECTION_EXISTS" = "false" ] || [ "${NED_COLLECTION_COUNT:-0}" -ne 
         --eval "db.$NED_COLLECTION_NAME.createIndex({ 'coordinates.radec_geojson': '2dsphere' })"
 
     echo "Importing NED alerts into $DB_NAME MongoDB database"
-    gunzip -kc /kowalski.NED.json.gz | \
+    gunzip -kc /BOOM.NED.json.gz | \
         mongoimport \
         "mongodb://mongoadmin:mongoadminsecret@mongo:27017/$DB_NAME?authSource=admin$DB_ADD_URI" \
         --collection $NED_COLLECTION_NAME \

--- a/tests/throughput/mongo-init.sh
+++ b/tests/throughput/mongo-init.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NED_EXPECTED_COUNT=1872544
+NED_EXPECTED_COUNT=2103732
 
 # Only import NED alerts if the collection does not exist or has the wrong count
 NED_COLLECTION_NAME="NED"


### PR DESCRIPTION
This PR moves to hosting the NED throughput fixture on a GitHub release.