### PR TITLE
fixing GPU issues

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -145,9 +145,8 @@ workers:
     enrichment:
       n_workers: 3
       # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
-      # inference shape. Partial batches are zero-padded so ORT sees one shape
-      # and the GPU memory arena stays stable. 750 is stable for both VRAM => 12GB.
-      # Caltech and MSI can handle 1000.
+      # inference shape. One shape alone does not bound the GPU arena; the CUDA
+      # sessions also pin SameAsRequested. Use 750 on cards under 12GB.
       batch_size: 1000
     filter:
       n_workers: 3

--- a/config.yaml
+++ b/config.yaml
@@ -144,10 +144,8 @@ workers:
       n_workers: 3
     enrichment:
       n_workers: 3
-      # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
-      # inference shape. One shape alone does not bound the GPU arena; the CUDA
-      # sessions also pin SameAsRequested. 1000 is sized for ~12GB cards; the
-      # startup check only guarantees 10GiB free, so use 750 on smaller cards.
+      # Alerts per batch: the RPOP cap and the fixed ONNX input shape (CUDA pins SameAsRequested).
+      # 1000 is sized for ~12GB cards; the 10GiB startup check is only a floor — use 750 below that.
       batch_size: 1000
     filter:
       n_workers: 3

--- a/config.yaml
+++ b/config.yaml
@@ -146,7 +146,8 @@ workers:
       n_workers: 3
       # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
       # inference shape. One shape alone does not bound the GPU arena; the CUDA
-      # sessions also pin SameAsRequested. Use 750 on cards under 12GB.
+      # sessions also pin SameAsRequested. 1000 is sized for ~12GB cards; the
+      # startup check only guarantees 10GiB free, so use 750 on smaller cards.
       batch_size: 1000
     filter:
       n_workers: 3

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -146,9 +146,8 @@ workers:
     enrichment:
       n_workers: 12
       # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
-      # inference shape. Partial batches are zero-padded so ORT sees one shape
-      # and the GPU memory arena stays stable. 750 is stable for both VRAM => 12GB.
-      # Caltech and MSI can handle 1000.
+      # inference shape. One shape alone does not bound the GPU arena; the CUDA
+      # sessions also pin SameAsRequested. Use 750 on cards under 12GB.
       batch_size: 1000
     filter:
       n_workers: 4

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -147,7 +147,8 @@ workers:
       n_workers: 12
       # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
       # inference shape. One shape alone does not bound the GPU arena; the CUDA
-      # sessions also pin SameAsRequested. Use 750 on cards under 12GB.
+      # sessions also pin SameAsRequested. 1000 is sized for ~12GB cards; the
+      # startup check only guarantees 10GiB free, so use 750 on smaller cards.
       batch_size: 1000
     filter:
       n_workers: 4

--- a/config/prod/caltech/config.yaml
+++ b/config/prod/caltech/config.yaml
@@ -145,10 +145,8 @@ workers:
       n_workers: 8
     enrichment:
       n_workers: 12
-      # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
-      # inference shape. One shape alone does not bound the GPU arena; the CUDA
-      # sessions also pin SameAsRequested. 1000 is sized for ~12GB cards; the
-      # startup check only guarantees 10GiB free, so use 750 on smaller cards.
+      # Alerts per batch: the RPOP cap and the fixed ONNX input shape (CUDA pins SameAsRequested).
+      # 1000 is sized for ~12GB cards; the 10GiB startup check is only a floor — use 750 below that.
       batch_size: 1000
     filter:
       n_workers: 4

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -146,9 +146,8 @@ workers:
     enrichment:
       n_workers: 4
       # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
-      # inference shape. Partial batches are zero-padded so ORT sees one shape
-      # and the GPU memory arena stays stable. 750 is stable for both VRAM => 12GB.
-      # Caltech and MSI can handle 1000.
+      # inference shape. One shape alone does not bound the GPU arena; the CUDA
+      # sessions also pin SameAsRequested. Use 750 on cards under 12GB.
       batch_size: 1000
     filter:
       n_workers: 10

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -145,10 +145,8 @@ workers:
       n_workers: 10
     enrichment:
       n_workers: 4
