### PR TITLE
Let config.gpu.enabled alone decide GPU inference

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -100,15 +100,8 @@ jobs:
       BOOM_API_RATE_LIMIT_AVERAGE: ${{ vars.BOOM_API_RATE_LIMIT_AVERAGE }}
       BOOM_API_RATE_LIMIT_BURST: ${{ vars.BOOM_API_RATE_LIMIT_BURST }}
       BOOM_API_RATE_LIMIT_PERIOD: ${{ vars.BOOM_API_RATE_LIMIT_PERIOD }}
-      # Set explicitly because the model loader (src/enrichment/models/base.rs)
-      # reads BOOM_GPU__ENABLED straight from the environment and DEFAULTS TO
-      # TRUE when unset; config.gpu.enabled does not gate it. Driven by the
-      # BOOM_GPU__ENABLED (true/false) and BOOM_GPU__DEVICE_IDS (e.g. "0,1")
-      # repository variables; no code change needed to flip it. Keep
-      # config/prod/<deployment>/config.yaml's gpu.enabled in sync so the
-      # scheduler's GPU-pool path agrees with the model loader.
-      # BOOM_GPU__ENABLED also drives the "Select GPU compose overlay" step
-      # below, which layers in docker-compose.cuda.yaml (CUDA image + device
+      # Overrides config.gpu.enabled, and drives the "Select GPU compose overlay"
+      # step below, which layers in docker-compose.cuda.yaml (CUDA image + device
       # passthrough); setting this var alone does nothing without that overlay.
       BOOM_GPU__ENABLED: ${{ vars.BOOM_GPU__ENABLED || 'false' }}
       BOOM_GPU__DEVICE_IDS: ${{ vars.BOOM_GPU__DEVICE_IDS || '0' }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -104,7 +104,7 @@ jobs:
       # step below, which layers in docker-compose.cuda.yaml (CUDA image + device
       # passthrough); setting this var alone does nothing without that overlay.
       BOOM_GPU__ENABLED: ${{ vars.BOOM_GPU__ENABLED || 'false' }}
-      BOOM_GPU__DEVICE_IDS: ${{ vars.BOOM_GPU__DEVICE_IDS || '0' }}
+      BOOM_GPU__DEVICE_IDS: ${{ vars.BOOM_GPU__DEVICE_IDS }}
     steps:
       - name: Require maintain/admin actor permissions
         uses: actions/github-script@v7

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -100,9 +100,7 @@ jobs:
       BOOM_API_RATE_LIMIT_AVERAGE: ${{ vars.BOOM_API_RATE_LIMIT_AVERAGE }}
       BOOM_API_RATE_LIMIT_BURST: ${{ vars.BOOM_API_RATE_LIMIT_BURST }}
       BOOM_API_RATE_LIMIT_PERIOD: ${{ vars.BOOM_API_RATE_LIMIT_PERIOD }}
-      # Overrides config.gpu.enabled, and drives the "Select GPU compose overlay"
-      # step below, which layers in docker-compose.cuda.yaml (CUDA image + device
-      # passthrough); setting this var alone does nothing without that overlay.
+      # Drives the "Select GPU compose overlay" step below; alone it does nothing.
       BOOM_GPU__ENABLED: ${{ vars.BOOM_GPU__ENABLED || 'false' }}
       BOOM_GPU__DEVICE_IDS: ${{ vars.BOOM_GPU__DEVICE_IDS }}
     steps:

--- a/config.yaml
+++ b/config.yaml
@@ -98,7 +98,8 @@ posthog:
 gpu:
   enabled: false # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.
-  # When false, models are loaded on CPU (BOOM_GPU__ENABLED env var is still respected).
+  # When false, models are loaded on CPU. Overwrite with BOOM_GPU__ENABLED, which
+  # also selects the CUDA image and device passthrough in the deployment scripts.
   device_ids: [0] # CUDA device(s) to use. E.g. [0,1,2,3,4,5,6,7] for 8 GPUs.
   # ONNX models are loaded on the first device. Additional devices are available
   # for the GPU pool (future lightcurve fitting).

--- a/config.yaml
+++ b/config.yaml
@@ -98,8 +98,7 @@ posthog:
 gpu:
   enabled: false # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.
-  # When false, models are loaded on CPU. Overwrite with BOOM_GPU__ENABLED, which
-  # also selects the CUDA image and device passthrough in the deployment scripts.
+  # When false, models are loaded on CPU. Overridden by BOOM_GPU__ENABLED.
   device_ids: [0] # CUDA device(s) to use. E.g. [0,1,2,3,4,5,6,7] for 8 GPUs.
   # ONNX models are loaded on the first device. Additional devices are available
   # for the GPU pool (future lightcurve fitting).

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -99,7 +99,8 @@ posthog:
 gpu:
   enabled: true # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.
-  # When false, models are loaded on CPU (BOOM_GPU__ENABLED env var is still respected).
+  # When false, models are loaded on CPU. Overwrite with BOOM_GPU__ENABLED, which
+  # also selects the CUDA image and device passthrough in the deployment scripts.
   device_ids: [0] # CUDA device(s) to use. E.g. [0,1,2,3,4,5,6,7] for 8 GPUs.
   # ONNX models are loaded on the first device. Additional devices are available
   # for the GPU pool (future lightcurve fitting).

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -99,8 +99,7 @@ posthog:
 gpu:
   enabled: true # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.
-  # When false, models are loaded on CPU. Overwrite with BOOM_GPU__ENABLED, which
-  # also selects the CUDA image and device passthrough in the deployment scripts.
+  # When false, models are loaded on CPU. Overridden by BOOM_GPU__ENABLED.
   device_ids: [0] # CUDA device(s) to use. E.g. [0,1,2,3,4,5,6,7] for 8 GPUs.
   # ONNX models are loaded on the first device. Additional devices are available
   # for the GPU pool (future lightcurve fitting).

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -99,8 +99,7 @@ posthog:
 gpu:
   enabled: true # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.
-  # When false, models are loaded on CPU. Overwrite with BOOM_GPU__ENABLED, which
-  # also selects the CUDA image and device passthrough in the deployment scripts.
+  # When false, models are loaded on CPU. Overridden by BOOM_GPU__ENABLED.
   device_ids: [0, 1, 2, 3] # CUDA device(s) to use. E.g. [0,1,2,3,4,5,6,7] for 8 GPUs.
   # ONNX models are loaded on the first device. Additional devices are available
   # for the GPU pool (future lightcurve fitting).

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -99,7 +99,8 @@ posthog:
 gpu:
   enabled: true # Set to true to load ONNX models on GPU (CUDA) instead of CPU.
   # Models are loaded once at startup and shared across all enrichment workers.
-  # When false, models are loaded on CPU (BOOM_GPU__ENABLED env var is still respected).
+  # When false, models are loaded on CPU. Overwrite with BOOM_GPU__ENABLED, which
+  # also selects the CUDA image and device passthrough in the deployment scripts.
   device_ids: [0, 1, 2, 3] # CUDA device(s) to use. E.g. [0,1,2,3,4,5,6,7] for 8 GPUs.
   # ONNX models are loaded on the first device. Additional devices are available
   # for the GPU pool (future lightcurve fitting).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -525,7 +525,7 @@ services:
       BOOM_BABAMUL__ENABLED: ${BOOM_BABAMUL__ENABLED:-false}
       BOOM_REDIS__HOST: valkey
       BOOM_GPU__ENABLED: ${BOOM_GPU__ENABLED:-false}
-      BOOM_GPU__DEVICE_IDS: ${BOOM_GPU__DEVICE_IDS:-0}
+      BOOM_GPU__DEVICE_IDS: ${BOOM_GPU__DEVICE_IDS:-}
     networks:
       - boom
     profiles:
@@ -560,7 +560,7 @@ services:
       BOOM_BABAMUL__ENABLED: ${BOOM_BABAMUL__ENABLED:-false}
       BOOM_REDIS__HOST: valkey
       BOOM_GPU__ENABLED: ${BOOM_GPU__ENABLED:-false}
-      BOOM_GPU__DEVICE_IDS: ${BOOM_GPU__DEVICE_IDS:-0}
+      BOOM_GPU__DEVICE_IDS: ${BOOM_GPU__DEVICE_IDS:-}
     networks:
       - boom
     profiles:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -249,7 +249,7 @@ volume paths, and the specific env keys injected into containers) belong here.
 | `BOOM_BABAMUL__ENABLED` | No | Defaults to `false`. |
 | `BOOM_BABAMUL__REGISTRATION_ENABLED` | No | Whether the API accepts new account creation; defaults to `true`. Pairs with `VITE_PRERELEASE_MODE`: that decides what the web app offers, this decides what the API allows. |
 | `BOOM_GPU__ENABLED` | No | Set `true` to run ONNX inference on GPU. Overrides `config.gpu.enabled`, and selects the `docker-compose.cuda.yaml` overlay. |
