### PR TITLE
Keep user email addresses out of PostHog

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -50,6 +50,10 @@ profiles.
 or as a `distinct_id`: the id keys everything to one person already, and the
 id-to-address join lives in Mongo, where the account does. A login whose
 `/profile` call fails identifies nobody rather than falling back to the address.
+Activation and password-reset links do carry the address in their query string,
+so the client masks `email`, `token` and `activation_code` out of the
+`$current_url` every event reports (`mask_personal_data_properties` in
+[`frontend/src/main.tsx`](../frontend/src/main.tsx)).
 
 ## PostHog events
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -46,6 +46,11 @@ endpoints) are reported against a fixed `babamul-anonymous` id and carry
 `$process_person_profile: false`, so they're counted without creating person
 profiles.
 
+**Email addresses are never sent**, as a person property, as an event property,
+or as a `distinct_id`: the id keys everything to one person already, and the
+id-to-address join lives in Mongo, where the account does. A login whose
+`/profile` call fails identifies nobody rather than falling back to the address.
+
 ## PostHog events
 
 ### `babamul_api_request`

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,126 +1,39 @@
-/**
- * PostHog Analytics Utility
- * Event tracking for common user activities
- */
+import posthog, { type Properties } from 'posthog-js';
 
-import posthog from 'posthog-js';
-
-// Signup & Authentication
-
-export function trackSignupInitiated(properties?: { email?: string }) {
-  posthog.capture('signup_initiated', properties);
+function event<P extends Properties>(name: string) {
+  return (properties?: P) => posthog.capture(name, properties);
 }
 
-export function trackSignupEmailSubmitted(properties?: { email?: string }) {
-  posthog.capture('signup_email_submitted', properties);
-}
+export const trackSignupInitiated = () => posthog.capture('signup_initiated');
+export const trackSignupEmailSubmitted = () => posthog.capture('signup_email_submitted');
+export const trackActivationCodeSubmitted = () => posthog.capture('activation_code_submitted');
+export const trackAccountActivated = event<{ via_link?: boolean }>('account_activated');
+export const trackLoginSuccess = () => posthog.capture('login_success');
 
-export function trackActivationCodeSubmitted(properties?: { email?: string }) {
-  posthog.capture('activation_code_submitted', properties);
-}
+export const trackKafkaCredentialCreateInitiated = event<{ credential_name?: string }>('kafka_credential_create_initiated');
+export const trackKafkaCredentialCreated = event<{ credential_id?: string; credential_name?: string }>('kafka_credential_created');
+export const trackKafkaCredentialDeleted = event<{ credential_id?: string }>('kafka_credential_deleted');
+export const trackCredentialSecretToggled = event<{ credential_id?: string; revealed?: boolean }>('credential_secret_toggled');
+export const trackCredentialCopied = event<{ label?: string }>('credential_copied');
 
-export function trackAccountActivated(properties?: { email?: string; via_link?: boolean }) {
-  posthog.capture('account_activated', properties);
-}
+export const trackApiTokenCreateInitiated = event<{ token_name?: string; expiry_days?: number }>('api_token_create_initiated');
+export const trackApiTokenCreated = event<{ token_id?: string; token_name?: string; expiry_days?: number }>('api_token_created');
+export const trackApiTokenDeleted = event<{ token_id?: string }>('api_token_deleted');
 
-export function trackLoginSuccess(properties?: { email?: string }) {
-  posthog.capture('login_success', properties);
-}
+export const trackAlertSearchSubmitted = event<Properties>('alert_search_submitted');
+export const trackAlertSearchCompleted = event<Properties>('alert_search_completed');
+export const trackObjectSearchSubmitted = event<Properties>('object_search_submitted');
+export const trackObjectSearchCompleted = event<Properties>('object_search_completed');
 
-// Kafka Credentials
-
-export function trackKafkaCredentialCreateInitiated(properties?: { credential_name?: string }) {
-  posthog.capture('kafka_credential_create_initiated', properties);
-}
-
-export function trackKafkaCredentialCreated(properties?: { credential_id?: string; credential_name?: string }) {
-  posthog.capture('kafka_credential_created', properties);
-}
-
-export function trackKafkaCredentialDeleted(properties?: { credential_id?: string }) {
-  posthog.capture('kafka_credential_deleted', properties);
-}
-
-export function trackCredentialSecretToggled(properties?: { credential_id?: string; revealed?: boolean }) {
-  posthog.capture('credential_secret_toggled', properties);
-}
-
-export function trackCredentialCopied(properties?: { label?: string }) {
-  posthog.capture('credential_copied', properties);
-}
-
-// API Tokens
-
-export function trackApiTokenCreateInitiated(properties?: { token_name?: string; expiry_days?: number }) {
-  posthog.capture('api_token_create_initiated', properties);
-}
-
-export function trackApiTokenCreated(properties?: { token_id?: string; token_name?: string; expiry_days?: number }) {
-  posthog.capture('api_token_created', properties);
-}
-
-export function trackApiTokenDeleted(properties?: { token_id?: string }) {
-  posthog.capture('api_token_deleted', properties);
-}
-
-export function trackTokenCopied(properties?: { label?: string }) {
-  posthog.capture('token_copied', properties);
-}
-
-// Search & Queries
-
-export function trackAlertSearchSubmitted(properties?: Record<string, unknown>) {
-  posthog.capture('alert_search_submitted', properties);
-}
-
-export function trackAlertSearchCompleted(properties?: Record<string, unknown>) {
-  posthog.capture('alert_search_completed', properties);
-}
-
-export function trackObjectSearchSubmitted(properties?: Record<string, unknown>) {
-  posthog.capture('object_search_submitted', properties);
-}
-
-export function trackObjectSearchCompleted(properties?: Record<string, unknown>) {
-  posthog.capture('object_search_completed', properties);
-}
-
-/**
- * Track an error that occurred in the application
- */
-export function trackError(
-  context: string,
-  error: unknown,
-  additionalInfo?: Record<string, unknown>
-) {
-  const errorMessage = error instanceof Error ? error.message : String(error);
+export function trackError(context: string, error: unknown, additionalInfo?: Properties) {
   posthog.capture('error_occurred', {
     category: 'error',
     context,
-    error_message: errorMessage,
+    error_message: error instanceof Error ? error.message : String(error),
     ...additionalInfo,
   });
 }
 
-/**
- * Set user properties after signup/login
- */
-export function setUserProperties(properties: Record<string, unknown>) {
-  posthog.setPersonProperties(properties);
-}
+export const identifyUser = (userId: string) => posthog.identify(userId);
 
-/**
- * Identify user by email or ID
- */
-export function identifyUser(userId: string, email?: string) {
-  posthog.identify(userId, {
-    email,
-  });
-}
-
-/**
- * Reset user identity on logout
- */
-export function resetUser() {
-  posthog.reset();
-}
+export const resetUser = () => posthog.reset();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { PostHogProvider } from 'posthog-js/react'
+import type { PostHogConfig } from 'posthog-js'
 
-const options = {
+const options: Partial<PostHogConfig> = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
   defaults: '2025-11-30',
-} as const
+  mask_personal_data_properties: true,
+  custom_personal_data_properties: ['email', 'token', 'activation_code'],
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -37,15 +37,14 @@ export default function Login({ onLoginSuccess }: Props) {
     try {
       await api.login(email, password);
       const profile = await api.fetchProfile().catch(() => null);
-      const identifiedEmail = profile?.email ?? email;
-      const identifiedUserId = profile?.id ?? profile?.username ?? identifiedEmail;
-      analytics.identifyUser(identifiedUserId, identifiedEmail);
-      analytics.trackLoginSuccess({ email });
+      const identifiedUserId = profile?.id ?? profile?.username;
+      if (identifiedUserId) analytics.identifyUser(identifiedUserId);
+      analytics.trackLoginSuccess();
       onLoginSuccess();
     } catch (err: unknown) {
       const msg = err && typeof err === 'object' && 'message' in err ? String((err as { message?: unknown }).message) : String(err);
       setError(msg);
-      analytics.trackError('login', err, { email });
+      analytics.trackError('login', err);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/OAuthCallback.tsx
+++ b/frontend/src/pages/OAuthCallback.tsx
@@ -60,10 +60,8 @@ export default function OAuthCallback() {
     (async () => {
       try {
         const profile = await ensureProfileLoaded({ force: true });
-        if (profile) {
-          analytics.identifyUser(profile.id ?? profile.username ?? profile.email, profile.email);
-        }
-        analytics.trackLoginSuccess({ email: profile?.email });
+        if (profile) analytics.identifyUser(profile.id ?? profile.username);
+        analytics.trackLoginSuccess();
       } catch (err) {
         // A profile hiccup shouldn't strand a user who is already signed in.
         console.error("OAuthCallback: could not load profile", err);

--- a/frontend/src/pages/OAuthComplete.tsx
+++ b/frontend/src/pages/OAuthComplete.tsx
@@ -73,7 +73,7 @@ export default function OAuthComplete() {
       setStep("code");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
-      analytics.trackError("oauth_complete_email", err, { email });
+      analytics.trackError("oauth_complete_email", err);
     } finally {
       setLoading(false);
     }
@@ -91,10 +91,8 @@ export default function OAuthComplete() {
       useAppStore.getState().clearProfile();
       try {
         const profile = await ensureProfileLoaded({ force: true });
-        if (profile) {
-          analytics.identifyUser(profile.id ?? profile.username ?? profile.email, profile.email);
-        }
-        analytics.trackLoginSuccess({ email: profile?.email ?? email });
+        if (profile) analytics.identifyUser(profile.id ?? profile.username);
+        analytics.trackLoginSuccess();
       } catch (profileErr) {
         // Already signed in; a profile hiccup shouldn't strand the user here.
         console.error("OAuthComplete: could not load profile", profileErr);
@@ -103,7 +101,7 @@ export default function OAuthComplete() {
       navigate(destination, { replace: true });
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
-      analytics.trackError("oauth_verify_email", err, { email });
+      analytics.trackError("oauth_verify_email", err);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -10,6 +10,10 @@ import * as analytics from '@/lib/analytics';
 // Use same-origin proxy; prod nginx should route /api to backend
 const API_BASE = '/api/babamul';
 
+function errorMessage(err: unknown) {
+  return err && typeof err === 'object' && 'message' in err ? String((err as { message?: unknown }).message) : String(err);
+}
+
 export default function SignupPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -49,7 +53,7 @@ export default function SignupPage() {
     setError(null);
     setMessage(null);
     setLoading(true);
-    analytics.trackSignupInitiated({ email });
+    analytics.trackSignupInitiated();
     try {
       const res = await fetch(`${API_BASE}/signup`, {
         method: 'POST',
@@ -71,11 +75,10 @@ export default function SignupPage() {
         setMessage('An email has been sent with an activation code. Check your inbox.');
         setStep('code');
       }
-      analytics.trackSignupEmailSubmitted({ email });
+      analytics.trackSignupEmailSubmitted();
     } catch (err: unknown) {
-      const msg = err && typeof err === 'object' && 'message' in err ? String((err as { message?: unknown }).message) : String(err);
-      setError(msg);
-      analytics.trackError('signup_email_submission', err, { email });
+      setError(errorMessage(err));
+      analytics.trackError('signup_email_submission', err);
     } finally {
       setLoading(false);
     }
@@ -85,7 +88,7 @@ export default function SignupPage() {
     e?.preventDefault();
     setError(null);
     setLoading(true);
-    analytics.trackActivationCodeSubmitted({ email });
+    analytics.trackActivationCodeSubmitted();
     try {
       const res = await fetch(`${API_BASE}/activate`, {
         method: 'POST',
@@ -108,11 +111,10 @@ export default function SignupPage() {
         setMessage('An account with this email is already activated.');
         setStep('done');
       }
-      analytics.trackAccountActivated({ email });
+      analytics.trackAccountActivated();
     } catch (err: unknown) {
-      const msg = err && typeof err === 'object' && 'message' in err ? String((err as { message?: unknown }).message) : String(err);
-      setError(msg);
-      analytics.trackError('account_activation', err, { email });
+      setError(errorMessage(err));
+      analytics.trackError('account_activation', err);
     } finally {
       setLoading(false);
     }
@@ -143,11 +145,10 @@ export default function SignupPage() {
         setMessage('An account with this email is already activated.');
         setStep('done');
       }
-      analytics.trackAccountActivated({ email: emailToUse, via_link: true });
+      analytics.trackAccountActivated({ via_link: true });
     } catch (err: unknown) {
-      const msg = err && typeof err === 'object' && 'message' in err ? String((err as { message?: unknown }).message) : String(err);
-      setError(msg);
-      analytics.trackError('auto_account_activation', err, { email: emailToUse });
+      setError(errorMessage(err));
+      analytics.trackError('auto_account_activation', err);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
This need to be merge before https://github.com/boom-astro/boom/pull/623.

Data minimization: PostHog is a third-party processor, and the user id is enough for every funnel we track, so the address has no reason to be there. It stays in Mongo, keyed by that same id, so nothing is lost.

PostHog only gets the user id. No email address is sent: not as a person property, not as an event property, not as a `distinct_id`.

- `posthog.identify` and the 15 signup / login / error events no longer send `{ email }`. Their helpers take no properties now, so it cannot come back by accident.
- If `/profile` fails after a login, we identify nobody instead of falling back to the address as `distinct_id`. The session stays anonymous until the next identify.
- Activation and reset links carry `email`, `token` and `activation_code` in the URL, and PostHog sends `$current_url` with every event, so these three are masked in `main.tsx`.
- Cleanup