### PR TITLE
Improve binaries

### DIFF
--- a/src/bin/prepare_catalog.rs
+++ b/src/bin/prepare_catalog.rs
@@ -3,17 +3,21 @@ use boom::{
     conf::{load_dotenv, AppConfig},
     utils::{
         data::{make_progress_bar, spawn_progress_logger},
-        db::create_index,
+        db::{
+            check_shard_coverage, collection_exists, create_index, exact_count, join_tasks,
+            merge_filters, range_shards, shard_field, CURSOR_BATCH_SIZE,
+        },
         parser::parse_positive_usize,
         spatial::Coordinates,
     },
 };
 use clap::Parser;
 use futures::TryStreamExt;
+use indicatif::ProgressBar;
 use mongodb::{
     bson::{doc, to_bson, Bson, Document},
     options::{UpdateOneModel, WriteModel},
-    Namespace,
+    Collection,
 };
 use tracing::{error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
@@ -66,6 +70,10 @@ struct Cli {
     #[arg(long, default_value_t = 1000, value_parser = parse_positive_usize)]
     batch_size: usize,
 
+    /// Number of parallel scan+update shards.
+    #[arg(long, default_value_t = 1, value_parser = parse_positive_usize)]
+    processes: usize,
+
     /// Recompute `coordinates` for documents that already have it.
     #[arg(long, default_value_t = false)]
     force: bool,
@@ -87,6 +95,8 @@ fn as_f64(value: Option<&Bson>) -> Option<f64> {
     }
 }
 
+const MAX_SAMPLES: usize = 10;
+
 #[derive(Default)]
 struct Report {
     updated: u64,
@@ -97,10 +107,94 @@ struct Report {
 
 impl Report {
     fn reject(&mut self, id: &Bson, reason: &str) {
-        if self.samples.len() < 10 {
+        if self.samples.len() < MAX_SAMPLES {
             self.samples.push(format!("{} ({})", id, reason));
         }
     }
+
+    fn merge(&mut self, other: Report) {
+        self.updated += other.updated;
+        self.missing += other.missing;
+        self.out_of_range += other.out_of_range;
+        for sample in other.samples {
+            if self.samples.len() < MAX_SAMPLES {
+                self.samples.push(sample);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_shard(
+    collection: Collection<Document>,
+    filter: Document,
+    ra_field: String,
+    dec_field: String,
+    batch_size: usize,
+    dry_run: bool,
+    pb: ProgressBar,
+) -> Result<Report, mongodb::error::Error> {
+    let client = collection.client().clone();
+    let namespace = collection.namespace();
+    let mut cursor = collection
+        .find(filter)
+        .projection(doc! { &ra_field: 1, &dec_field: 1 })
+        .no_cursor_timeout(true)
+        .batch_size(CURSOR_BATCH_SIZE)
+        .await?;
+
+    let mut report = Report::default();
+    let mut writes: Vec<WriteModel> = Vec::with_capacity(batch_size);
+
+    while let Some(doc) = cursor.try_next().await? {
+        pb.inc(1);
+
+        let id = match doc.get("_id") {
+            Some(id) => id.clone(),
+            None => continue,
+        };
+
+        let (ra, dec) = match (as_f64(doc.get(&ra_field)), as_f64(doc.get(&dec_field))) {
+            (Some(ra), Some(dec)) => (ra, dec),
+            _ => {
+                report.missing += 1;
+                report.reject(&id, "missing or non-numeric ra/dec");
+                continue;
+            }
+        };
+        if !(0.0..=360.0).contains(&ra) || !(-90.0..=90.0).contains(&dec) {
+            report.out_of_range += 1;
+            report.reject(&id, &format!("ra={} dec={} out of range", ra, dec));
+            continue;
+        }
+
+        report.updated += 1;
+        if dry_run {
+            continue;
+        }
+
+        let coordinates = to_bson(&Coordinates::new(ra, dec)).expect("coordinates serialize");
+        writes.push(WriteModel::UpdateOne(
+            UpdateOneModel::builder()
+                .namespace(namespace.clone())
+                .filter(doc! { "_id": id })
+                .update(doc! { "$set": { "coordinates": coordinates, "ra": ra, "dec": dec } })
+                .build(),
+        ));
+
+        if writes.len() >= batch_size {
+            client
+                .bulk_write(std::mem::take(&mut writes))
+                .ordered(false)
+                .await?;
+            writes = Vec::with_capacity(batch_size);
+        }
+    }
+
+    if !writes.is_empty() {
+        client.bulk_write(writes).ordered(false).await?;
+    }
+    Ok(report)
 }
 
 #[tokio::main]
@@ -129,16 +223,15 @@ async fn main() {
         }
     };
 
-    match db.list_collection_names().await {
-        Ok(names) => {
-            if !names.iter().any(|n| n == &args.catalog) {
-                error!(
-                    "collection {} does not exist in database {}, import it first",
-                    args.catalog,
-                    db.name()
-                );
-                std::process::exit(1);
-            }
+    match collection_exists(&db, &args.catalog).await {
+        Ok(true) => {}
+        Ok(false) => {
+            error!(
+                "collection {} does not exist in database {}, import it first",
+                args.catalog,
+                db.name()
+            );
+            std::process::exit(1);
         }
         Err(e) => {
             error!("error listing collections: {}", e);
@@ -147,120 +240,80 @@ async fn main() {
     }
 
     let collection = db.collection::<Document>(&args.catalog);
-    let namespace = Namespace {
-        db: db.name().to_string(),
-        coll: args.catalog.clone(),
-    };
-    let client = db.client();
 
-    let filter = if args.force {
+    let base_filter = if args.force {
         doc! {}
     } else {
         doc! { "coordinates": { "$exists": false } }
     };
-    let total = match collection.count_documents(filter.clone()).await {
-        Ok(total) => total,
-        Err(e) => {
-            error!("error counting documents: {}", e);
-            std::process::exit(1);
-        }
-    };
-    info!(
-        "{}: {} document(s) to process ({} in total)",
-        args.catalog,
-        total,
-        collection.estimated_document_count().await.unwrap_or(0)
-    );
+    // Counting the non-indexed coordinates filter would collection-scan the catalog twice.
+    let total = if args.force {
+        exact_count(&collection).await
+    } else {
+        collection.estimated_document_count().await
+    }
+    .unwrap_or_else(|e| {
+        error!("error counting documents: {}", e);
+        std::process::exit(1);
+    });
+    if args.force {
+        info!("{}: {} document(s) to process", args.catalog, total);
+    } else {
+        info!(
+            "{}: scanning about {} document(s) for missing coordinates",
+            args.catalog, total
+        );
+    }
 
     let mut report = Report::default();
+    let mut shard_count = 1;
 
     if total > 0 {
-        let mut cursor = match collection
-            .find(filter)
-            .projection(doc! { &args.ra_field: 1, &args.dec_field: 1 })
-            .no_cursor_timeout(true)
-            .await
-        {
-            Ok(cursor) => cursor,
-            Err(e) => {
-                error!("error querying documents: {}", e);
-                std::process::exit(1);
-            }
-        };
+        let shard_field = shard_field(&collection).await;
+        let shards = range_shards(&collection, args.processes, shard_field, &base_filter).await;
+        shard_count = shards.len();
+        info!(
+            "scanning {} in {} shard(s) cut on '{}'",
+            args.catalog,
+            shards.len(),
+            shard_field
+        );
 
         let label = format!("{} coordinates", args.catalog);
         let pb = make_progress_bar(total, label.clone());
         let logger = spawn_progress_logger(pb.clone(), label);
-        let mut writes: Vec<WriteModel> = Vec::with_capacity(args.batch_size);
 
-        loop {
-            let doc = match cursor.try_next().await {
-                Ok(Some(doc)) => doc,
-                Ok(None) => break,
-                Err(e) => {
-                    error!("error reading documents: {}", e);
-                    std::process::exit(1);
-                }
-            };
-            pb.inc(1);
-
-            let id = match doc.get("_id") {
-                Some(id) => id.clone(),
-                None => continue,
-            };
-
-            let (ra, dec) = match (
-                as_f64(doc.get(&args.ra_field)),
-                as_f64(doc.get(&args.dec_field)),
-            ) {
-                (Some(ra), Some(dec)) => (ra, dec),
-                _ => {
-                    report.missing += 1;
-                    report.reject(&id, "missing or non-numeric ra/dec");
-                    continue;
-                }
-            };
-            if !(0.0..=360.0).contains(&ra) || !(-90.0..=90.0).contains(&dec) {
-                report.out_of_range += 1;
-                report.reject(&id, &format!("ra={} dec={} out of range", ra, dec));
-                continue;
-            }
-
-            report.updated += 1;
-            if args.dry_run {
-                continue;
-            }
-
-            let coordinates = to_bson(&Coordinates::new(ra, dec)).expect("coordinates serialize");
-            writes.push(WriteModel::UpdateOne(
-                UpdateOneModel::builder()
-                    .namespace(namespace.clone())
-                    .filter(doc! { "_id": id })
-                    .update(doc! { "$set": { "coordinates": coordinates, "ra": ra, "dec": dec } })
-                    .build(),
-            ));
-
-            if writes.len() >= args.batch_size {
-                if let Err(e) = client
-                    .bulk_write(std::mem::take(&mut writes))
-                    .ordered(false)
-                    .await
-                {
-                    error!("error writing batch: {}", e);
-                    std::process::exit(1);
-                }
-                writes = Vec::with_capacity(args.batch_size);
-            }
+        let mut handles = Vec::with_capacity(shards.len());
+        for shard in &shards {
+            let collection = collection.clone();
+            let filter = merge_filters(&base_filter, shard);
+            let ra_field = args.ra_field.clone();
+            let dec_field = args.dec_field.clone();
+            let batch_size = args.batch_size;
+            let dry_run = args.dry_run;
+            let pb = pb.clone();
+            handles.push(tokio::spawn(async move {
+                process_shard(
+                    collection, filter, ra_field, dec_field, batch_size, dry_run, pb,
+                )
+                .await
+            }));
         }
 
-        if !writes.is_empty() {
-            if let Err(e) = client.bulk_write(writes).ordered(false).await {
-                error!("error writing final batch: {}", e);
+        let outcome = join_tasks(handles, "shard").await;
+        logger.abort();
+        pb.finish();
+        match outcome {
+            Ok(reports) => {
+                for shard_report in reports {
+                    report.merge(shard_report);
+                }
+            }
+            Err(e) => {
+                error!("error preparing {}: {}", args.catalog, e);
                 std::process::exit(1);
             }
         }
-        logger.abort();
-        pb.finish();
     }
 
     if args.dry_run {
@@ -284,8 +337,14 @@ async fn main() {
         warn!("  skipped _id {}", sample);
     }
 
+    let scanned = report.updated + report.missing + report.out_of_range;
+    let covered = !args.force || check_shard_coverage(scanned, total, shard_count);
+
     if args.dry_run {
         info!("dry run: skipping index creation");
+        if !covered {
+            std::process::exit(1);
+        }
         return;
     }
 
@@ -300,6 +359,10 @@ async fn main() {
         std::process::exit(1);
     }
     info!("2dsphere index on coordinates.radec_geojson ready");
+
+    if !covered {
+        std::process::exit(1);
+    }
 
     info!(
         "{} is ready, declare it under crossmatch.<survey> in {} and backfill \

--- a/src/bin/reprocess_crossmatch.rs
+++ b/src/bin/reprocess_crossmatch.rs
@@ -7,6 +7,7 @@ use boom::{
     conf::{load_dotenv, AppConfig, CatalogXmatchConfig},
     utils::{
         data::{make_progress_bar, spawn_progress_logger},
+        db::{join_tasks, merge_filters, range_shards, shard_field, TaskError, CURSOR_BATCH_SIZE},
         enums::Survey,
         parser::parse_positive_usize,
         spatial::{
@@ -20,7 +21,7 @@ use flare::{spatial::great_circle_distance, Time};
 use futures::{StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
 use mongodb::{
-    bson::{doc, Bson, Document},
+    bson::{doc, Document},
     options::{UpdateModifications, UpdateOneModel, WriteModel},
     Namespace,
 };
@@ -28,7 +29,6 @@ use tracing::{error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
 const QUEUE_MULTIPLIER: usize = 2;
-const CURSOR_BATCH_SIZE: u32 = 10_000;
 const ARCSEC_TO_RAD: f64 = std::f64::consts::PI / 180.0 / 3600.0;
 const STATE_COLLECTION: &str = "reprocess_crossmatch_state";
 const STATUS_MATCHING: &str = "matching";
@@ -180,77 +180,6 @@ async fn temp_needs_reset(
 // region on disk rather than jumping around it.
 // -----------------------------------------------------------------------------
 
-/// `created_at` is exactly insertion order, but it is only indexed if someone created
-/// that index; `_id` always is, and both ZTF object ids and LSST diaObject ids happen
-/// to be allocated in an order that correlates well with insertion.
-async fn shard_field(collection: &mongodb::Collection<Document>) -> &'static str {
-    let indexed_on_created_at = match collection.list_indexes().await {
-        Ok(cursor) => match cursor.try_collect::<Vec<_>>().await {
-            Ok(indexes) => indexes
-                .iter()
-                .any(|index| index.keys.keys().next().is_some_and(|k| k == "created_at")),
-            Err(_) => false,
-        },
-        Err(_) => false,
-    };
-    if indexed_on_created_at {
-        "created_at"
-    } else {
-        "_id"
-    }
-}
-
-async fn range_shards(
-    collection: &mongodb::Collection<Document>,
-    parts: usize,
-    field: &str,
-) -> Vec<Document> {
-    if parts <= 1 {
-        return vec![Document::new()];
-    }
-    let sample_size = (parts * 20).min(10_000);
-    let bounds: Vec<Bson> = match collection
-        .aggregate(vec![
-            doc! { "$sample": { "size": sample_size as i64 } },
-            doc! { "$project": { field: 1 } },
-            doc! { "$sort": { field: 1 } },
-        ])
-        .await
-    {
-        Ok(cursor) => match cursor.try_collect::<Vec<Document>>().await {
-            Ok(docs) => docs.iter().filter_map(|d| d.get(field).cloned()).collect(),
-            Err(e) => {
-                warn!(error = %e, "could not sample {} bounds, falling back to a single shard", field);
-                Vec::new()
-            }
-        },
-        Err(e) => {
-            warn!(error = %e, "could not sample {} bounds, falling back to a single shard", field);
-            Vec::new()
-        }
-    };
-
-    if bounds.len() < parts {
-        warn!(
-            "only {} sampled bounds on '{}' for {} shards, running as a single shard",
-            bounds.len(),
-            field,
-            parts
-        );
-        return vec![Document::new()];
-    }
-    let step = bounds.len() / parts;
-    let cuts: Vec<Bson> = (1..parts).map(|i| bounds[i * step].clone()).collect();
-
-    let mut shards = Vec::with_capacity(cuts.len() + 1);
-    shards.push(doc! { field: { "$lt": cuts[0].clone() } });
-    for pair in cuts.windows(2) {
-        shards.push(doc! { field: { "$gte": pair[0].clone(), "$lt": pair[1].clone() } });
-    }
-    shards.push(doc! { field: { "$gte": cuts[cuts.len() - 1].clone() } });
-    shards
-}
-
 async fn sharded_update_many(
     collection: &mongodb::Collection<Document>,
     shards: &[Document],
@@ -261,13 +190,7 @@ async fn sharded_update_many(
     let done = Arc::new(AtomicUsize::new(0));
     let total = shards.len();
     let results = futures::future::join_all(shards.iter().enumerate().map(|(index, shard)| {
-        let filter = if shard.is_empty() {
-            base_filter.clone()
-        } else if base_filter.is_empty() {
-            shard.clone()
-        } else {
-            doc! { "$and": [base_filter.clone(), shard.clone()] }
-        };
+        let filter = merge_filters(base_filter, shard);
         let collection = collection.clone();
         let update = update.clone();
         let done = Arc::clone(&done);
@@ -316,7 +239,7 @@ async fn run_objects_driven(
     processes: usize,
     concurrency: usize,
     skip_existing: bool,
-) -> Result<(), mongodb::error::Error> {
+) -> Result<(), TaskError> {
     let aux_collection: mongodb::Collection<AuxIdAndCoords> =
         db.collection(&format!("{}_alerts_aux", survey));
     let estimated = aux_collection.estimated_document_count().await.unwrap_or(0);
@@ -368,24 +291,10 @@ async fn run_objects_driven(
     }
     drop(tx);
 
-    let mut first_err: Option<mongodb::error::Error> = None;
-    for h in workers {
-        match h.await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                error!("worker failed: {}", e);
-                first_err.get_or_insert(e);
-            }
-            Err(e) => {
-                error!("worker join failed: {}", e);
-            }
-        }
-    }
+    let outcome = join_tasks(workers, "worker").await;
     logger.abort();
     pb.finish();
-    if let Some(e) = first_err {
-        return Err(e);
-    }
+    outcome?;
     Ok(())
 }
 
@@ -497,7 +406,7 @@ async fn run_watchlist_driven(
     db: mongodb::Database,
     batch_size: usize,
     processes: usize,
-) -> Result<(), mongodb::error::Error> {
+) -> Result<(), TaskError> {
     let wl_collection: mongodb::Collection<Document> = db.collection(&watchlist_config.catalog);
     let estimated = wl_collection.estimated_document_count().await.unwrap_or(0);
     let label = format!("watchlist→{}", watchlist_config.catalog);
@@ -535,24 +444,10 @@ async fn run_watchlist_driven(
     }
     drop(tx);
 
-    let mut first_err: Option<mongodb::error::Error> = None;
-    for h in workers {
-        match h.await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                error!("worker failed: {}", e);
-                first_err.get_or_insert(e);
-            }
-            Err(e) => {
-                error!("worker join failed: {}", e);
-            }
-        }
-    }
+    let outcome = join_tasks(workers, "worker").await;
     logger.abort();
     pb.finish();
-    if let Some(e) = first_err {
-        return Err(e);
-    }
+    outcome?;
     Ok(())
 }
 
@@ -656,7 +551,7 @@ async fn run_catalog_driven(
     concurrency: usize,
     skip_empty: bool,
     reset_temp: bool,
-) -> Result<(), mongodb::error::Error> {
+) -> Result<(), TaskError> {
     let aux_collection: mongodb::Collection<Document> =
         db.collection(&format!("{}_alerts_aux", survey));
     let cat_collection: mongodb::Collection<Document> = db.collection(&catalog_config.catalog);
@@ -664,7 +559,7 @@ async fn run_catalog_driven(
     let temp_field = format!("cross_matches.{}_temp", catalog_config.catalog);
     let run_start_jd = Time::now().to_jd();
     let shard_field = shard_field(&aux_collection).await;
-    let shards = range_shards(&aux_collection, processes, shard_field).await;
+    let shards = range_shards(&aux_collection, processes, shard_field, &Document::new()).await;
     info!(
         "[catalog\u{2192}{}] cleanup passes sharded on '{}' into {} ranges",
         catalog_config.catalog,
@@ -758,26 +653,11 @@ async fn run_catalog_driven(
         }
     }
     drop(tx);
-    let mut first_err: Option<mongodb::error::Error> = None;
-    for h in workers {
-        match h.await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                error!("worker failed: {}", e);
-                first_err.get_or_insert(e);
-            }
-            Err(e) => {
-                error!("worker join failed: {}", e);
-            }
-        }
-    }
+    let outcome = join_tasks(workers, "worker").await;
     logger.abort();
     pb.finish();
-    if let Some(e) = first_err {
-        // CRITICAL: temp holds a partial result; committing it would overwrite valid
-        // live cross_matches with an incomplete list. The next run's phase 1 clears it.
-        return Err(e);
-    }
+    // A partial temp must never reach phase 3: it commits empty match lists over valid ones.
+    outcome?;
 
     // Phase 3: sort, trim and commit in a single pass. $ifNull gives records with no
     // match the empty array that phase 1 used to pre-write on every record.

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -1,11 +1,12 @@
 use chrono::NaiveDate;
+use futures::TryStreamExt;
 use mongodb::{
-    bson::{doc, to_document, Document},
-    options::IndexOptions,
+    bson::{doc, to_document, Bson, Document},
+    options::{Hint, IndexOptions},
     Collection, Database, IndexModel,
 };
 use serde::Serialize;
-use tracing::instrument;
+use tracing::{error, info, instrument, warn};
 
 use crate::utils::enums::Survey;
 
@@ -280,5 +281,324 @@ pub fn fetch_timeseries_op(
                 "$and": conditions
             }
         }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Range sharding: splitting a full-collection pass into contiguous ranges is the
+// only way to use more than one thread on it. Ranges are cut on an indexed field
+// that tracks insertion order, so that each shard walks a roughly contiguous
+// region on disk rather than jumping around it.
+// -----------------------------------------------------------------------------
+
+pub const CURSOR_BATCH_SIZE: u32 = 10_000;
+
+/// Without the hint the empty-filter count collection-scans instead of counting the _id index.
+pub async fn exact_count(collection: &Collection<Document>) -> Result<u64, mongodb::error::Error> {
+    info!("counting the documents in {}", collection.namespace());
+    collection
+        .count_documents(doc! {})
+        .hint(Hint::Keys(doc! { "_id": 1 }))
+        .await
+}
+
+pub async fn collection_exists(db: &Database, name: &str) -> Result<bool, mongodb::error::Error> {
+    Ok(db.list_collection_names().await?.iter().any(|n| n == name))
+}
+
+/// `created_at` is exactly insertion order, but it is only indexed if someone created
+/// that index; `_id` always is, and both ZTF object ids and LSST diaObject ids happen
+/// to be allocated in an order that correlates well with insertion.
+pub async fn shard_field(collection: &Collection<Document>) -> &'static str {
+    let indexed_on_created_at = match collection.list_indexes().await {
+        Ok(cursor) => match cursor.try_collect::<Vec<_>>().await {
+            Ok(indexes) => indexes
+                .iter()
+                .any(|index| index.keys.keys().next().is_some_and(|k| k == "created_at")),
+            Err(_) => false,
+        },
+        Err(_) => false,
+    };
+    if indexed_on_created_at {
+        "created_at"
+    } else {
+        "_id"
+    }
+}
+
+pub async fn range_shards(
+    collection: &Collection<Document>,
+    parts: usize,
+    field: &str,
+    base_filter: &Document,
+) -> Vec<Document> {
+    if parts <= 1 {
+        return vec![Document::new()];
+    }
+    // Behind a $match, $sample loses its random-cursor plan and collection-scans.
+    let sample_size = if base_filter.is_empty() {
+        (parts * 20).min(10_000)
+    } else {
+        10_000
+    };
+    info!(
+        "sampling {} bounds on '{}' to cut {} shards",
+        sample_size, field, parts
+    );
+    let mut pipeline = vec![doc! { "$sample": { "size": sample_size as i64 } }];
+    if !base_filter.is_empty() {
+        pipeline.push(doc! { "$match": base_filter.clone() });
+    }
+    pipeline.push(doc! { "$project": { field: 1 } });
+    pipeline.push(doc! { "$sort": { field: 1 } });
+
+    let bounds: Vec<Bson> = match collection.aggregate(pipeline).await {
+        Ok(cursor) => match cursor.try_collect::<Vec<Document>>().await {
+            Ok(docs) => docs.iter().filter_map(|d| d.get(field).cloned()).collect(),
+            Err(e) => {
+                warn!(error = %e, "could not sample {} bounds, falling back to a single shard", field);
+                Vec::new()
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "could not sample {} bounds, falling back to a single shard", field);
+            Vec::new()
+        }
+    };
+
+    if bounds.len() < parts {
+        warn!(
+            "only {} sampled bounds on '{}' for {} shards, running as a single shard",
+            bounds.len(),
+            field,
+            parts
+        );
+        return vec![Document::new()];
+    }
+    shard_filters(field, &bounds, parts)
+}
+
+/// Contiguous filters covering everything; expects `parts >= 2` and `bounds.len() >= parts`.
+fn shard_filters(field: &str, bounds: &[Bson], parts: usize) -> Vec<Document> {
+    let step = bounds.len() / parts;
+    let cuts: Vec<&Bson> = (1..parts).map(|i| &bounds[i * step]).collect();
+
+    let mut shards = Vec::with_capacity(parts);
+    shards.push(doc! { "$or": [
+        doc! { field: { "$lt": cuts[0].clone() } },
+        doc! { field: { "$exists": false } },
+    ] });
+    for pair in cuts.windows(2) {
+        shards.push(doc! { field: { "$gte": pair[0].clone(), "$lt": pair[1].clone() } });
+    }
+    shards.push(doc! { field: { "$gte": cuts[cuts.len() - 1].clone() } });
+    shards
+}
+
+/// False: the shards did not cover every document counted before the pass.
+pub fn check_shard_coverage(scanned: u64, total: u64, shard_count: usize) -> bool {
+    if scanned >= total {
+        true
+    } else if shard_count > 1 {
+        error!(
+            "only {} of the {} document(s) counted before the pass were scanned: the shards did \
+             not cover them all, re-run with --processes 1",
+            scanned, total
+        );
+        false
+    } else {
+        warn!(
+            "scanned {} of the {} document(s) counted before the pass: documents were modified \
+             or deleted while it ran",
+            scanned, total
+        );
+        true
+    }
+}
+
+pub fn merge_filters(base: &Document, shard: &Document) -> Document {
+    if shard.is_empty() {
+        base.clone()
+    } else if base.is_empty() {
+        shard.clone()
+    } else {
+        doc! { "$and": [base.clone(), shard.clone()] }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum TaskError {
+    #[error("{0}")]
+    Failed(#[from] mongodb::error::Error),
+    #[error("task did not run to completion: {0}")]
+    Join(#[from] tokio::task::JoinError),
+}
+
+/// Ignoring a JoinError would report a run that covered only part of the collection as a success.
+pub async fn join_tasks<T>(
+    handles: Vec<tokio::task::JoinHandle<Result<T, mongodb::error::Error>>>,
+    label: &str,
+) -> Result<Vec<T>, TaskError> {
+    let mut results = Vec::with_capacity(handles.len());
+    let mut first_err: Option<TaskError> = None;
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(value)) => results.push(value),
+            Ok(Err(e)) => {
+                error!("{} failed: {}", label, e);
+                first_err.get_or_insert(e.into());
+            }
+            Err(e) => {
+                error!("{} did not run to completion: {}", label, e);
+                first_err.get_or_insert(e.into());
+            }
+        }
+    }
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(results),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bounds(values: &[i32]) -> Vec<Bson> {
+        values.iter().map(|v| Bson::Int32(*v)).collect()
+    }
+
+    fn lower(shard: &Document, field: &str) -> Option<Bson> {
+        shard.get_document(field).ok()?.get("$gte").cloned()
+    }
+
+    fn upper(shard: &Document, field: &str) -> Option<Bson> {
+        match shard.get_array("$or") {
+            Ok(branches) => branches[0]
+                .as_document()?
+                .get_document(field)
+                .ok()?
+                .get("$lt")
+                .cloned(),
+            Err(_) => shard.get_document(field).ok()?.get("$lt").cloned(),
+        }
+    }
+
+    #[test]
+    fn shard_filters_builds_one_filter_per_part() {
+        let b = bounds(&(0..100).collect::<Vec<_>>());
+        for parts in 2..10 {
+            assert_eq!(
+                shard_filters("_id", &b, parts).len(),
+                parts,
+                "parts={}",
+                parts
+            );
+        }
+    }
+
+    #[test]
+    fn shard_filters_covers_every_value_without_a_gap() {
+        let b = bounds(&(0..100).collect::<Vec<_>>());
+        for parts in 2..10 {
+            let shards = shard_filters("_id", &b, parts);
+            assert!(
+                lower(&shards[0], "_id").is_none(),
+                "the first shard is open-ended"
+            );
+            assert!(
+                upper(shards.last().unwrap(), "_id").is_none(),
+                "the last shard is open-ended"
+            );
+            for pair in shards.windows(2) {
+                assert_eq!(
+                    upper(&pair[0], "_id"),
+                    lower(&pair[1], "_id"),
+                    "parts={}, a value falls between two shards",
+                    parts
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn shard_filters_first_shard_also_takes_documents_without_the_field() {
+        let shards = shard_filters("created_at", &bounds(&[1, 2, 3, 4]), 2);
+        let branches = shards[0].get_array("$or").expect("first shard is an $or");
+        assert_eq!(branches.len(), 2);
+        assert_eq!(
+            branches[1].as_document().unwrap(),
+            &doc! { "created_at": { "$exists": false } }
+        );
+    }
+
+    #[test]
+    fn shard_filters_handles_a_sample_as_small_as_the_part_count() {
+        let shards = shard_filters("_id", &bounds(&[10, 20, 30]), 3);
+        assert_eq!(shards.len(), 3);
+        assert_eq!(upper(&shards[0], "_id"), Some(Bson::Int32(20)));
+        assert_eq!(lower(&shards[2], "_id"), Some(Bson::Int32(30)));
+    }
+
+    #[test]
+    fn shard_filters_keeps_covering_everything_when_cuts_repeat() {
+        let shards = shard_filters("_id", &bounds(&[7, 7, 7, 7]), 4);
+        assert_eq!(shards.len(), 4);
+        for pair in shards.windows(2) {
+            assert_eq!(upper(&pair[0], "_id"), lower(&pair[1], "_id"));
+        }
+    }
+
+    #[test]
+    fn merge_filters_keeps_whichever_side_is_present() {
+        let base = doc! { "coordinates": { "$exists": false } };
+        let shard = doc! { "_id": { "$gte": 1 } };
+        assert_eq!(merge_filters(&base, &Document::new()), base);
+        assert_eq!(merge_filters(&Document::new(), &shard), shard);
+        assert_eq!(
+            merge_filters(&base, &shard),
+            doc! { "$and": [base.clone(), shard.clone()] }
+        );
+        assert_eq!(
+            merge_filters(&Document::new(), &Document::new()),
+            Document::new()
+        );
+    }
+
+    fn io_error(message: &str) -> mongodb::error::Error {
+        std::io::Error::other(message.to_string()).into()
+    }
+
+    #[tokio::test]
+    async fn join_tasks_returns_every_value_when_all_succeed() {
+        let handles = vec![
+            tokio::spawn(async { Ok::<i32, mongodb::error::Error>(1) }),
+            tokio::spawn(async { Ok::<i32, mongodb::error::Error>(2) }),
+        ];
+        assert_eq!(join_tasks(handles, "task").await.unwrap(), vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn join_tasks_reports_the_first_error() {
+        let handles = vec![
+            tokio::spawn(async { Err(io_error("first")) }),
+            tokio::spawn(async { Err(io_error("second")) }),
+        ];
+        let error = join_tasks::<i32>(handles, "task").await.unwrap_err();
+        assert!(error.to_string().contains("first"), "got {}", error);
+    }
+
+    #[tokio::test]
+    async fn join_tasks_does_not_swallow_a_panicking_task() {
+        let handles = vec![
+            tokio::spawn(async { Ok::<i32, mongodb::error::Error>(1) }),
+            tokio::spawn(async {
+                let ran = false;
+                assert!(ran, "panicking on purpose");
+                Ok::<i32, mongodb::error::Error>(2)
+            }),
+        ];
+        let error = join_tasks(handles, "task").await.unwrap_err();
+        assert!(matches!(error, TaskError::Join(_)), "got {:?}", error);
     }
 }


### PR DESCRIPTION
- Hoist the range-sharding machinery (`shard_field`, `range_shards`, `merge_filters`, `join_tasks`) from `reprocess_crossmatch` into `utils::db`, with new shared helpers `exact_count`, `collection_exists` and `check_shard_coverage`.
- `range_shards` now assigns documents missing the shard field to the first shard, and samples its cut points from the caller's filter subset (keeping `$sample` first to preserve its random-cursor plan).
- A worker that panics now fails the run instead of being silently ignored, which previously reported a partial pass as a success.
- Parallelize `prepare_catalog`'s scan with `--processes`, sharded on an indexed insertion-order field.
- `prepare_catalog` no longer collection-scans the catalog just to count: exact count via an `_id`-hinted `COUNT_SCAN` under `--force`, collection estimate otherwise.
- Fail `prepare_catalog` when the shards did not cover every document (after the 2dsphere index is created, so the catalog stays usable), and only warn when the shortfall can just be concurrent modification.
- Unit-test the shard cut arithmetic, filter merging and task joining.