-| `BOOM_GPU__DEVICE_IDS` | No | Comma-separated CUDA device IDs (e.g. `0,1`); defaults to `0`. Only relevant when `BOOM_GPU__ENABLED=true`. |
+| `BOOM_GPU__DEVICE_IDS` | No | Comma-separated CUDA device IDs (e.g. `0,1`). Unset, the deployment config's `gpu.device_ids` applies. Only relevant when `BOOM_GPU__ENABLED=true`. |
 | `BOOM_DATA_MONGODB_PATH` | No | Host bind mount for MongoDB; falls back to a named volume. |
 | `BOOM_DATA_VALKEY_PATH` | No | Host bind mount for Valkey; falls back to a named volume. |
 | `BOOM_DATA_KAFKA_PATH` | No | Host bind mount for Kafka; falls back to a named volume. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -248,7 +248,7 @@ volume paths, and the specific env keys injected into containers) belong here.
 | `VITE_PUBLIC_POSTHOG_HOST` | No | PostHog host, e.g. `https://us.i.posthog.com`. Also supplies the server-side `BOOM_POSTHOG__HOST`. |
 | `BOOM_BABAMUL__ENABLED` | No | Defaults to `false`. |
 | `BOOM_BABAMUL__REGISTRATION_ENABLED` | No | Whether the API accepts new account creation; defaults to `true`. Pairs with `VITE_PRERELEASE_MODE`: that decides what the web app offers, this decides what the API allows. |
