### PR TITLE
keep one document per comet when MPC publishes a second solution

### DIFF
--- a/src/utils/mpcorb.rs
+++ b/src/utils/mpcorb.rs
@@ -453,28 +453,34 @@ async fn refresh_comets_into_staging(
     }
 
     let file = std::fs::File::open(tmp.path())?;
-    let mut documents: Vec<Document> = Vec::new();
+    // MPC publishes a second solution for a comet while one is pending, so the
+    // same designation can appear twice; the later row wins.
+    let mut documents: HashMap<String, Document> = HashMap::new();
     for line in BufReader::new(file).lines() {
         let Ok(line) = line else { continue };
         if let Some(entry) = crate::utils::comets::parse_line(&line) {
-            documents.push(doc! {
-                "_id": &entry.designation,
-                "epoch_jd": entry.elements.epoch_jd,
-                "a": entry.elements.a,
-                "e": entry.elements.e,
-                "incl": entry.elements.incl,
-                "node": entry.elements.node,
-                "peri": entry.elements.peri,
-                "mean_anomaly": entry.elements.mean_anomaly,
-                "q": entry.elements.q,
-                "tp": entry.elements.tp,
-                "h": entry.h,
-                "g": entry.g,
-                "updated_at": now,
-            });
+            documents.insert(
+                entry.designation.clone(),
+                doc! {
+                    "_id": &entry.designation,
+                    "epoch_jd": entry.elements.epoch_jd,
+                    "a": entry.elements.a,
+                    "e": entry.elements.e,
+                    "incl": entry.elements.incl,
+                    "node": entry.elements.node,
+                    "peri": entry.elements.peri,
+                    "mean_anomaly": entry.elements.mean_anomaly,
+                    "q": entry.elements.q,
+                    "tp": entry.elements.tp,
+                    "h": entry.h,
+                    "g": entry.g,
+                    "updated_at": now,
+                },
+            );
         }
     }
 
+    let documents: Vec<Document> = documents.into_values().collect();
     let parsed = documents.len() as u64;
     if parsed < MIN_PLAUSIBLE_COMETS {
         return Err(RefreshError::ImplausiblyShort {


### PR DESCRIPTION
The comet ingest failed with a duplicate `_id` after #637:

```
E11000 duplicate key error collection: boom.MPC_orbits_staging
index: _id_ dup key: { _id: "C/2023RS61" }
```

CometEls.txt carries two rows for `C/2023 RS61 (PANSTARRS)` — the same packed
designation with near-identical elements, one referencing an MPEC and one still
pending:

```
CK23R61S  ... q=7.992085  H=6.8   MPEC 2026-RA
CK23R61S  ... q=7.992060  H=9.1   MPC xxxxx
```

Before #637 these landed under different keys, because each row fused its own
trailing reference into the designation. With that fixed they collide, and
`insert_many` aborts the whole refresh.

Collecting into a map keyed by designation makes the later row win. Against
today's file: 959 records, 958 unique.
