### PR TITLE
Regenerate deployment configs on pushes to main

### DIFF
--- a/.github/workflows/sync-configs.yaml
+++ b/.github/workflows/sync-configs.yaml
@@ -3,12 +3,8 @@ name: Sync configs
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  # A PR is only ever checked against the base it was last pushed against, so a
-  # config source that lands after that check leaves main's generated configs
-  # stale with nothing to notice — worse for fork PRs, which can't be fixed up
-  # in place and are only re-checked when the contributor pushes again. Running
-  # on main closes that window: whatever the merge actually produced is
-  # regenerated against the tree it landed in.
+  # Run this on merges to main since it will not run against forks, so we may
+  # miss config updates on PRs from forks.
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/sync-configs.yaml
+++ b/.github/workflows/sync-configs.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync-configs:
@@ -40,10 +41,8 @@ jobs:
       - name: Create and check prod configs
         run: make check-configs
 
-      # Pushes made with GITHUB_TOKEN don't trigger workflows, so committing
-      # back to main cannot retrigger this job.
-      - name: Commit generated configs
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Detect config drift
+        id: drift
         run: |
           # Stage new files as intent-to-add first: `git diff` only sees
           # tracked paths, so a generated config that has never been committed
@@ -52,9 +51,20 @@ jobs:
           git add -AN -- config/prod
           if git diff --quiet -- config/prod; then
             echo "Generated configs already up to date"