-| `BOOM_GPU__ENABLED` | No | Set `true` to run ONNX inference on GPU. The workflow forces `false` when unset because the model loader's own default is `true` (it reads this env var directly, not `config.gpu.enabled`). |
+| `BOOM_GPU__ENABLED` | No | Set `true` to run ONNX inference on GPU. Overrides `config.gpu.enabled`, and selects the `docker-compose.cuda.yaml` overlay. |
 | `BOOM_GPU__DEVICE_IDS` | No | Comma-separated CUDA device IDs (e.g. `0,1`); defaults to `0`. Only relevant when `BOOM_GPU__ENABLED=true`. |
 | `BOOM_DATA_MONGODB_PATH` | No | Host bind mount for MongoDB; falls back to a named volume. |
 | `BOOM_DATA_VALKEY_PATH` | No | Host bind mount for Valkey; falls back to a named volume. |

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -889,7 +889,7 @@ use serde::{de, Deserializer};
 pub struct GpuConfig {
     /// Whether to load ONNX models on GPU (CUDA) instead of CPU.
     /// Models are loaded once at startup and shared across all enrichment workers
-    /// via `Arc<Mutex<...>>`. When false, models are loaded on CPU.
+    /// via `Arc<Mutex<...>>`.
     #[serde(default)]
     pub enabled: bool,
     /// CUDA device IDs available for GPU work. Default: [0].

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -889,8 +889,7 @@ use serde::{de, Deserializer};
 pub struct GpuConfig {
     /// Whether to load ONNX models on GPU (CUDA) instead of CPU.
     /// Models are loaded once at startup and shared across all enrichment workers
-    /// via `Arc<Mutex<...>>`. When false, models are loaded on CPU (the BOOM_GPU__ENABLED
-    /// env var is still respected by the ORT session builder).
+    /// via `Arc<Mutex<...>>`. When false, models are loaded on CPU.
     #[serde(default)]
     pub enabled: bool,
     /// CUDA device IDs available for GPU work. Default: [0].

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -1,11 +1,9 @@
-use crate::{
-    utils::cutouts::AlertCutout,
-    utils::fits::{prepare_triplet, CutoutError},
+use crate::utils::{
+    cutouts::AlertCutout,
+    fits::{prepare_triplet, CutoutError},
 };
 use ndarray::{Array, Dim};
 use ort::session::{builder::GraphOptimizationLevel, Session};
-#[cfg(target_os = "linux")]
-use std::env;
 use tracing::instrument;
 
 #[derive(thiserror::Error, Debug)]
@@ -41,22 +39,20 @@ pub fn load_model(path: &str) -> Result<Session, ModelError> {
 /// # Safety
 /// When non-null, `cuda_stream` must be a valid `cudaStream_t` belonging to
 /// `device_id`'s device, and must outlive the returned [`Session`].
+#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
 pub fn load_model_on_device(
     path: &str,
     device_id: Option<i32>,
-    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     cuda_stream: *mut std::ffi::c_void,
 ) -> Result<Session, ModelError> {
     let mut builder = Session::builder()?;
 
     #[cfg(target_os = "linux")]
-    if env::var_os("ORT_DYLIB_PATH").is_none() {
+    if std::env::var_os("ORT_DYLIB_PATH").is_none() {
         return Err(ModelError::MissingOrtDylibPath);
     }
 
     // Pin execution providers explicitly so CPU mode never initializes GPU EPs.
-    // A device is only passed when config.gpu.enabled selected the GPU path.
-    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     if let Some(dev) = device_id {
         // Disable CPU fallback to make sure we only use the GPUs as instructed.
         // We only do this on Linux as Apple's CoreML EP does need to fallback

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use ndarray::{Array, Dim};
 use ort::session::{builder::GraphOptimizationLevel, Session};
+#[cfg(target_os = "linux")]
 use std::env;
 use tracing::instrument;
 
@@ -27,25 +28,15 @@ pub enum ModelError {
     MissingOrtDylibPath,
 }
 
-/// Load an ONNX model, optionally on a specific CUDA device.
-///
-/// GPU usage is controlled by the `BOOM_GPU__ENABLED` environment variable (default: `"true"`).
-/// When `device_id` is `Some(id)`, that CUDA device is used; otherwise device 0.
 pub fn load_model(path: &str) -> Result<Session, ModelError> {
     load_model_on_device(path, None, std::ptr::null_mut())
 }
 
-fn env_truthy(value: &str) -> bool {
-    matches!(
-        value.trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on"
-    )
-}
-
-/// Load an ONNX model on a specific device. On Linux+CUDA, `cuda_stream` (a
-/// `cudaStream_t` cast to `*mut c_void`) lets the session share its compute
-/// stream with other CUDA work — pass `std::ptr::null_mut()` to let ORT
-/// allocate its own stream. The stream argument is ignored on macOS.
+/// Load an ONNX model on `device_id`'s CUDA device, or on CPU when `None`.
+/// On Linux+CUDA, `cuda_stream` (a `cudaStream_t` cast to `*mut c_void`) lets
+/// the session share its compute stream with other CUDA work — pass
+/// `std::ptr::null_mut()` to let ORT allocate its own stream. The stream
+/// argument is ignored on macOS.
 ///
 /// # Safety
 /// When non-null, `cuda_stream` must be a valid `cudaStream_t` belonging to
@@ -58,17 +49,15 @@ pub fn load_model_on_device(
 ) -> Result<Session, ModelError> {
     let mut builder = Session::builder()?;
 
-    let use_gpu = env::var("BOOM_GPU__ENABLED")
-        .map(|v| env_truthy(&v))
-        .unwrap_or(true);
-
     #[cfg(target_os = "linux")]
     if env::var_os("ORT_DYLIB_PATH").is_none() {
         return Err(ModelError::MissingOrtDylibPath);
     }
 
     // Pin execution providers explicitly so CPU mode never initializes GPU EPs.
-    if use_gpu {
+    // A device is only passed when config.gpu.enabled selected the GPU path.
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    if let Some(dev) = device_id {
         // Disable CPU fallback to make sure we only use the GPUs as instructed.
         // We only do this on Linux as Apple's CoreML EP does need to fallback
         // to the CPU for some operators of the ONNX runtime.
@@ -76,9 +65,6 @@ pub fn load_model_on_device(
         {
             builder = builder.with_disable_cpu_fallback()?;
         }
-
-        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
-        let dev = device_id.unwrap_or(0);
 
         #[cfg(target_os = "linux")]
         let cuda_ep = {

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -578,7 +578,8 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
             alert_pipeline: create_ztf_alert_pipeline(false),
             models,
             babamul,
-            gpu_enabled: config.gpu.enabled,
+            // No devices means SharedModelPool loaded a CPU model set.
+            gpu_enabled: config.gpu.enabled && !config.gpu.device_ids.is_empty(),
             batch_size,
         })
     }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -742,7 +742,7 @@ impl EnrichmentWorker for ZtfEnrichmentWorker {
         }
 
         // GPU batch Villar light curve fitting — only when SharedModels was
-        // loaded with a GPU device (i.e. config.gpu.enabled is true).
+        // loaded with a GPU device.
         // Otherwise `villar_inputs` is empty and we skip the entire block.
         #[cfg(feature = "gpu")]
         if let Some(gpu_ctx) = self.models.as_ref().and_then(|m| m.gpu_ctx.as_ref()) {


### PR DESCRIPTION
## Problem

The model loader read `BOOM_GPU__ENABLED` straight from the environment, bypassing the config layer, and defaulted to `true` when unset:

```rust
let use_gpu = env::var("BOOM_GPU__ENABLED")
    .map(|v| env_truthy(&v))
    .unwrap_or(true);
```

So GPU inference had two sources of truth that could disagree:

- `gpu.enabled: false` could not turn the GPU off. With the variable unset, ZTF took the per-worker CPU path while ORT still registered the CUDA execution provider on device 0.
- `gpu.enabled: true` with the variable set to `false` did the reverse: the scheduler built a `SharedModelPool` and a CUDA stream per device while the sessions were built on CPU.

`deploy.yaml` worked around this with ten lines of comment telling operators to keep the repo variable and the deployment YAML in sync by hand. `docs/deployment.md` repeated it.

## Fix

`device_id` already carries the answer:

```rust
if let Some(dev) = device_id {
```

`Some(id)` only originates from `SharedModelPool::load`, reached through `config.gpu.enabled`, or from `validate_gpu_inference`, gated the same way. `config.gpu.enabled` becomes the single source of truth, and `BOOM_GPU__ENABLED` still overrides it through the normal `BOOM_*` overlay, so "set false to force CPU" is unchanged.

It also makes `SharedModelPool::load`'s doc true: it says an empty `device_ids` loads a CPU model set, which the old env default contradicted. `ZtfEnrichmentWorker::gpu_enabled` now accounts for that case too.

On macOS this changes behaviour only when `gpu.enabled` is `false`, where CoreML was used regardless; `docs/gpu.md` already tells macOS users to set it to `true`.

## Also here

- `docker-compose.yaml`: `BOOM_GPU__DEVICE_IDS: ${...:-0}` becomes `${...:-}`, so a deployment config's `device_ids` can win under Docker — `ignore_empty(true)` exists for that form. `BOOM_GPU__ENABLED: ${...:-false}` is left alone: it also selects the CUDA overlay, so its default is an interlock.
- Dropped the now-false comments in `deploy.yaml`, `docs/deployment.md`, `config.yaml` and the generated prod configs. The generated configs carry the comment change only, no values.
- `env_truthy` and `device_id.unwrap_or(0)` are gone; `use std::env` is gated on Linux, its only remaining use.