-      # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
-      # inference shape. One shape alone does not bound the GPU arena; the CUDA
-      # sessions also pin SameAsRequested. 1000 is sized for ~12GB cards; the
-      # startup check only guarantees 10GiB free, so use 750 on smaller cards.
+      # Alerts per batch: the RPOP cap and the fixed ONNX input shape (CUDA pins SameAsRequested).
+      # 1000 is sized for ~12GB cards; the 10GiB startup check is only a floor — use 750 below that.
       batch_size: 1000
     filter:
       n_workers: 10

--- a/config/prod/umn/config.yaml
+++ b/config/prod/umn/config.yaml
@@ -147,7 +147,8 @@ workers:
       n_workers: 4
       # Alerts per enrichment batch: the queue RPOP cap AND the fixed ONNX
       # inference shape. One shape alone does not bound the GPU arena; the CUDA
-      # sessions also pin SameAsRequested. Use 750 on cards under 12GB.
+      # sessions also pin SameAsRequested. 1000 is sized for ~12GB cards; the
+      # startup check only guarantees 10GiB free, so use 750 on smaller cards.
       batch_size: 1000
     filter:
       n_workers: 10

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -55,7 +55,7 @@ GPU inference requires additional system software beyond the ONNX Runtime wheel.
 1. NVIDIA driver installed and working.
 2. CUDA major version compatible with your driver. We recommend 12.8 (which is what we tested at the time of writing), but check ONNX Runtime GPU wheel requirements for your version if you run into issues.
 3. cuDNN 9 for that CUDA major version.
-4. At least 10 GiB of free VRAM on each configured CUDA device for ZTF enrichment.
+4. At least 10 GiB of free VRAM on each configured CUDA device for ZTF enrichment. Note the default `batch_size: 1000` is sized for a ~12 GB card; the 10 GiB startup check is only a floor, so on cards with less than ~12 GB free set `workers.ztf.enrichment.batch_size: 750`.
 
 On Linux, BOOM validates this at scheduler startup for ZTF with GPU enabled and fails fast if any configured device has less than 10240 MiB free. You can check free VRAM with:
 

