### PR TITLE
Fix some clippy failed

### DIFF
--- a/src/bin/migrate_fp_flux.rs
+++ b/src/bin/migrate_fp_flux.rs
@@ -10,7 +10,7 @@ use mongodb::bson::{doc, Bson, Document};
 use tracing::{error, info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-const FLUXERR2MAGERR_FACTOR: f64 = 2.5_f64 / 2.30258509299_f64;
+const FLUXERR2MAGERR_FACTOR: f64 = 2.5_f64 / std::f64::consts::LN_10;
 
 /// Fixed zeropoint for ZTF forced photometry.
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1031,7 +1031,7 @@ impl AppConfig {
         }
 
         // Validate token expiration
-        if self.api.auth.token_expiration <= 0 {
+        if self.api.auth.token_expiration == 0 {
             return Err("Token expiration must be greater than 0 for security reasons".to_string());
         }
 

--- a/tests/test_kafka_auth.rs
+++ b/tests/test_kafka_auth.rs
@@ -32,14 +32,11 @@ async fn create_topic(cfg: &ClientConfig, topic: &str) -> Result<(), KafkaError>
         .create_topics(&[new_topic], &AdminOptions::new())
         .await?;
 
-    for result in results {
-        match result {
-            Ok(_) => return Ok(()),
-            Err((_topic_name, code)) => return Err(KafkaError::AdminOp(code)),
-        }
-    }
     // If the vector was empty (shouldn't happen), treat as success.
-    Ok(())
+    match results.into_iter().next() {
+        Some(Err((_topic_name, code))) => Err(KafkaError::AdminOp(code)),
+        Some(Ok(_)) | None => Ok(()),
+    }
 }
 
 fn make_base_cfg() -> ClientConfig {


### PR DESCRIPTION
Cargo clippy failed on three deny-by-default lints: a `<= 0` comparison on an unsigned integer, a hand-written ln(10), and a loop that always returns on its first iteration. None changes behavior, and the ln(10) literal was truncated, so the constant is if anything more precise.