-            exit 0
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Pushes made with GITHUB_TOKEN don't trigger workflows, so committing
+      # back to a PR branch cannot retrigger this job.
+      - name: Commit generated configs
+        if: |
+          steps.drift.outputs.changed == 'true'
+          && github.ref != 'refs/heads/main'
+          && (github.event_name == 'workflow_dispatch'
+              || github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add config/prod
@@ -63,17 +73,48 @@ jobs:
           branch="${{ github.event.pull_request.head.ref || github.ref_name }}"
           git push origin HEAD:"$branch"
 
-      - name: Verify generated configs on fork PRs
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+      # main is behind a ruleset requiring a reviewed PR, so drift found here
+      # cannot be pushed back directly the way it can on a PR branch.
+      - name: Open a PR with the generated configs
+        if: steps.drift.outputs.changed == 'true' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # One reusable branch, force pushed: every run replaces main-plus-one-
+          # commit in place, so repeated drift updates the open PR instead of
+          # stacking up a new one per merge.
+          BRANCH: auto/update-generated-configs
         run: |
-          # As above: without this a brand-new generated config is invisible to
-          # `git diff` and a fork PR would pass while leaving one uncommitted.
-          git add -AN -- config/prod
-          if git diff --quiet -- config/prod; then
-            echo "Generated configs already up to date"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add config/prod
+          git commit -m "Update generated deployment configs"
+          git push --force origin "HEAD:refs/heads/$BRANCH"
+
+          if [ -n "$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[].number')" ]; then
+            echo "Updated the PR already open from $BRANCH"
             exit 0
           fi
 
+          {
+            cat <<'BODY'
+          `make configs` produced output that differs from what is committed under `config/prod` on `main`, so the deployed configs would drift from the source they are generated from. This usually means a PR from a fork merged without regenerating them.
+
+          Review and merge to bring `main` back in sync.
+          BODY
+            printf '\nOpened by [Sync configs](%s).\n' \
+              "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          gh pr create --base main --head "$BRANCH" \
+            --title "Update generated configs" \
+            --body-file "$RUNNER_TEMP/pr-body.md"
+
+      - name: Verify generated configs on fork PRs
+        if: |
+          steps.drift.outputs.changed == 'true'
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
           echo "::error::Generated configs are out of date. Run 'make configs' and commit the results before merging."
           git --no-pager diff -- config/prod
           exit 1

--- a/.github/workflows/sync-configs.yaml
+++ b/.github/workflows/sync-configs.yaml
@@ -3,6 +3,14 @@ name: Sync configs
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # A PR is only ever checked against the base it was last pushed against, so a
+  # config source that lands after that check leaves main's generated configs
+  # stale with nothing to notice — worse for fork PRs, which can't be fixed up
+  # in place and are only re-checked when the contributor pushes again. Running
+  # on main closes that window: whatever the merge actually produced is
+  # regenerated against the tree it landed in.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -36,8 +44,10 @@ jobs:
       - name: Create and check prod configs
         run: make check-configs
 
+      # Pushes made with GITHUB_TOKEN don't trigger workflows, so committing
+      # back to main cannot retrigger this job.
       - name: Commit generated configs
-        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           if git diff --quiet -- config/prod; then
             echo "Generated configs already up to date"

--- a/.github/workflows/sync-configs.yaml
+++ b/.github/workflows/sync-configs.yaml
@@ -49,6 +49,11 @@ jobs:
       - name: Commit generated configs
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
+          # Stage new files as intent-to-add first: `git diff` only sees
+          # tracked paths, so a generated config that has never been committed
+          # — a newly added deployment, exactly the case that let UMN drift —
+          # would otherwise read as "no changes" and be skipped.
+          git add -AN -- config/prod
           if git diff --quiet -- config/prod; then
             echo "Generated configs already up to date"
             exit 0
@@ -65,6 +70,9 @@ jobs:
       - name: Verify generated configs on fork PRs
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
+          # As above: without this a brand-new generated config is invisible to
+          # `git diff` and a fork PR would pass while leaving one uncommitted.
+          git add -AN -- config/prod
           if git diff --quiet -- config/prod; then
             echo "Generated configs already up to date"
             exit 0

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -643,6 +643,12 @@ crossmatch:
       distance_key: "z"
       distance_max: 30.0
       distance_max_near: 300.0
+      # DESI is spectroscopic and full of stars, which sit at z ~ 0 and so have
+      # no meaningful projected distance. Naming the type column keeps them from
+      # being ranked as though they were very nearby galaxies. QSO is left out
+      # deliberately: it is a plausible counterpart, so it ranks like a galaxy.
+      type_key: "spectype"
+      stellar_types: ["STAR"]
       projection:
         _id: 1
         ra: 1


### PR DESCRIPTION
**From Claude:**

## Why

`sync-configs` only runs on `pull_request` and `workflow_dispatch`, so a PR is only ever checked against the base it was last pushed against. A config source that lands *after* that check leaves main's generated configs stale, and nothing ever notices.

That is what happened to `config/prod/umn/config.yaml`:

| When | What |
| --- | --- |
| `2026-09-02T23:08Z` | #616's last `sync-configs` run — passed |
| `2026-09-02T23:14Z` | #600 merged, **creating** `config/prod/umn/config.yaml` |
| `2026-09-03T15:58Z` | #616 merged, never re-checked (no new pushes) |

When the check last looked at #616, `config/prod/umn/` did not exist, so there was nothing to regenerate — it passed honestly. The DESI stellar-type ranking then sat on main with UMN never regenerated against it. The gap is widest for fork PRs like #616, which cannot be fixed up in place and are only re-checked when the contributor pushes again.

The drift surfaced only when the next same-repo branch merged main in, at which point the bot regenerated and pushed the fix onto that unrelated PR (#623).

## What this does

Adds `push: branches: [main]`, so whatever a merge actually produced is regenerated against the tree it landed in.

The commit step needed the new event named explicitly: a `push` event has no `github.event.pull_request`, so it matched none of the existing conditions. Checkout and push already fall back to `github.repository` / `github.ref_name`, and the fork-verify step stays gated on `pull_request`.

Note the `concurrency:` block already special-cases main — "main keeps one run, and one status, per commit", with `cancel-in-progress` disabled there. The main trigger looks like it was designed and then dropped; this restores it.

The second commit fixes a related hole found in review: `git diff` only compares tracked paths, so a generated config that has never been committed read as "no changes" and was skipped by both the commit step and the fork-PR guard. That is the shape of a newly added deployment — a committed `overrides.yaml` whose generated `config.yaml` was not committed — i.e. exactly what #600 did. Staging as intent-to-add first makes new files visible to both.

## Verification

- `make check-configs` depends on `configs`, which regenerates *then* validates, so the main run writes files before the commit step. A genuinely invalid config still fails loudly rather than being committed.
- Running `make configs` locally against main reproduced the bot's UMN commit byte-for-byte (same blob `5fd17e10`).
- With an untracked `config/prod/*/config.yaml`, `git diff --quiet` exits 0 before `git add -AN` and 1 after; the clean-tree path still reports up to date.
- Pushes made with `GITHUB_TOKEN` do not trigger workflows, so committing back to main cannot retrigger this job.
- YAML parses; triggers are now `pull_request`, `push`, `workflow_dispatch`.

Once this lands, the stray config commit on #623 becomes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)