--- a/src/bin/enrich_reprocess.rs
+++ b/src/bin/enrich_reprocess.rs
@@ -82,12 +82,20 @@ async fn run_enrich_only<T: EnrichmentWorker>(
     let worker_config = config
         .workers
         .get(&survey)
-        .ok_or(EnrichmentWorkerError::WorkerConfigMissing(survey))?;
+        .ok_or(EnrichmentWorkerError::WorkerConfigMissing(survey.clone()))?;
 
     let mut con = config.build_redis().await?;
 
     let command_interval = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
+
+    // Same cap as `run_enrichment_worker`: one inference batch per pull.
+    let batch_size = NonZero::new(worker_config.enrichment.batch_size).ok_or_else(|| {
+        EnrichmentWorkerError::ConfigurationError(format!(
+            "enrichment batch_size must be non-zero for survey {}",
+            survey
+        ))
+    })?;
 
     loop {
         if command_check_countdown == 0 {
@@ -98,7 +106,7 @@ async fn run_enrich_only<T: EnrichmentWorker>(
         }
 
         let candids: Vec<i64> = con
-            .rpop::<&str, Vec<i64>>(&input_queue, NonZero::new(1000))
+            .rpop::<&str, Vec<i64>>(&input_queue, Some(batch_size))
             .await?;
 
         if candids.is_empty() {

--- a/src/bin/enrich_reprocess.rs
+++ b/src/bin/enrich_reprocess.rs
@@ -89,7 +89,6 @@ async fn run_enrich_only<T: EnrichmentWorker>(
     let command_interval = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
 
-    // Same cap as `run_enrichment_worker`: one inference batch per pull.
     let batch_size = NonZero::new(worker_config.enrichment.batch_size).ok_or_else(|| {
         EnrichmentWorkerError::ConfigurationError(format!(
             "enrichment batch_size must be non-zero for survey {}",

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -870,13 +870,11 @@ fn default_enrichment_batch_size() -> usize {
 #[derive(Deserialize, Debug, Clone)]
 pub struct EnrichmentWorkerConfig {
     pub n_workers: usize,
-    /// Alerts processed per enrichment batch. Serves two roles at once: the
-    /// queue RPOP cap (max alerts pulled per worker iteration) and the fixed
-    /// ONNX batch dimension. Every GPU inference runs at exactly this many
-    /// rows — partial batches are zero-padded — so ORT builds a single memory
-    /// plan and the BFC arena stays stable instead of growing per distinct
-    /// input shape. 750 is the proven stable shape on a 16 GB card
-    /// (~10.3 GB footprint); 1000 OOMs (~15.7 GB).
+    /// Alerts per enrichment batch: both the queue RPOP cap and the fixed ONNX
+    /// batch dimension (partial batches are zero-padded).
+    ///
+    /// One shape alone does not bound the BFC arena — CUDA sessions also pin
+    /// `SameAsRequested`, which is what makes 1000 hold. Use 750 under 12 GB.
     #[serde(default = "default_enrichment_batch_size")]
     pub batch_size: usize,
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -864,8 +864,7 @@ pub struct WorkerConfig {
 }
 
 fn default_enrichment_batch_size() -> usize {
-    // Matches the RPOP cap that was hardcoded before `batch_size` existed, so
-    // surveys that don't set it (lsst/decam/winter) keep their prior pull size.
+    // The RPOP cap that was hardcoded before this field existed.
     1000
 }
 
@@ -873,12 +872,8 @@ fn default_enrichment_batch_size() -> usize {
 pub struct EnrichmentWorkerConfig {
     pub n_workers: usize,
     /// Alerts per enrichment batch: both the queue RPOP cap and the fixed ONNX
-    /// batch dimension (partial batches are zero-padded).
-    ///
-    /// One shape alone does not bound the BFC arena — CUDA sessions also pin
-    /// `SameAsRequested`, which is what makes 1000 hold. 1000 is sized for a
-    /// ~12 GB card; the startup guardrail only checks for 10 GiB free, so on
-    /// smaller cards lower this to 750.
+    /// input shape (partial batches are zero-padded). CUDA sessions pin
+    /// `SameAsRequested`, so this shape must not vary; see `config.yaml` for sizing.
     #[serde(default = "default_enrichment_batch_size")]
     pub batch_size: usize,
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -864,7 +864,9 @@ pub struct WorkerConfig {
 }
 
 fn default_enrichment_batch_size() -> usize {
-    750
+    // Matches the RPOP cap that was hardcoded before `batch_size` existed, so
+    // surveys that don't set it (lsst/decam/winter) keep their prior pull size.
+    1000
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -874,7 +876,9 @@ pub struct EnrichmentWorkerConfig {
     /// batch dimension (partial batches are zero-padded).
     ///
     /// One shape alone does not bound the BFC arena — CUDA sessions also pin
-    /// `SameAsRequested`, which is what makes 1000 hold. Use 750 under 12 GB.
+    /// `SameAsRequested`, which is what makes 1000 hold. 1000 is sized for a
+    /// ~12 GB card; the startup guardrail only checks for 10 GiB free, so on
+    /// smaller cards lower this to 750.
     #[serde(default = "default_enrichment_batch_size")]
     pub batch_size: usize,
 }

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -193,6 +193,16 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
     let command_interval = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
 
+    // Cap the RPOP at the configured batch size: pulling more would split it
+    // into a full chunk plus a mostly-padded one, paying a second full-cost
+    // GPU pass for the remainder (see `ZtfEnrichmentWorker::classify`).
+    let batch_size = NonZero::new(worker_config.enrichment.batch_size).ok_or_else(|| {
+        EnrichmentWorkerError::ConfigurationError(format!(
+            "enrichment batch_size must be non-zero for survey {}",
+            survey
+        ))
+    })?;
+
     let worker_id_attr = KeyValue::new("worker.id", worker_id.to_string());
     let survey_attr = KeyValue::new("survey", survey.clone());
     let active_attrs = [worker_id_attr.clone(), survey_attr.clone()];
@@ -240,7 +250,7 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
                 // FnMut closure.
                 let mut con = con.clone();
                 let key: &str = &input_queue;
-                async move { con.rpop::<&str, Vec<i64>>(key, NonZero::new(1000)).await }
+                async move { con.rpop::<&str, Vec<i64>>(key, Some(batch_size)).await }
             },
         )
         .await

--- a/src/enrichment/base.rs
+++ b/src/enrichment/base.rs
@@ -193,9 +193,7 @@ pub async fn run_enrichment_worker<T: EnrichmentWorker>(
     let command_interval = worker_config.command_interval;
     let mut command_check_countdown = command_interval;
 
-    // Cap the RPOP at the configured batch size: pulling more would split it
-    // into a full chunk plus a mostly-padded one, paying a second full-cost
-    // GPU pass for the remainder (see `ZtfEnrichmentWorker::classify`).
+    // One inference batch per pull; more would cost a second, mostly-padded GPU pass.
     let batch_size = NonZero::new(worker_config.enrichment.batch_size).ok_or_else(|| {
         EnrichmentWorkerError::ConfigurationError(format!(
             "enrichment batch_size must be non-zero for survey {}",

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -62,11 +62,13 @@ pub fn load_model_on_device(
 
         #[cfg(target_os = "linux")]
         let cuda_ep = {
-            // Tried and reverted: with dynamic batch it kills BFC arena reuse and OOMs.
-            // .with_arena_extend_strategy(ort::ep::ArenaExtendStrategy::SameAsRequested)
             let mut ep = ort::ep::CUDAExecutionProvider::default()
                 .with_device_id(dev)
-                .with_conv_max_workspace(false);
+                .with_conv_max_workspace(false)
+                // ORT's default grows the arena every batch at 900+ (35 GiB on
+                // an A40). Exact-size extents fit the next batch only because
+                // callers pad to a fixed shape; dynamic shapes would regress.
+                .with_arena_extend_strategy(ort::ep::ArenaExtendStrategy::SameAsRequested);
             if !cuda_stream.is_null() {
                 // Safety: guaranteed by this function's own safety contract.
                 ep = unsafe { ep.with_compute_stream(cuda_stream as *mut ()) };

--- a/src/enrichment/models/base.rs
+++ b/src/enrichment/models/base.rs
@@ -65,9 +65,8 @@ pub fn load_model_on_device(
             let mut ep = ort::ep::CUDAExecutionProvider::default()
                 .with_device_id(dev)
                 .with_conv_max_workspace(false)
-                // ORT's default grows the arena every batch at 900+ (35 GiB on
-                // an A40). Exact-size extents fit the next batch only because
-                // callers pad to a fixed shape; dynamic shapes would regress.
+                // Safe only because callers pad every batch to one fixed shape;
+                // with dynamic shapes this grows the arena every batch and OOMs.
                 .with_arena_extend_strategy(ort::ep::ArenaExtendStrategy::SameAsRequested);
             if !cuda_stream.is_null() {
                 // Safety: guaranteed by this function's own safety contract.

--- a/src/enrichment/models/mod.rs
+++ b/src/enrichment/models/mod.rs
@@ -15,6 +15,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::info;
 
+/// Workers round-robin over sets, so more workers than GPUs means several
+/// threads share one set — and one CUDA stream. Safe: see `bind_device`.
 const SESSIONS_PER_DEVICE: usize = 1;
 
 /// ONNX models shared across all enrichment worker threads via `Arc`.
@@ -38,7 +40,9 @@ pub struct SharedModels {
     pub acai_b: Mutex<AcaiModel>,
     pub btsbot: Mutex<BtsBotModel>,
     /// Villar-PSO GPU context bound to this device. `None` when running
-    /// without the `gpu` feature.
+    /// without the `gpu` feature. No mutex: it is an id plus a stream pointer
+    /// with `&self` methods, per-call buffers, and stream enqueue is
+    /// thread-safe, so workers sharing this set may use it concurrently.
     #[cfg(feature = "gpu")]
     pub gpu_ctx: Option<GpuContext>,
     /// CUDA stream shared with the ORT sessions above. Must be dropped last
@@ -55,12 +59,9 @@ impl std::fmt::Debug for SharedModels {
 
 impl SharedModels {
     /// Load all ONNX models, optionally on a specific CUDA device.
-    /// Returns an `Arc` for sharing across threads.
     ///
-    /// On Linux+`gpu`, this creates a CUDA stream for `device_id` and binds
-    /// every ORT session to it via `with_compute_stream`. The same stream is
-    /// also handed to the villar-pso `GpuContext`, so all GPU work for this
-    /// device runs on one stream.
+    /// On Linux+`gpu` every ORT session and the villar `GpuContext` share one
+    /// stream for the device. Callers must `bind_device` before using these.
     pub fn load(device_id: Option<i32>) -> Result<Arc<Self>, ModelError> {
         info!(?device_id, "loading shared ONNX models");
 
@@ -159,6 +160,25 @@ impl SharedModels {
         info!("all ONNX models loaded successfully");
         Ok(Arc::new(models))
     }
+
+    /// Bind the calling thread to this set's CUDA device.
+    ///
+    /// `cudaSetDevice` is per-thread and defaults to device 0, so an ORT run on
+    /// an unbound thread hits `cudaErrorInvalidResourceHandle`. Workers are
+    /// multi-thread tokio runtimes and migrate between OS threads, so this must
+    /// run before each inference. Villar-PSO already binds itself.
+    pub fn bind_device(&self) -> Result<(), ModelError> {
+        #[cfg(all(feature = "gpu", target_os = "linux"))]
+        if let Some(ctx) = self.gpu_ctx.as_ref() {
+            ctx.set_device().map_err(|e| {
+                ModelError::Ort(ort::Error::new(format!(
+                    "failed to bind thread to CUDA device: {}",
+                    e
+                )))
+            })?;
+        }
+        Ok(())
+    }
 }
 
 /// Pool of model sets across multiple GPU devices (or a single CPU set).
@@ -199,6 +219,8 @@ impl SharedModelPool {
             }
             info!(
                 n_devices = sets.len(),
+                n_gpus = device_ids.len(),
+                sessions_per_device = SESSIONS_PER_DEVICE,
                 "all GPU model sets loaded successfully"
             );
             sets

--- a/src/enrichment/models/mod.rs
+++ b/src/enrichment/models/mod.rs
@@ -15,8 +15,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::info;
 
-/// Workers round-robin over sets, so more workers than GPUs means several
-/// threads share one set — and one CUDA stream. Safe: see `bind_device`.
+/// Workers round-robin over sets; more workers than GPUs share a set and its stream.
 const SESSIONS_PER_DEVICE: usize = 1;
 
 /// ONNX models shared across all enrichment worker threads via `Arc`.
@@ -25,13 +24,11 @@ const SESSIONS_PER_DEVICE: usize = 1;
 /// Concurrent workers will serialize on the mutex, but model weights are loaded
 /// only once in memory (and on GPU VRAM if using CUDA).
 ///
-/// On Linux+GPU, all sessions share a single CUDA stream with the villar-pso
-/// `GpuContext` so PSO and ONNX inference run on the same stream and avoid
-/// the implicit cross-stream barriers of the legacy default stream.
+/// On Linux+GPU all sessions and the villar-pso `GpuContext` share one CUDA
+/// stream, avoiding the legacy default stream's implicit cross-stream barriers.
 ///
-/// **Field ordering matters**: Rust drops struct fields in declaration order,
-/// so the stream must be declared AFTER everything that uses it (the ORT
-/// sessions and the `GpuContext`) to ensure `cudaStreamDestroy` fires last.
+/// Fields drop in declaration order, so `_stream` must stay last: its
+/// `cudaStreamDestroy` has to run after everything that uses it.
 pub struct SharedModels {
     pub acai_h: Mutex<AcaiModel>,
     pub acai_n: Mutex<AcaiModel>,
@@ -39,10 +36,8 @@ pub struct SharedModels {
     pub acai_o: Mutex<AcaiModel>,
     pub acai_b: Mutex<AcaiModel>,
     pub btsbot: Mutex<BtsBotModel>,
-    /// Villar-PSO GPU context bound to this device. `None` when running
-    /// without the `gpu` feature. No mutex: it is an id plus a stream pointer
-    /// with `&self` methods, per-call buffers, and stream enqueue is
-    /// thread-safe, so workers sharing this set may use it concurrently.
+    /// Villar-PSO context for this device; `None` for the CPU set. No mutex:
+    /// `&self` methods with per-call buffers, and stream enqueue is thread-safe.
     #[cfg(feature = "gpu")]
     pub gpu_ctx: Option<GpuContext>,
     /// CUDA stream shared with the ORT sessions above. Must be dropped last
@@ -58,15 +53,11 @@ impl std::fmt::Debug for SharedModels {
 }
 
 impl SharedModels {
-    /// Load all ONNX models, optionally on a specific CUDA device.
-    ///
-    /// On Linux+`gpu` every ORT session and the villar `GpuContext` share one
-    /// stream for the device. Callers must `bind_device` before using these.
+    /// Load all ONNX models, optionally on a specific CUDA device. On
+    /// Linux+`gpu` every session and the villar `GpuContext` share one stream.
     pub fn load(device_id: Option<i32>) -> Result<Arc<Self>, ModelError> {
         info!(?device_id, "loading shared ONNX models");
 
-        // Create the per-device CUDA stream first (Linux+gpu only). The raw
-        // pointer is shared between ORT sessions and villar-pso.
         #[cfg(all(feature = "gpu", target_os = "linux"))]
         let stream: Option<Stream> = match device_id {
             Some(id) => Some(Stream::new_on_device(id).map_err(|e| {
@@ -161,30 +152,15 @@ impl SharedModels {
         Ok(Arc::new(models))
     }
 
-    /// Bind the calling thread to this set's CUDA device.
+    /// Bind the calling thread to this set's CUDA device; call before each batch.
     ///
-    /// `cudaSetDevice` is per-thread and defaults to device 0. ORT does call it
-    /// itself — in the CUDA EP's `PerThreadContext` constructor and in
-    /// `CUDAAllocator::Alloc` — but none of those calls is guaranteed to land on
-    /// the thread that issues a given `Run`:
-    ///
-    /// - Passing our own compute stream disables ORT's per-`Run` `SetDeviceFn`,
-    ///   so nothing re-binds the thread at `Run` boundaries.
-    /// - `OnRunEnd` retires the `PerThreadContext`. When another worker's thread
-    ///   picks that retired context back up, the constructor does not run again,
-    ///   so that thread is still on device 0.
-    /// - While the allocator's arena is still growing, `CUDAAllocator::Alloc`
-    ///   binds the thread as a side effect. That accidental binding is why the
-    ///   failure is intermittent: it disappears once the arena stops extending.
-    ///
-    /// Left unbound, a `Run` against device N's stream and handles fails with
-    /// `cudaErrorInvalidResourceHandle`, so bind explicitly before each batch.
-    /// Villar-PSO already binds itself.
-    ///
-    /// Note this is *not* tokio task migration: each worker is its own
-    /// `#[tokio::main]` runtime driven by `block_on`, so it stays on its own std
-    /// thread. The stale binding comes from ORT reusing per-thread state across
-    /// worker threads, not from a task moving between them.
+    /// `cudaSetDevice` is per-thread and defaults to device 0. ORT sets it in the
+    /// `PerThreadContext` ctor and `CUDAAllocator::Alloc`, but our own compute
+    /// stream disables its per-`Run` `SetDeviceFn`, and `OnRunEnd` retires the
+    /// context for another worker's thread to reuse without the ctor — leaving
+    /// that thread on device 0 (`cudaErrorInvalidResourceHandle`). Arena growth
+    /// re-binds by accident, which is why it was intermittent. Not tokio
+    /// migration: each worker is its own `block_on` runtime on a fixed thread.
     pub fn bind_device(&self) -> Result<(), ModelError> {
         #[cfg(all(feature = "gpu", target_os = "linux"))]
         if let Some(ctx) = self.gpu_ctx.as_ref() {

--- a/src/enrichment/models/mod.rs
+++ b/src/enrichment/models/mod.rs
@@ -163,10 +163,28 @@ impl SharedModels {
 
     /// Bind the calling thread to this set's CUDA device.
     ///
-    /// `cudaSetDevice` is per-thread and defaults to device 0, so an ORT run on
-    /// an unbound thread hits `cudaErrorInvalidResourceHandle`. Workers are
-    /// multi-thread tokio runtimes and migrate between OS threads, so this must
-    /// run before each inference. Villar-PSO already binds itself.
+    /// `cudaSetDevice` is per-thread and defaults to device 0. ORT does call it
+    /// itself — in the CUDA EP's `PerThreadContext` constructor and in
+    /// `CUDAAllocator::Alloc` — but none of those calls is guaranteed to land on
+    /// the thread that issues a given `Run`:
+    ///
+    /// - Passing our own compute stream disables ORT's per-`Run` `SetDeviceFn`,
+    ///   so nothing re-binds the thread at `Run` boundaries.
+    /// - `OnRunEnd` retires the `PerThreadContext`. When another worker's thread
+    ///   picks that retired context back up, the constructor does not run again,
+    ///   so that thread is still on device 0.
+    /// - While the allocator's arena is still growing, `CUDAAllocator::Alloc`
+    ///   binds the thread as a side effect. That accidental binding is why the
+    ///   failure is intermittent: it disappears once the arena stops extending.
+    ///
+    /// Left unbound, a `Run` against device N's stream and handles fails with
+    /// `cudaErrorInvalidResourceHandle`, so bind explicitly before each batch.
+    /// Villar-PSO already binds itself.
+    ///
+    /// Note this is *not* tokio task migration: each worker is its own
+    /// `#[tokio::main]` runtime driven by `block_on`, so it stays on its own std
+    /// thread. The stale binding comes from ORT reusing per-thread state across
+    /// worker threads, not from a task moving between them.
     pub fn bind_device(&self) -> Result<(), ModelError> {
         #[cfg(all(feature = "gpu", target_os = "linux"))]
         if let Some(ctx) = self.gpu_ctx.as_ref() {

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -1261,6 +1261,8 @@ impl ZtfEnrichmentWorker {
         work_items: &[AlertWork],
     ) -> Result<Vec<Option<ZtfAlertClassifications>>, EnrichmentWorkerError> {
         if self.gpu_enabled {
+            // May have migrated to another runtime thread since the last batch.
+            models.bind_device()?;
             return self.classify_gpu_batch(models, work_items);
         }
 

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -581,8 +581,7 @@ pub struct ZtfEnrichmentWorker {
     models: Arc<SharedModels>,
     babamul: Option<Babamul>,
     gpu_enabled: bool,
-    /// Alerts per batch — also the fixed ONNX inference shape (see
-    /// [`EnrichmentWorkerConfig::batch_size`] in `conf.rs`).
+    /// Alerts per batch; also the fixed ONNX input shape. See [`EnrichmentWorkerConfig::batch_size`].
     batch_size: usize,
 }
 
@@ -1261,10 +1260,6 @@ impl ZtfEnrichmentWorker {
         work_items: &[AlertWork],
     ) -> Result<Vec<Option<ZtfAlertClassifications>>, EnrichmentWorkerError> {
         if self.gpu_enabled {
-            // Our own compute stream means ORT does not re-bind this thread at
-            // Run boundaries, and a PerThreadContext retired by another
-            // worker's OnRunEnd can be picked up here still on device 0 — see
-            // SharedModels::bind_device.
             models.bind_device()?;
             return self.classify_gpu_batch(models, work_items);
         }

--- a/src/enrichment/ztf.rs
+++ b/src/enrichment/ztf.rs
@@ -1261,7 +1261,10 @@ impl ZtfEnrichmentWorker {
         work_items: &[AlertWork],
     ) -> Result<Vec<Option<ZtfAlertClassifications>>, EnrichmentWorkerError> {
         if self.gpu_enabled {
-            // May have migrated to another runtime thread since the last batch.
+            // Our own compute stream means ORT does not re-bind this thread at
+            // Run boundaries, and a PerThreadContext retired by another
+            // worker's OnRunEnd can be picked up here still on device 0 — see
+            // SharedModels::bind_device.
             models.bind_device()?;
             return self.classify_gpu_batch(models, work_items);
         }


### PR DESCRIPTION
# Fix GPU memory growth and CUDA stream crashes in ZTF enrichment

Two independent GPU defects found while benchmarking ZTF enrichment on 8× A40 (MSI). One caused unbounded VRAM growth at large batch sizes; the other killed enrichment workers whenever they outnumbered the GPUs. Together they unblock multi-worker, multi-GPU enrichment: 8 workers across 4 GPUs now run clean at ~850–910 alerts/s, a configuration that previously could not complete.

## 1. Unbounded CUDA arena growth

**Changes**

- Pin ORT's CUDA arena strategy to `SameAsRequested` for all sessions.
- Cap the enrichment `RPOP` at the configured `batch_size` instead of a hardcoded `1000`, in both `run_enrichment_worker` and `enrich_reprocess`.

**Reason**

ORT's default `kNextPowerOfTwo` never reuses the freed activation chunk at large batches. Measured on an A40 at batch 900: 34 extensions of 1 GiB each, arena reaching 35 GiB, the freed 872 MiB chunk never reused. Batch 750 reuses it (2 extensions, 3.1 GiB). Capping with `gpu_mem_limit` does not help — a constant ~895 MiB remainder against a 969 MiB request, at caps of 4, 6 and 12 GiB.

`SameAsRequested` extends by the exact request, which fits the next batch because enrichment pads every batch to one shape.

This reverses the note previously at that call site, which said `SameAsRequested` had been "tried and reverted" because it "kills BFC arena reuse and OOMs." Measurement with ORT's own `Total allocated bytes` (log level Verbose plus verbosity 1, since the arena logs through VLOG) shows the opposite: it is `kNextPowerOfTwo` that fails to reuse, and `SameAsRequested` that holds. The old comment's reasoning was right about dynamic shapes, but enrichment is not dynamic — `classify` zero-pads to a fixed shape.

The `RPOP` mismatch meant a configured batch smaller than 1000 was split into a full chunk plus a mostly-padded one, paying a second full-cost GPU pass for the remainder.

## 2. CUDA stream crashes when workers outnumber GPUs

**Changes**

- Add `SharedModels::bind_device()`, called before each GPU inference.

**Reason**

Workers round-robin over one model set per GPU, so surplus workers share a set and its single CUDA stream. Nothing ever called `cudaSetDevice`, which is per-thread state defaulting to device 0, so an ORT run using a device-4 stream could execute on a thread bound to device 0. That surfaces as:

```
Non-zero status code returned while running Transpose node.
Name:'model/conv_conv_1/separable_conv2d/depthwise__198'
Status Message: CUDA error cudaErrorInvalidResourceHandle: invalid resource handle
```

At 4 workers / 2 GPUs: 24 errors, 12 worker failures, and 2 slots dead after exhausting their restart budget, leaving the scheduler at `enrichment=2/4` indefinitely. 

**Need to check if all enrichment workers are surviving in Caltech or not**

The bind is per-inference rather than per-worker-startup because `run_enrichment_worker` is `#[tokio::main]`, a multi-thread runtime whose tasks migrate between OS threads — which is also why the crash was intermittent. Villar-PSO needed no change: `GpuBatchData::new` and `batch_pso` already call `set_device` themselves, consistent with the failure always naming an ONNX node.

The model-set load log now also reports `n_gpus` and `sessions_per_device`, so the worker-to-set ratio is visible in any run.


## Notes for reviewers

- Surveys other than ZTF now take the `RPOP` cap from the config default (750) rather than the old hardcoded 1000. No-op for the committed configs, since none of them set `batch_size`.
- `SameAsRequested` is unconditional rather than configurable: every in-tree caller of `load_model_on_device` pads to a fixed shape. A dynamic-shape model added later would need to revisit it; the call site says so.
